### PR TITLE
Adds support for basic dispenser actions

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -7,6 +7,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import net.glowstone.block.BuiltinMaterialValueManager;
 import net.glowstone.block.MaterialValueManager;
+import net.glowstone.block.state.GlowDispenser;
 import net.glowstone.command.ColorCommand;
 import net.glowstone.command.TellrawCommand;
 import net.glowstone.command.TitleCommand;
@@ -105,6 +106,7 @@ public final class GlowServer implements Server {
             ConfigurationSerialization.registerClass(GlowOfflinePlayer.class);
             GlowPotionEffect.register();
             GlowEnchantment.register();
+            GlowDispenser.register();
 
             // start server
             final GlowServer server = new GlowServer(config);

--- a/src/main/java/net/glowstone/block/blocktype/BlockDispenser.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockDispenser.java
@@ -5,13 +5,16 @@ import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.TEDispenser;
 import net.glowstone.block.entity.TileEntity;
+import net.glowstone.block.state.GlowDispenser;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.inventory.MaterialMatcher;
 import net.glowstone.inventory.ToolType;
+import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.Dispenser;
 import org.bukkit.material.MaterialData;
+import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 public class BlockDispenser extends BlockContainer {
@@ -36,5 +39,75 @@ public class BlockDispenser extends BlockContainer {
     @Override
     protected MaterialMatcher getNeededMiningTool(GlowBlock block) {
         return ToolType.PICKAXE;
+    }
+
+    @Override
+    public void afterPlace(GlowPlayer player, GlowBlock block, ItemStack holding, GlowBlockState oldState) {
+        updatePhysics(block);
+    }
+
+    @Override
+    public void onNearBlockChanged(GlowBlock block, BlockFace face, GlowBlock changedBlock, Material oldType, byte oldData, Material newType, byte newData) {
+        updatePhysics(block);
+    }
+
+    @Override
+    public void updatePhysics(final GlowBlock block) {
+        GlowBlock up = block.getRelative(BlockFace.UP);
+        boolean powered = block.isBlockPowered() | block.isBlockIndirectlyPowered() |
+                up.isBlockPowered() | up.isBlockIndirectlyPowered();
+
+        GlowBlockState state = block.getState();
+        MaterialData data = state.getData();
+        if (!(data instanceof Dispenser)) {
+            return;
+        }
+
+        boolean isTriggered = (data.getData() >> 3 & 1) != 0;
+        if (powered && !isTriggered) {
+            (new BukkitRunnable() {
+                @Override
+                public void run() {
+                    trigger(block);
+                }
+            }).runTaskLater(null, 4);
+
+            // TODO replace this with dispenser materialdata class (as soon as it provides access to this property)
+            data.setData((byte) (data.getData() | 0x8));
+            state.update();
+        } else if (!powered && isTriggered) {
+            data.setData((byte) (data.getData() & ~(0x8)));
+            state.update();
+        }
+    }
+
+    public static Vector getDispensePosition(GlowBlock block) {
+        BlockFace facing = getFacing(block);
+        double x = block.getX() + 0.7 * facing.getModX();
+        double y = block.getY() + 0.7 * facing.getModY();
+        double z = block.getZ() + 0.7 * facing.getModZ();
+        return new Vector(x, y, z);
+    }
+
+    public static BlockFace getFacing(GlowBlock block) {
+        GlowBlockState state = block.getState();
+        MaterialData data = state.getData();
+        if (!(data instanceof Dispenser)) {
+            return BlockFace.SELF;
+        }
+        Dispenser dispenserData = (Dispenser) data;
+
+        return dispenserData.getFacing();
+    }
+
+    public void trigger(GlowBlock block) {
+        TileEntity te = block.getTileEntity();
+        if (!(te instanceof TEDispenser)) {
+            return;
+        }
+        TEDispenser teDispenser = (TEDispenser) te;
+
+        GlowDispenser dispenser = (GlowDispenser) teDispenser.getState();
+        dispenser.dispense();
     }
 }

--- a/src/main/java/net/glowstone/block/entity/TEDispenser.java
+++ b/src/main/java/net/glowstone/block/entity/TEDispenser.java
@@ -10,6 +10,10 @@ public class TEDispenser extends TEContainer {
 
     public TEDispenser(GlowBlock block) {
         super(block, new GlowInventory(new GlowDispenser(block), InventoryType.DISPENSER));
+        setOwnSaveId();
+    }
+
+    protected void setOwnSaveId() {
         setSaveId("Trap");
     }
 

--- a/src/main/java/net/glowstone/block/entity/TEDropper.java
+++ b/src/main/java/net/glowstone/block/entity/TEDropper.java
@@ -3,13 +3,15 @@ package net.glowstone.block.entity;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.state.GlowDropper;
-import net.glowstone.inventory.GlowInventory;
-import org.bukkit.event.inventory.InventoryType;
 
-public class TEDropper extends TEContainer {
+public class TEDropper extends TEDispenser {
 
     public TEDropper(GlowBlock block) {
-        super(block, new GlowInventory(new GlowDropper(block), InventoryType.DROPPER));
+        super(block);
+    }
+
+    @Override
+    protected void setOwnSaveId() {
         setSaveId("Dropper");
     }
 

--- a/src/main/java/net/glowstone/block/itemtype/ItemFilledBucket.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFilledBucket.java
@@ -22,6 +22,10 @@ public class ItemFilledBucket extends ItemType {
         setMaxStackSize(1);
     }
 
+    public BlockType getLiquid() {
+        return liquid;
+    }
+
     @Override
     public void rightClickBlock(GlowPlayer player, GlowBlock against, BlockFace face, ItemStack holding, Vector clickedLoc) {
         GlowBlock target = against.getRelative(face);

--- a/src/main/java/net/glowstone/block/itemtype/ItemTool.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemTool.java
@@ -18,6 +18,10 @@ public class ItemTool extends ItemType {
         this.maxDurability = maxDurability;
     }
 
+    public int getMaxDurability() {
+        return maxDurability;
+    }
+
     @Override
     public final void rightClickBlock(GlowPlayer player, GlowBlock target, BlockFace face, ItemStack holding, Vector clickedLoc) {
         if (onToolRightClick(player, holding, target, face, clickedLoc)) {

--- a/src/main/java/net/glowstone/block/state/GlowDispenser.java
+++ b/src/main/java/net/glowstone/block/state/GlowDispenser.java
@@ -3,13 +3,28 @@ package net.glowstone.block.state;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.TEDispenser;
+import net.glowstone.dispenser.*;
+import org.bukkit.Effect;
+import org.bukkit.Material;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Projectile;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.util.Vector;
 
+import java.util.Map;
+import java.util.Random;
+
 public class GlowDispenser extends GlowBlockState implements Dispenser, BlockProjectileSource {
+
+    private static final Random random = new Random();
+
+    private static final DispenseBehaviorRegistry dispenseBehaviorRegistry = new DispenseBehaviorRegistry();
+
+    public static DispenseBehaviorRegistry getDispenseBehaviorRegistry() {
+        return dispenseBehaviorRegistry;
+    }
 
     public GlowDispenser(GlowBlock block) {
         super(block);
@@ -26,13 +41,60 @@ public class GlowDispenser extends GlowBlockState implements Dispenser, BlockPro
 
     @Override
     public boolean dispense() {
-        // todo: dispense item
-        return false;
+        GlowBlock block = getBlock();
+
+        int dispenseSlot = getDispenseSlot();
+        if (dispenseSlot < 0) {
+            block.getWorld().playEffect(block.getLocation(), Effect.CLICK1, 0);
+            return false;
+        }
+
+        ItemStack origItems = getInventory().getItem(dispenseSlot);
+
+        DispenseBehavior behavior = getDispenseBehaviorRegistry().getBehavior(origItems.getType());
+        ItemStack result = behavior.dispense(block, origItems);
+        getInventory().setItem(dispenseSlot, result);
+        return true;
+    }
+
+    public int getDispenseSlot() {
+        Inventory inv = getInventory();
+
+        int slot = -1;
+        int randomChance = 1;
+
+        for (int i = 0; i < inv.getSize(); i++) {
+            if (inv.getItem(i) != null && random.nextInt(randomChance++) == 0) {
+                slot = i;
+            }
+        }
+
+        return slot;
+    }
+
+    public ItemStack placeInDispenser(ItemStack toPlace) {
+        Inventory inv = getInventory();
+        Map<Integer, ItemStack> map = inv.addItem(toPlace);
+        return map.isEmpty() ? null : map.get(0);
     }
 
     @Override
     public Inventory getInventory() {
         return getTileEntity().getInventory();
+    }
+
+    @Override
+    public boolean update(boolean force, boolean applyPhysics) {
+        ItemStack[] contents = getInventory().getContents();
+
+        boolean result = super.update(force, applyPhysics);
+
+        if (result) {
+            getTileEntity().setContents(contents);
+            getTileEntity().updateInRange();
+        }
+
+        return result;
     }
 
     @Override
@@ -45,4 +107,15 @@ public class GlowDispenser extends GlowBlockState implements Dispenser, BlockPro
         // todo: projectile launching
         return null;
     }
+
+    public static void register() {
+        // register all dispense behaviors
+        DefaultDispenseBehavior bucketDispenseBehavior = new BucketDispenseBehavior();
+        GlowDispenser.getDispenseBehaviorRegistry().putBehavior(Material.WATER_BUCKET, bucketDispenseBehavior);
+        GlowDispenser.getDispenseBehaviorRegistry().putBehavior(Material.LAVA_BUCKET, bucketDispenseBehavior);
+        GlowDispenser.getDispenseBehaviorRegistry().putBehavior(Material.BUCKET, new EmptyBucketDispenseBehavior());
+        GlowDispenser.getDispenseBehaviorRegistry().putBehavior(Material.FLINT_AND_STEEL, new FlintAndSteelDispenseBehavior());
+        GlowDispenser.getDispenseBehaviorRegistry().putBehavior(Material.TNT, new TNTDispenseBehavior());
+    }
+
 }

--- a/src/main/java/net/glowstone/dispenser/BucketDispenseBehavior.java
+++ b/src/main/java/net/glowstone/dispenser/BucketDispenseBehavior.java
@@ -1,0 +1,44 @@
+package net.glowstone.dispenser;
+
+import net.glowstone.block.GlowBlock;
+import net.glowstone.block.ItemTable;
+import net.glowstone.block.blocktype.BlockDispenser;
+import net.glowstone.block.blocktype.BlockLiquid;
+import net.glowstone.block.blocktype.BlockType;
+import net.glowstone.block.itemtype.ItemFilledBucket;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.ItemStack;
+
+public class BucketDispenseBehavior extends DefaultDispenseBehavior {
+    DefaultDispenseBehavior defaultBehavior = new DefaultDispenseBehavior();
+
+    @Override
+    protected ItemStack dispenseStack(GlowBlock block, ItemStack stack) {
+        ItemFilledBucket bucket = (ItemFilledBucket) ItemTable.instance().getItem(stack.getType());
+        BlockLiquid liquid = (BlockLiquid) bucket.getLiquid();
+        BlockFace facing = BlockDispenser.getFacing(block);
+        GlowBlock target = block.getRelative(facing);
+
+        if (canPlace(target, facing, stack)) {
+            target.setType(liquid.getMaterial());
+            stack.setType(Material.BUCKET);
+            stack.setAmount(1);
+            return stack;
+        } else {
+            return defaultBehavior.dispense(block, stack);
+        }
+    }
+
+    private boolean canPlace(GlowBlock target, BlockFace facing, ItemStack stack) {
+        if (!target.isEmpty()) {
+            BlockType targetType = ItemTable.instance().getBlock(target.getTypeId());
+            //noinspection ConstantConditions
+            if (!targetType.canOverride(target, facing.getOppositeFace(), stack)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/net/glowstone/dispenser/DefaultDispenseBehavior.java
+++ b/src/main/java/net/glowstone/dispenser/DefaultDispenseBehavior.java
@@ -1,0 +1,71 @@
+package net.glowstone.dispenser;
+
+import net.glowstone.block.GlowBlock;
+import net.glowstone.block.blocktype.BlockDispenser;
+import net.glowstone.entity.objects.GlowItem;
+import org.bukkit.Effect;
+import org.bukkit.Location;
+import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+
+import java.util.Random;
+
+public class DefaultDispenseBehavior implements DispenseBehavior {
+
+    private final Random random = new Random();
+
+    @Override
+    public ItemStack dispense(GlowBlock block, ItemStack stack) {
+        ItemStack result = dispenseStack(block, stack);
+        playDispenseSound(block);
+        spawnDispenseParticles(block, BlockDispenser.getFacing(block));
+        return result;
+    }
+
+    protected ItemStack dispenseStack(GlowBlock block, ItemStack stack) {
+        BlockFace facing = BlockDispenser.getFacing(block);
+        Vector dispensePosition = BlockDispenser.getDispensePosition(block);
+
+        ItemStack items = new ItemStack(stack.getType(), 1);
+        stack.setAmount(stack.getAmount() - 1);
+
+        doDispense(block, items, 6, facing, dispensePosition);
+
+        return stack.getAmount() > 0 ? stack : null;
+    }
+
+    private void doDispense(GlowBlock block, ItemStack items, int power, BlockFace facing, Vector target) {
+        double x = target.getX();
+        double y = target.getY();
+        double z = target.getZ();
+
+        if (facing.getModY() != 0) {
+            y -= 0.125;
+        } else {
+            y -= 0.15625;
+        }
+
+        GlowItem item = new GlowItem(new Location(block.getWorld(), x, y, z), items);
+        double velocity = random.nextDouble() * 0.1 + 0.2;
+        double velocityX = facing.getModX() * velocity;
+        double velocityY = 0.2;
+        double velocityZ = facing.getModZ() * velocity;
+        velocityX += random.nextGaussian() * 0.0075 * power;
+        velocityY += random.nextGaussian() * 0.0075 * power;
+        velocityZ += random.nextGaussian() * 0.0075 * power;
+        item.setVelocity(new Vector(velocityX, velocityY, velocityZ));
+    }
+
+    private int getParticleMetadataForFace(BlockFace face) {
+        return face.getModX() + 1 + (face.getModZ() + 1) * 3;
+    }
+
+    protected void playDispenseSound(GlowBlock block) {
+        block.getWorld().playEffect(block.getLocation(), Effect.CLICK2, 0);
+    }
+
+    protected void spawnDispenseParticles(GlowBlock block, BlockFace facing) {
+        block.getWorld().playEffect(block.getLocation(), Effect.SMOKE, getParticleMetadataForFace(facing));
+    }
+}

--- a/src/main/java/net/glowstone/dispenser/DispenseBehavior.java
+++ b/src/main/java/net/glowstone/dispenser/DispenseBehavior.java
@@ -1,0 +1,8 @@
+package net.glowstone.dispenser;
+
+import net.glowstone.block.GlowBlock;
+import org.bukkit.inventory.ItemStack;
+
+public interface DispenseBehavior {
+    ItemStack dispense(GlowBlock block, ItemStack stack);
+}

--- a/src/main/java/net/glowstone/dispenser/DispenseBehaviorRegistry.java
+++ b/src/main/java/net/glowstone/dispenser/DispenseBehaviorRegistry.java
@@ -1,0 +1,31 @@
+package net.glowstone.dispenser;
+
+import org.bukkit.Material;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class DispenseBehaviorRegistry {
+    private final Map<Material, DispenseBehavior> dispenseBehaviorMap = new ConcurrentHashMap<>();
+
+    public void putBehavior(Material material, DispenseBehavior behavior) {
+        dispenseBehaviorMap.put(material, behavior);
+    }
+
+    public void resetBehavior(Material material) {
+        dispenseBehaviorMap.remove(material);
+    }
+
+    public DispenseBehavior getBehavior(Material material) {
+        if (material == null) {
+            return new DefaultDispenseBehavior();
+        }
+
+        DispenseBehavior behavior = dispenseBehaviorMap.get(material);
+        if (behavior == null) {
+            return new DefaultDispenseBehavior();
+        }
+
+        return behavior;
+    }
+}

--- a/src/main/java/net/glowstone/dispenser/EmptyBucketDispenseBehavior.java
+++ b/src/main/java/net/glowstone/dispenser/EmptyBucketDispenseBehavior.java
@@ -1,0 +1,58 @@
+package net.glowstone.dispenser;
+
+import net.glowstone.block.GlowBlock;
+import net.glowstone.block.ItemTable;
+import net.glowstone.block.blocktype.BlockDispenser;
+import net.glowstone.block.blocktype.BlockLiquid;
+import net.glowstone.block.blocktype.BlockType;
+import net.glowstone.block.state.GlowDispenser;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class EmptyBucketDispenseBehavior extends DefaultDispenseBehavior {
+    private DefaultDispenseBehavior defaultBehavior = new DefaultDispenseBehavior();
+
+    @Override
+    protected ItemStack dispenseStack(GlowBlock block, ItemStack stack) {
+        GlowDispenser dispenser = (GlowDispenser) block.getState();
+        GlowBlock target = block.getRelative(BlockDispenser.getFacing(block));
+        BlockLiquid liquid = collectableLiquidAtBlock(target);
+        if (liquid == null) {
+            return super.dispenseStack(block, stack);
+        }
+        Material bucket = liquid.getBucketType();
+        target.setType(Material.AIR);
+        stack.setAmount(stack.getAmount() - 1);
+        if (stack.getAmount() == 0) {
+            stack.setAmount(1);
+            stack.setType(bucket);
+        } else {
+            ItemStack toPlace = new ItemStack(bucket);
+            ItemStack remaining = dispenser.placeInDispenser(toPlace);
+            if (remaining != null) {
+                defaultBehavior.dispense(block, remaining);
+            }
+        }
+
+        return stack;
+    }
+
+    private BlockLiquid collectableLiquidAtBlock(GlowBlock target) {
+        Material material = target.getType();
+        if (material == null || material == Material.AIR) {
+            return null;
+        }
+
+        BlockType type = ItemTable.instance().getBlock(material);
+        if (!(type instanceof BlockLiquid)) {
+            return null;
+        }
+
+        BlockLiquid liquid = (BlockLiquid) type;
+        if (!liquid.isCollectible(target.getState())) {
+            return null;
+        }
+
+        return liquid;
+    }
+}

--- a/src/main/java/net/glowstone/dispenser/FlintAndSteelDispenseBehavior.java
+++ b/src/main/java/net/glowstone/dispenser/FlintAndSteelDispenseBehavior.java
@@ -1,0 +1,46 @@
+package net.glowstone.dispenser;
+
+import net.glowstone.block.GlowBlock;
+import net.glowstone.block.ItemTable;
+import net.glowstone.block.blocktype.BlockDispenser;
+import net.glowstone.block.blocktype.BlockTNT;
+import net.glowstone.block.itemtype.ItemTool;
+import net.glowstone.block.itemtype.ItemType;
+import org.bukkit.Effect;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class FlintAndSteelDispenseBehavior extends DefaultDispenseBehavior {
+    private boolean successful = true;
+
+    @Override
+    protected ItemStack dispenseStack(GlowBlock block, ItemStack stack) {
+        GlowBlock target = block.getRelative(BlockDispenser.getFacing(block));
+
+        successful = true;
+        if (target.getType() == Material.AIR) {
+            target.setType(Material.FIRE);
+            stack.setDurability((short) (stack.getDurability() + 1));
+            ItemType type = ItemTable.instance().getItem(stack.getType());
+            if (!(type instanceof ItemTool)) {
+                return stack;
+            }
+            ItemTool toolType = (ItemTool) type;
+            if (stack.getDurability() > toolType.getMaxDurability()) {
+                stack.setAmount(0);
+            }
+        } else if (target.getType() == Material.TNT) {
+            BlockTNT.igniteBlock(target, false);
+        } else {
+            successful = false;
+        }
+
+        return stack.getAmount() > 0 ? stack : null;
+    }
+
+    @Override
+    protected void playDispenseSound(GlowBlock block) {
+        Effect effect = successful ? Effect.CLICK2 : Effect.CLICK1;
+        block.getWorld().playEffect(block.getLocation(), effect, 0);
+    }
+}

--- a/src/main/java/net/glowstone/dispenser/ProjectileDispenseBehavior.java
+++ b/src/main/java/net/glowstone/dispenser/ProjectileDispenseBehavior.java
@@ -1,0 +1,34 @@
+package net.glowstone.dispenser;
+
+import net.glowstone.GlowWorld;
+import net.glowstone.block.GlowBlock;
+import net.glowstone.block.blocktype.BlockDispenser;
+import org.bukkit.Effect;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Projectile;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+
+public abstract class ProjectileDispenseBehavior extends DefaultDispenseBehavior {
+    @Override
+    protected ItemStack dispenseStack(GlowBlock block, ItemStack stack) {
+        GlowWorld world = block.getWorld();
+        Vector position = BlockDispenser.getDispensePosition(block);
+        BlockFace face = BlockDispenser.getFacing(block);
+        Projectile entity = getProjectileEntity(world, position);
+        entity.setVelocity(new Vector(face.getModX(), face.getModY() + 0.1f, face.getModZ()).multiply(6));
+
+        stack.setAmount(stack.getAmount() - 1);
+        if (stack.getAmount() < 1) {
+            return null;
+        }
+        return stack;
+    }
+
+    @Override
+    protected void playDispenseSound(GlowBlock block) {
+        block.getWorld().playEffect(block.getLocation(), Effect.BOW_FIRE, 0);
+    }
+
+    protected abstract Projectile getProjectileEntity(GlowWorld world, Vector position);
+}

--- a/src/main/java/net/glowstone/dispenser/TNTDispenseBehavior.java
+++ b/src/main/java/net/glowstone/dispenser/TNTDispenseBehavior.java
@@ -1,0 +1,21 @@
+package net.glowstone.dispenser;
+
+import net.glowstone.GlowWorld;
+import net.glowstone.block.GlowBlock;
+import net.glowstone.block.blocktype.BlockDispenser;
+import net.glowstone.entity.GlowTNTPrimed;
+import org.bukkit.Sound;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemStack;
+
+public class TNTDispenseBehavior extends DefaultDispenseBehavior {
+    @Override
+    protected ItemStack dispenseStack(GlowBlock block, ItemStack stack) {
+        GlowWorld world = block.getWorld();
+        GlowBlock target = block.getRelative(BlockDispenser.getFacing(block));
+        GlowTNTPrimed tnt = (GlowTNTPrimed) world.spawnEntity(target.getLocation().add(0.5, 0, 0.5), EntityType.PRIMED_TNT);
+        world.playSound(tnt.getLocation(), Sound.FUSE, 1, 1);
+        stack.setAmount(stack.getAmount() - 1);
+        return stack.getAmount() > 0 ? stack : null;
+    }
+}


### PR DESCRIPTION
This PR adds support for basic dispenser actions, while trying to imitate the notchian server as much as possible. Dispensers react exactly like on a vanilla server.
This PR does not only add dispensing items out of a dispenser, but also adds support for placing buckets, picking up buckets, placing TNT and lighting things on fire.
