### PR TITLE
Add Baby spawning with spawn eggs.

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowAnimal.java
+++ b/src/main/java/net/glowstone/entity/GlowAnimal.java
@@ -1,14 +1,8 @@
 package net.glowstone.entity;
 
-import net.glowstone.net.message.play.player.InteractEntityMessage;
-import org.bukkit.GameMode;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.entity.Animals;
 import org.bukkit.entity.EntityType;
-import org.bukkit.event.entity.CreatureSpawnEvent;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.SpawnMeta;
 
 /**
  * Represents an Animal, such as a Cow
@@ -24,31 +18,5 @@ public class GlowAnimal extends GlowAgeable implements Animals {
      */
     public GlowAnimal(Location location, EntityType type, double maxHealth) {
         super(location, type, maxHealth);
-    }
-
-    @Override
-    public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
-        super.entityInteract(player, message);
-        ItemStack item = player.getItemInHand();
-
-        if (item != null && item.getType() == Material.MONSTER_EGG && item.hasItemMeta()) {
-            SpawnMeta meta = (SpawnMeta) item.getItemMeta();
-            if (meta.hasEntityType() && meta.getEntityType() == this.getType()) {
-                Class<? extends GlowEntity> spawn = EntityRegistry.getEntity(getType().getTypeId());
-                GlowAnimal animal = (GlowAnimal) getWorld().spawn(getLocation(), spawn, CreatureSpawnEvent.SpawnReason.SPAWNER_EGG);
-                animal.setBaby();
-
-                if (player.getGameMode() == GameMode.SURVIVAL || player.getGameMode() == GameMode.ADVENTURE) {
-                    // Consume the egg
-                    if (item.getAmount() > 1) {
-                        item.setAmount(item.getAmount() - 1);
-                    } else {
-                        player.getInventory().clear(player.getInventory().getHeldItemSlot());
-                    }
-                }
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/main/java/net/glowstone/entity/GlowAnimal.java
+++ b/src/main/java/net/glowstone/entity/GlowAnimal.java
@@ -31,9 +31,6 @@ public class GlowAnimal extends GlowAgeable implements Animals {
         super.entityInteract(player, message);
         ItemStack item = player.getItemInHand();
 
-        if (player.getGameMode() == GameMode.SPECTATOR)
-            return false;
-
         if (item != null && item.getType() == Material.MONSTER_EGG && item.hasItemMeta()) {
             SpawnMeta meta = (SpawnMeta) item.getItemMeta();
             if (meta.hasEntityType() && meta.getEntityType() == this.getType()) {

--- a/src/main/java/net/glowstone/entity/GlowAnimal.java
+++ b/src/main/java/net/glowstone/entity/GlowAnimal.java
@@ -1,6 +1,7 @@
 package net.glowstone.entity;
 
 import net.glowstone.net.message.play.player.InteractEntityMessage;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Animals;
@@ -30,6 +31,9 @@ public class GlowAnimal extends GlowAgeable implements Animals {
         super.entityInteract(player, message);
         ItemStack item = player.getItemInHand();
 
+        if (player.getGameMode() == GameMode.SPECTATOR)
+            return false;
+
         if (item != null && item.getType() == Material.MONSTER_EGG && item.hasItemMeta()) {
             SpawnMeta meta = (SpawnMeta) item.getItemMeta();
             if (meta.hasEntityType() && meta.getEntityType() == this.getType()) {
@@ -37,14 +41,17 @@ public class GlowAnimal extends GlowAgeable implements Animals {
                 GlowAnimal animal = (GlowAnimal) getWorld().spawn(getLocation(), spawn, CreatureSpawnEvent.SpawnReason.SPAWNER_EGG);
                 animal.setBaby();
 
-                // Consume the egg
-                item.setAmount(item.getAmount() - 1);
-                if (item.getAmount() < 1)
-                    player.getInventory().remove(item);
+                if (player.getGameMode() == GameMode.SURVIVAL || player.getGameMode() == GameMode.ADVENTURE) {
+                    // Consume the egg
+                    if (item.getAmount() > 1) {
+                        item.setAmount(item.getAmount() - 1);
+                    } else {
+                        player.getInventory().clear(player.getInventory().getHeldItemSlot());
+                    }
+                }
                 return true;
             }
         }
-
         return false;
     }
 }

--- a/src/main/java/net/glowstone/entity/GlowAnimal.java
+++ b/src/main/java/net/glowstone/entity/GlowAnimal.java
@@ -1,8 +1,13 @@
 package net.glowstone.entity;
 
+import net.glowstone.net.message.play.player.InteractEntityMessage;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Animals;
 import org.bukkit.entity.EntityType;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SpawnMeta;
 
 /**
  * Represents an Animal, such as a Cow
@@ -18,5 +23,28 @@ public class GlowAnimal extends GlowAgeable implements Animals {
      */
     public GlowAnimal(Location location, EntityType type, double maxHealth) {
         super(location, type, maxHealth);
+    }
+
+    @Override
+    public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
+        super.entityInteract(player, message);
+        ItemStack item = player.getItemInHand();
+
+        if (item != null && item.getType() == Material.MONSTER_EGG && item.hasItemMeta()) {
+            SpawnMeta meta = (SpawnMeta) item.getItemMeta();
+            if (meta.hasEntityType() && meta.getEntityType() == this.getType()) {
+                Class<? extends GlowEntity> spawn = EntityRegistry.getEntity(getType().getTypeId());
+                GlowAnimal animal = (GlowAnimal) getWorld().spawn(getLocation(), spawn, CreatureSpawnEvent.SpawnReason.SPAWNER_EGG);
+                animal.setBaby();
+
+                // Consume the egg
+                item.setAmount(item.getAmount() - 1);
+                if (item.getAmount() < 1)
+                    player.getInventory().remove(item);
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/main/java/net/glowstone/entity/monster/GlowMonster.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowMonster.java
@@ -1,13 +1,13 @@
 package net.glowstone.entity.monster;
 
-import net.glowstone.entity.GlowAgeable;
+import net.glowstone.entity.GlowCreature;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Monster;
 
-public class GlowMonster extends GlowAgeable implements Monster {
+public class GlowMonster extends GlowCreature implements Monster {
     /**
-     * Creates a new ageable non-passive mob.
+     * Creates a new non-passive mob.
      *
      * @param loc  The location of the non-passive mob.
      * @param type The type of mob.

--- a/src/main/java/net/glowstone/entity/passive/GlowCow.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowCow.java
@@ -20,6 +20,7 @@ public class GlowCow extends GlowAnimal implements Cow {
 
     @Override
     public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
+        super.entityInteract(player, message);
         if (player.getGameMode().equals(GameMode.CREATIVE) || player.getGameMode().equals(GameMode.SPECTATOR))
             return false;
         if (!player.getItemInHand().getType().equals(Material.BUCKET)) return false;

--- a/src/main/java/net/glowstone/entity/passive/GlowCow.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowCow.java
@@ -23,6 +23,9 @@ public class GlowCow extends GlowAnimal implements Cow {
         super.entityInteract(player, message);
         if (player.getGameMode().equals(GameMode.CREATIVE) || player.getGameMode().equals(GameMode.SPECTATOR))
             return false;
+
+        if (!isAdult()) return false;
+
         if (!player.getItemInHand().getType().equals(Material.BUCKET)) return false;
 
         if (player.getItemInHand().getAmount() > 1) {

--- a/src/main/java/net/glowstone/entity/passive/GlowPig.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowPig.java
@@ -31,6 +31,9 @@ public class GlowPig extends GlowAnimal implements Pig {
     @Override
     public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
         super.entityInteract(player, message);
+
+        if (!isAdult()) return false;
+
         if (!hasSaddle()) {
             ItemStack hand = player.getItemInHand();
             if (hand.getType() == Material.SADDLE) {

--- a/src/main/java/net/glowstone/entity/passive/GlowPig.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowPig.java
@@ -30,6 +30,7 @@ public class GlowPig extends GlowAnimal implements Pig {
 
     @Override
     public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
+        super.entityInteract(player, message);
         if (!hasSaddle()) {
             ItemStack hand = player.getItemInHand();
             if (hand.getType() == Material.SADDLE) {

--- a/src/main/java/net/glowstone/entity/passive/GlowSheep.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowSheep.java
@@ -69,6 +69,9 @@ public class GlowSheep extends GlowAnimal implements Sheep {
     @Override
     public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
         super.entityInteract(player, message);
+
+        if (!isAdult()) return false;
+
         if (player.getGameMode().equals(GameMode.SPECTATOR)) return false;
         if (player.getItemInHand() == null) return false;
         switch (player.getItemInHand().getType()) {

--- a/src/main/java/net/glowstone/entity/passive/GlowSheep.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowSheep.java
@@ -68,6 +68,7 @@ public class GlowSheep extends GlowAnimal implements Sheep {
 
     @Override
     public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
+        super.entityInteract(player, message);
         if (player.getGameMode().equals(GameMode.SPECTATOR)) return false;
         if (player.getItemInHand() == null) return false;
         switch (player.getItemInHand().getType()) {


### PR DESCRIPTION
Adds babies to Animals when clicking on a mob with the same type of Spawn Egg.

GlowCow, GlowPig and GlowSheep need to get their super#entityInteract method called in order to have babies.
