### PR TITLE
Fixed wrong nbt key name Criteria -> CriteriaName

### DIFF
--- a/src/main/java/net/glowstone/scoreboard/NbtScoreboardIoReader.java
+++ b/src/main/java/net/glowstone/scoreboard/NbtScoreboardIoReader.java
@@ -49,7 +49,7 @@ public class NbtScoreboardIoReader {
     }
 
     private static void registerObjective(CompoundTag data, GlowScoreboard scoreboard) {
-        String criteria = data.getString("Criteria");
+        String criteria = data.getString("CriteriaName");
         String displayName = data.getString("DisplayName");
         String name = data.getString("Name");
         String renderType = data.getString("RenderType");

--- a/src/main/java/net/glowstone/scoreboard/NbtScoreboardIoWriter.java
+++ b/src/main/java/net/glowstone/scoreboard/NbtScoreboardIoWriter.java
@@ -44,7 +44,7 @@ public class NbtScoreboardIoWriter {
         List<CompoundTag> objectives = new ArrayList<>();
         for (Objective objective: scoreboard.getObjectives()) {
             CompoundTag objectiveNbt = new CompoundTag();
-            objectiveNbt.putString("Criteria", objective.getCriteria());
+            objectiveNbt.putString("CriteriaName", objective.getCriteria());
             objectiveNbt.putString("DisplayName", objective.getDisplayName());
             objectiveNbt.putString("Name", objective.getName());
             objectiveNbt.putString("RenderType", objective.getType().name());


### PR DESCRIPTION
I tried to load an original minecraft world into Glowstone and it complained about the non-existent scoreboard objective nbt tag "Criteria". 

This PR changes the tag name to "CriteriaName" as it is used in Minecraft Vanilla (-> [Minecraft Wiki](http://minecraft.gamepedia.com/Scoreboard#NBT_format)) to allow scoreboard objectives to be loaded on a Glowstone server.
