### PR TITLE
Fixes for Entity metadata not being saved properly, Zombie Villager profession implementation

### DIFF
--- a/src/main/java/net/glowstone/entity/monster/GlowCreeper.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowCreeper.java
@@ -26,12 +26,12 @@ public class GlowCreeper extends GlowMonster implements Creeper {
 
     @Override
     public boolean isPowered() {
-        return metadata.getByte(MetadataIndex.CREEPER_POWERED) == 1;
+        return metadata.getBoolean(MetadataIndex.CREEPER_POWERED);
     }
 
     @Override
     public void setPowered(boolean value) {
-        metadata.set(MetadataIndex.CREEPER_POWERED, value ? (byte) 1 : (byte) 0);
+        metadata.set(MetadataIndex.CREEPER_POWERED, value);
     }
 
     public int getExplosionRadius() {

--- a/src/main/java/net/glowstone/entity/monster/GlowGhast.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowGhast.java
@@ -22,10 +22,10 @@ public class GlowGhast extends GlowMonster implements Ghast {
     }
 
     public boolean isAttacking() {
-        return metadata.getByte(MetadataIndex.GHAST_ATTACKING) == 1;
+        return metadata.getBoolean(MetadataIndex.GHAST_ATTACKING);
     }
 
     public void setAttacking(boolean attacking) {
-        metadata.set(MetadataIndex.GHAST_ATTACKING, attacking ? (byte) 1 : (byte) 0);
+        metadata.set(MetadataIndex.GHAST_ATTACKING, attacking);
     }
 }

--- a/src/main/java/net/glowstone/entity/monster/GlowSlime.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowSlime.java
@@ -41,11 +41,11 @@ public class GlowSlime extends GlowMonster implements Slime {
 
     @Override
     public int getSize() {
-        return metadata.getByte(MetadataIndex.SLIME_SIZE);
+        return metadata.getInt(MetadataIndex.SLIME_SIZE);
     }
 
     @Override
     public void setSize(int sz) {
-        metadata.set(MetadataIndex.SLIME_SIZE, (byte) sz);
+        metadata.set(MetadataIndex.SLIME_SIZE, sz);
     }
 }

--- a/src/main/java/net/glowstone/entity/monster/GlowWitch.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowWitch.java
@@ -12,10 +12,10 @@ public class GlowWitch extends GlowMonster implements Witch {
     }
 
     public boolean isAgressive() {
-        return metadata.getByte(MetadataIndex.WITCH_AGGRESSIVE) == 1;
+        return metadata.getBoolean(MetadataIndex.WITCH_AGGRESSIVE);
     }
 
     public void setAgressive(boolean agressive) {
-        metadata.set(MetadataIndex.WITCH_AGGRESSIVE, agressive ? (byte) 1 : (byte) 0);
+        metadata.set(MetadataIndex.WITCH_AGGRESSIVE, agressive);
     }
 }

