### PR TITLE
Can use bare hands (without holding an item) to interact with levers and buttons.

### DIFF
--- a/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
@@ -78,7 +78,10 @@ public final class BlockPlacementHandler implements MessageHandler<GlowSession, 
         ItemStack holding = player.getItemInHand();
 
         // check that held item matches
-        if (!Objects.equals(holding, message.getHeldItem())) {
+        // apparently the "message" container has comprehends held item as null,
+        // whereas the "holding" item is Material.AIR * 0 (hence the exceptional if statement here)
+        if ((!(holding != null && holding.getType() == Material.AIR && message.getHeldItem() == null))
+                && !Objects.equals(holding, message.getHeldItem())) {
             // above handles cases where holding and/or message's item are null
             // todo: inform player their item is wrong
             return;
@@ -113,7 +116,8 @@ public final class BlockPlacementHandler implements MessageHandler<GlowSession, 
             if (clicked == null) {
                 type.rightClickAir(player, holding);
             } else {
-                type.rightClickBlock(player, clicked, face, holding, clickedLoc);
+                if (holding.getType() != Material.AIR)
+                    type.rightClickBlock(player, clicked, face, holding, clickedLoc);
             }
         }
 


### PR DESCRIPTION
This hard fix made me realize that the following check was obsolete (BlockPlacementHandler.java@81):

``` java
if (!Objects.equals(holding, message.getHeldItem())) {
    // above handles cases where holding and/or message's item are null
    // todo: inform player their item is wrong
    return;
}
```

In fact, in the case of the interaction of a lever using bare hands, `holding` would represent an ItemStack of `Material.AIR * 0` while `message.getHeldItem()` would return `null`.

In order to resolve this, I placed an exceptional check to ensure this doesn't occur with bare hands (for this particular scenario).
