### PR TITLE
Remove spurious SetWindowContentsMessage packet sent in GlowPlayer constructor

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -329,7 +329,6 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
 
         //creates InventoryMonitor to avoid NullPointerException
         invMonitor = new InventoryMonitor(getOpenInventory());
-        updateInventory(); // send inventory contents
     }
 
     public void join(GlowSession session, PlayerDataService.PlayerReader reader) {


### PR DESCRIPTION
The GlowPlayer() constructor incorrectly called updateInventory(), which
sent the SetWindowContentsMessage packet (aka 0x30 window_items
http://prismarinejs.github.io/minecraft-data/?d=protocol#toClient_window_items).
This occurred before the JoinGameMessage packet (aka 0x01 login
http://prismarinejs.github.io/minecraft-data/?d=protocol#toClient_login),
and was followed by another SetWindowContentsMessage packet:
1. SetWindowContentsMessage (GlowPlayer constructor)
2. JoinGameMessage (player.join())
3. SetWindowContentsMessage  (called by player.join())

The first packet is not sent by the official server and would crash some
clients e.g. mineflayer (see https://github.com/PrismarineJS/mineflayer/issues/353),
since it relies on the second packet to get the player's entity ID.

For this reason, this commit removes the first packet. The player
inventory is still updated on login via the third packet, as expected.

testing notes: https://gist.github.com/deathcap/bde8187261ac0b4cebe7