--- a/src/main/java/net/glowstone/entity/monster/GlowZombie.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowZombie.java
@@ -46,7 +46,7 @@ public class GlowZombie extends GlowMonster implements Zombie {
 
     @Override
     public void setVillager(boolean value) {
-        metadata.set(MetadataIndex.ZOMBIE_IS_VILLAGER, value ? villagerProfession.getId() : 0);
+        metadata.set(MetadataIndex.ZOMBIE_IS_VILLAGER, value ? villagerProfession.getId() + 1 : 0);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/monster/GlowZombie.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowZombie.java
@@ -13,6 +13,7 @@ public class GlowZombie extends GlowMonster implements Zombie {
 
     private int conversionTime = -1;
     private boolean canBreakDoors;
+    private Profession villagerProfession = Profession.FARMER;
 
     public GlowZombie(Location loc) {
         this(loc, EntityType.ZOMBIE);
@@ -45,17 +46,18 @@ public class GlowZombie extends GlowMonster implements Zombie {
 
     @Override
     public void setVillager(boolean value) {
-        metadata.set(MetadataIndex.ZOMBIE_IS_VILLAGER, value ? 1 : 0);
+        metadata.set(MetadataIndex.ZOMBIE_IS_VILLAGER, value ? villagerProfession.getId() : 0);
     }
 
     @Override
     public void setVillagerProfession(Profession profession) {
+        this.villagerProfession = profession;
         metadata.set(MetadataIndex.ZOMBIE_IS_VILLAGER, profession.getId() + 1);
     }
 
     @Override
     public Profession getVillagerProfession() {
-        return Profession.getProfession(metadata.getInt(MetadataIndex.ZOMBIE_IS_VILLAGER) - 1);
+        return villagerProfession;
     }
 
     public int getConversionTime() {

--- a/src/main/java/net/glowstone/entity/monster/GlowZombie.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowZombie.java
@@ -24,38 +24,38 @@ public class GlowZombie extends GlowMonster implements Zombie {
 
     @Override
     public List<Message> createSpawnMessage() {
-        metadata.set(MetadataIndex.ZOMBIE_IS_CONVERTING, conversionTime > 0 ? (byte) 1 : (byte) 0);
+        metadata.set(MetadataIndex.ZOMBIE_IS_CONVERTING, conversionTime > 0);
         return super.createSpawnMessage();
     }
 
     @Override
     public boolean isBaby() {
-        return metadata.getByte(MetadataIndex.ZOMBIE_IS_CHILD) == 1;
+        return metadata.getBoolean(MetadataIndex.ZOMBIE_IS_CHILD);
     }
 
     @Override
     public void setBaby(boolean value) {
-        metadata.set(MetadataIndex.ZOMBIE_IS_CHILD, value ? (byte) 1 : (byte) 0);
+        metadata.set(MetadataIndex.ZOMBIE_IS_CHILD, value);
     }
 
     @Override
     public boolean isVillager() {
-        return metadata.getByte(MetadataIndex.ZOMBIE_IS_VILLAGER) == 1;
+        return metadata.getInt(MetadataIndex.ZOMBIE_IS_VILLAGER) > 0;
     }
 
     @Override
     public void setVillager(boolean value) {
-        metadata.set(MetadataIndex.ZOMBIE_IS_VILLAGER, value ? (byte) 1 : (byte) 0);
+        metadata.set(MetadataIndex.ZOMBIE_IS_VILLAGER, value ? 1 : 0);
     }
 
     @Override
     public void setVillagerProfession(Profession profession) {
-
+        metadata.set(MetadataIndex.ZOMBIE_IS_VILLAGER, profession.getId() + 1);
     }
 
     @Override
     public Profession getVillagerProfession() {
-        return null;
+        return Profession.getProfession(metadata.getInt(MetadataIndex.ZOMBIE_IS_VILLAGER) - 1);
     }
 
     public int getConversionTime() {
@@ -64,7 +64,7 @@ public class GlowZombie extends GlowMonster implements Zombie {
 
     public void setConversionTime(int conversionTime) {
         this.conversionTime = conversionTime;
-        metadata.set(MetadataIndex.ZOMBIE_IS_CONVERTING, conversionTime > 0 ? (byte) 1 : (byte) 0);
+        metadata.set(MetadataIndex.ZOMBIE_IS_CONVERTING, conversionTime > 0);
     }
 
     public boolean isCanBreakDoors() {

--- a/src/main/java/net/glowstone/entity/passive/GlowPig.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowPig.java
@@ -20,12 +20,12 @@ public class GlowPig extends GlowAnimal implements Pig {
 
     @Override
     public boolean hasSaddle() {
-        return metadata.getByte(MetadataIndex.PIG_SADDLE) == 1;
+        return metadata.getBoolean(MetadataIndex.PIG_SADDLE);
     }
 
     @Override
     public void setSaddle(boolean hasSaddle) {
-        metadata.set(MetadataIndex.PIG_SADDLE, (byte) (hasSaddle ? 1 : 0));
+        metadata.set(MetadataIndex.PIG_SADDLE, hasSaddle);
     }
 
     @Override

--- a/src/main/java/net/glowstone/io/entity/ZombieStore.java
+++ b/src/main/java/net/glowstone/io/entity/ZombieStore.java
@@ -2,6 +2,7 @@ package net.glowstone.io.entity;
 
 import net.glowstone.entity.monster.GlowZombie;
 import net.glowstone.util.nbt.CompoundTag;
+import org.bukkit.entity.Villager;
 
 class ZombieStore<T extends GlowZombie> extends MonsterStore<GlowZombie> {
 
@@ -27,6 +28,10 @@ class ZombieStore<T extends GlowZombie> extends MonsterStore<GlowZombie> {
             entity.setBaby(tag.getBool("IsBaby"));
         } else {
             entity.setBaby(false);
+        }
+
+        if (tag.isInt("VillagerProfession")) {
+            entity.setVillagerProfession(Villager.Profession.getProfession(tag.getInt("VillagerProfession")));
         }
 
         if (tag.isInt("ConversionTime")) {


### PR DESCRIPTION
Since 1.9, a lot of Metadata fields for entities were changed from bytes to booleans. This PR fixes the issues when spawning, saving and changing these entities:
- Zombies & Zombie Pigmen (Fixed spawn and saving)
- Creepers (Fixed saving)
- Ghasts (Fixed state changing)
- Witches (Fixed state changing)
- Pigs (Fixed saving and interacting)

I've also implemented a basic handler for VillagerProfessions for Zombies. Please take note that the ZOMBIE_IS_VILLAGER's value is 0 when not a villager, and any other value to this makes the Zombie a Zombie Villager with a profession of the given ID, with an offset of +1.
