### PR TITLE
Set InLove property for GlowAgeable only if contained in nbt data

### DIFF
--- a/src/main/java/net/glowstone/io/entity/AgeableStore.java
+++ b/src/main/java/net/glowstone/io/entity/AgeableStore.java
@@ -37,7 +37,9 @@ class AgeableStore<T extends GlowAgeable> extends CreatureStore<T> {
         if (compound.containsKey("AgeLocked")) {
             entity.setAgeLock(compound.getBool("AgeLocked"));
         }
-        entity.setInLove(compound.getInt("InLove"));
+        if (compound.containsKey("InLove")) {
+            entity.setInLove(compound.getInt("InLove"));
+        }
         entity.setForcedAge(compound.getInt("ForcedAge"));
     }
 


### PR DESCRIPTION
The InLove tag may not be present as it is only added when needed in vanilla minecraft. This commit only sets the property of GlowAgeable if the NBT Tag is present. (It defaults to 0)
