### PR TITLE
[Moved] Mojangson utility for parsing and writing NBT Tags from/to JSON Text

### DIFF
--- a/src/main/java/net/glowstone/util/nbt/MojangsonUtil.java
+++ b/src/main/java/net/glowstone/util/nbt/MojangsonUtil.java
@@ -2,6 +2,8 @@ package net.glowstone.util.nbt;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +20,52 @@ public class MojangsonUtil {
         // For example, the JSON string {"foo":"bar"} would be
         // changed to {foo:"bar"}
         return json.toJSONString().replaceAll("\"+([^\"]+)\"+(?=:)", "$1");
+    }
+
+    /**
+     * Converts a Mojangson string into a JSON Object
+     * @param mojangson The Mojangson string to convert
+     * @return the resulting JSON object
+     * @throws ParseException if the conversion of the Mojangson string into valid JSON was unsuccessful.
+     */
+    public static JSONObject convertMojangsonToJSON(String mojangson) throws ParseException {
+        int len = mojangson.length();
+        StringBuilder builder = new StringBuilder();
+        List<Integer> indexes = new ArrayList<>();
+        boolean inArray = false;
+
+        for (int index = 0; index < len; index++) {
+            if (index == 0 || index == len - 1) continue;
+            char symbol = mojangson.charAt(index);
+            char prec = mojangson.charAt(index - 1);
+            char next = mojangson.charAt(index + 1);
+
+            if (symbol == '\"') {
+                continue;
+            }
+            if (symbol == '[') {
+                inArray = true;
+            } else if (symbol == ']' || symbol == '{') {
+                inArray = false;
+            }
+            if (inArray) {
+                continue;
+            }
+            if (prec == '{' || prec == ',') {
+                indexes.add(index - 1);
+            } else if (next == ':') {
+                indexes.add(index);
+            }
+        }
+
+        for (int index = 0; index < len; index++) {
+            builder.append(mojangson.charAt(index));
+            if (indexes.contains(index)) {
+                builder.append('\"');
+            }
+        }
+        JSONParser parser = new JSONParser();
+        return (JSONObject) parser.parse(builder.toString());
     }
 
     /**

--- a/src/main/java/net/glowstone/util/nbt/MojangsonUtil.java
+++ b/src/main/java/net/glowstone/util/nbt/MojangsonUtil.java
@@ -9,6 +9,18 @@ import java.util.List;
 public class MojangsonUtil {
 
     /**
+     * Converts a JSON Object into a standart Mojangson string
+     * @param json The JSON Object to convert
+     * @return the resulting Mojangson string
+     */
+    public static String convertJSONtoMojangson(JSONObject json) {
+        // This removes double-quotes from key names.
+        // For example, the JSON string {"foo":"bar"} would be
+        // changed to {foo:"bar"}
+        return json.toJSONString().replaceAll("\"+([^\"]+)\"+(?=:)", "$1");
+    }
+
+    /**
      * Transforms a CompoundTag into a JSON Object
      * @param compound The CompoundTag to convert
      * @return the resulting JSON Object
@@ -65,9 +77,9 @@ public class MojangsonUtil {
             Tag tag = toTag(value);
 
             if (tag == null) {
-                if (value instanceof JSONArray) {
+                if (value.getClass() == JSONArray.class) {
                     tag = parseList((JSONArray) value);
-                } else if (value instanceof JSONObject) {
+                } else if (value.getClass() == JSONObject.class) {
                     tag = parseCompound((JSONObject) value);
                 }
             }
@@ -89,9 +101,9 @@ public class MojangsonUtil {
         Object firstValue = array.get(0);
         Tag firstTag = toTag(firstValue);
         if (firstTag == null) {
-            if (firstValue instanceof JSONArray) {
+            if (firstValue.getClass() == JSONArray.class) {
                 firstTag = parseList((JSONArray) firstValue);
-            } else if (firstValue instanceof JSONObject) {
+            } else if (firstValue.getClass() == JSONObject.class) {
                 firstTag = parseCompound((JSONObject) firstValue);
             }
         }
@@ -100,9 +112,9 @@ public class MojangsonUtil {
         for (Object object : array) {
             Tag tag = toTag(object);
             if (tag == null) {
-                if (object instanceof JSONArray) {
+                if (object.getClass() == JSONArray.class) {
                     tag = parseList((JSONArray) object);
-                } else if (object instanceof JSONObject) {
+                } else if (object.getClass() == JSONObject.class) {
                     tag = parseCompound((JSONObject) object);
                 }
             }
@@ -115,26 +127,26 @@ public class MojangsonUtil {
     /**
      * Transforms a value into the appropriate NBT tag
      * @param value The value of the NBT tag
-     * @return the resultant NBT tag, null if the given value is not of an appropriate type or if it is a JSONObject or JSON Array
+     * @return the resultant NBT tag, null if the given value is not of an appropriate type or if it is a JSON Object or JSON Array
      */
     private static Tag toTag(Object value) {
-        if (value instanceof Integer) {
+        if (value.getClass() == int.class) {
             return new IntTag((int) value);
-        } else if (value instanceof Byte) {
+        } else if (value.getClass() == byte.class) {
             return new ByteTag((byte) value);
-        } else if (value instanceof Short) {
+        } else if (value.getClass() == short.class) {
             return new ShortTag((short) value);
-        } else if (value instanceof Long) {
+        } else if (value.getClass() == long.class) {
             return new LongTag((long) value);
-        } else if (value instanceof Float) {
+        } else if (value.getClass() == float.class) {
             return new FloatTag((float) value);
-        } else if (value instanceof Double) {
+        } else if (value.getClass() == double.class) {
             return new DoubleTag((double) value);
-        } else if (value instanceof byte[]) {
+        } else if (value.getClass() == byte[].class) {
             return new ByteArrayTag((byte[]) value);
-        } else if (value instanceof String) {
+        } else if (value.getClass() == String.class) {
             return new StringTag((String) value);
-        } else if (value instanceof int[]) {
+        } else if (value.getClass() == int[].class) {
             return new IntArrayTag((int[]) value);
         }
         return null;

--- a/src/main/java/net/glowstone/util/nbt/MojangsonUtil.java
+++ b/src/main/java/net/glowstone/util/nbt/MojangsonUtil.java
@@ -1,0 +1,142 @@
+package net.glowstone.util.nbt;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MojangsonUtil {
+
+    /**
+     * Transforms a CompoundTag into a JSON Object
+     * @param compound The CompoundTag to convert
+     * @return the resulting JSON Object
+     */
+    public static JSONObject compoundToJSON(CompoundTag compound) {
+        JSONObject object = new JSONObject();
+        for (String key : compound.getValue().keySet()) {
+            Tag tag = (Tag) compound.getValue().get(key);
+            Object value = tag.getValue();
+            if (tag.getType() == TagType.COMPOUND) {
+                object.put(key, compoundToJSON((CompoundTag) tag));
+            } else if (tag.getType() == TagType.LIST) {
+                ListTag listTag = (ListTag) tag;
+                object.put(key, listToJSON(listTag));
+            } else {
+                object.put(key, value);
+            }
+        }
+        return object;
+    }
+
+    /**
+     * Transforms a ListTag into a JSON Array
+     * @param list The ListTag to convert
+     * @return the resulting JSON Array
+     */
+    public static JSONArray listToJSON(ListTag list) {
+        JSONArray array = new JSONArray();
+        for (Object object : list.getValue()) {
+            Tag tag = (Tag) object;
+            if (tag.getType() == TagType.COMPOUND) {
+                array.add(compoundToJSON((CompoundTag) tag));
+            } else if (tag.getType() == TagType.LIST) {
+                ListTag listTag = (ListTag) tag;
+                array.add(listToJSON(listTag));
+            } else {
+                array.add(tag.getValue());
+            }
+        }
+        return array;
+    }
+
+    /**
+     * Parses a JSON Object into a CompoundTag
+     * @param json The JSON Object to parse
+     * @return the resulting CompoundTag
+     */
+    public static CompoundTag parseCompound(JSONObject json) {
+        CompoundTag compound = new CompoundTag();
+
+        for (Object keyO : json.keySet()) {
+            String key = (String) keyO;
+            Object value = json.get(keyO);
+            Tag tag = toTag(value);
+
+            if (tag == null) {
+                if (value instanceof JSONArray) {
+                    tag = parseList((JSONArray) value);
+                } else if (value instanceof JSONObject) {
+                    tag = parseCompound((JSONObject) value);
+                }
+            }
+            compound.put(key, tag);
+        }
+        return compound;
+    }
+
+    /**
+     * Parses a JSON Array into a ListTag of the same element type
+     * @param array The JSON Array to parse
+     * @return the resulting ListTag
+     */
+    public static ListTag parseList(JSONArray array) {
+        if (array.size() == 0) {
+            return new ListTag(TagType.COMPOUND, array);
+        }
+
+        Object firstValue = array.get(0);
+        Tag firstTag = toTag(firstValue);
+        if (firstTag == null) {
+            if (firstValue instanceof JSONArray) {
+                firstTag = parseList((JSONArray) firstValue);
+            } else if (firstValue instanceof JSONObject) {
+                firstTag = parseCompound((JSONObject) firstValue);
+            }
+        }
+        TagType type = firstTag.getType();
+        List list = new ArrayList();
+        for (Object object : array) {
+            Tag tag = toTag(object);
+            if (tag == null) {
+                if (object instanceof JSONArray) {
+                    tag = parseList((JSONArray) object);
+                } else if (object instanceof JSONObject) {
+                    tag = parseCompound((JSONObject) object);
+                }
+            }
+            list.add(tag);
+        }
+
+        return new ListTag(type, list);
+    }
+
+    /**
+     * Transforms a value into the appropriate NBT tag
+     * @param value The value of the NBT tag
+     * @return the resultant NBT tag, null if the given value is not of an appropriate type or if it is a JSONObject or JSON Array
+     */
+    private static Tag toTag(Object value) {
+        if (value instanceof Integer) {
+            return new IntTag((int) value);
+        } else if (value instanceof Byte) {
+            return new ByteTag((byte) value);
+        } else if (value instanceof Short) {
+            return new ShortTag((short) value);
+        } else if (value instanceof Long) {
+            return new LongTag((long) value);
+        } else if (value instanceof Float) {
+            return new FloatTag((float) value);
+        } else if (value instanceof Double) {
+            return new DoubleTag((double) value);
+        } else if (value instanceof byte[]) {
+            return new ByteArrayTag((byte[]) value);
+        } else if (value instanceof String) {
+            return new StringTag((String) value);
+        } else if (value instanceof int[]) {
+            return new IntArrayTag((int[]) value);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
This class is a utility for parsing and writing NBT compounds and lists from and to JSON text, using the JSONSimple library. There is currently no implemented use of this class in G++, but I will be working on the `summon` command when this utility is done.

"Mojangson" is the term Mojang uses to refer to NBT tags serialized as (almost) JSON, so it can be manipulated by the player using different commands, such as `/summon`, `/entitydata`, etc. The main difference between Mojangson over JSON is the relative flexibility: it does not need double-quotes for JSON element key names.

I am putting this here as I would like to have feedback on the class first before working on an implementation. Parsing and writing Mojangson/JSON using this utility _has_ been tested.

TODO list:
- [x] Transform NBT Tags to JSON
- [x] Transform JSON to NBT Tags
- [x] Transform JSON to Mojangson
- [x] Transform Mojangson to JSON
- [ ] Add suffixes to Mojangson tag values
