### PR TITLE
Use more modern build status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Glowstone++
 
 An experimental fork of [Glowstone](https://github.com/GlowstoneMC/Glowstone) focused on additional compatibility
 
-[![Build Status](https://circleci.com/gh/deathcap/GlowstonePlusPlus/tree/master.png?style=shield)](https://circleci.com/gh/deathcap/GlowstonePlusPlus/tree/master)
+[![Build Status](https://circleci.com/gh/deathcap/GlowstonePlusPlus/tree/master.png)](https://circleci.com/gh/deathcap/GlowstonePlusPlus/tree/master)
 
 (Warning: may be unstable, this is only an experiment, use at your own risk)
 
@@ -48,7 +48,7 @@ Downloads
 If you don't want to build from source, prebuilt jar files are available to download from:
 
 * **[CircleCI downloads](https://circleci.com/gh/deathcap/GlowstonePlusPlus/tree/master)** (preferred) - click the latest build then expand "Artifacts" (if it does not show, try logging in with GitHub)
-[![Build Status](https://circleci.com/gh/deathcap/GlowstonePlusPlus/tree/master.png?style=shield)](https://circleci.com/gh/deathcap/GlowstonePlusPlus/tree/master)
+[![Build Status](https://circleci.com/gh/deathcap/GlowstonePlusPlus/tree/master.png)](https://circleci.com/gh/deathcap/GlowstonePlusPlus/tree/master)
 
 * [drone.io downloads](https://drone.io/github.com/deathcap/GlowstonePlusPlus/files) - alternative
 [![Build Status](https://drone.io/github.com/deathcap/GlowstonePlusPlus/status.png)](https://drone.io/github.com/deathcap/GlowstonePlusPlus/files)


### PR DESCRIPTION
I feel like the default build status picture looks better, but it is up to @deathcap.
