### PR TITLE
Fixed issue #246 (and other bugs related to Double Plants)

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockDoublePlant.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockDoublePlant.java
@@ -50,19 +50,19 @@ public class BlockDoublePlant extends BlockNeedsAttached implements IBlockGrowab
         MaterialData data = block.getState().getData();
         if (data instanceof DoublePlant) {
             DoublePlantSpecies species = ((DoublePlant) data).getSpecies();
-            block.setType(Material.AIR);
             if (species == DoublePlantSpecies.PLANT_APEX) {
-                block = block.getRelative(BlockFace.DOWN);
-                if (!(block.getState().getData() instanceof DoublePlant)) {
+                GlowBlock blockUnder = block.getRelative(BlockFace.DOWN);
+                if (!(blockUnder.getState().getData() instanceof DoublePlant)) {
                     return;
                 }
+                blockUnder.setType(Material.AIR);
             } else {
-                block = block.getRelative(BlockFace.UP);
-                if (!(block.getState().getData() instanceof DoublePlant)) {
+                GlowBlock blockTop = block.getRelative(BlockFace.UP);
+                if (!(blockTop.getState().getData() instanceof DoublePlant)) {
                     return;
                 }
+                blockTop.setType(Material.AIR);
             }
-            block.setType(Material.AIR);
         } else {
             warnMaterialData(DoublePlant.class, data);
         }

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -13,6 +13,7 @@ import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.objects.GlowItem;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.DiggingMessage;
+import org.bukkit.DoublePlantSpecies;
 import org.bukkit.Effect;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -24,6 +25,8 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockDamageEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.material.DoublePlant;
+import org.bukkit.material.MaterialData;
 
 public final class DiggingHandler implements MessageHandler<GlowSession, DiggingMessage> {
     @Override
@@ -165,6 +168,13 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
                 return;
             }
 
+            MaterialData data = block.getState().getData();
+            if (data instanceof DoublePlant) {
+                if (((DoublePlant) data).getSpecies() == DoublePlantSpecies.PLANT_APEX && block.getRelative(BlockFace.DOWN).getState().getData() instanceof DoublePlant) {
+                    block = block.getRelative(BlockFace.DOWN);
+                }
+            }
+
             BlockType blockType = ItemTable.instance().getBlock(block.getType());
             if (blockType != null) {
                 blockType.blockDestroy(player, block, face);
@@ -172,7 +182,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
 
             // destroy the block
             if (!block.isEmpty() && !block.isLiquid() && player.getGameMode() != GameMode.CREATIVE && world.getGameRuleMap().getBoolean("doTileDrops")) {
-                for (ItemStack drop : block.getDrops(holding)) {
+                for (ItemStack drop : blockType.getDrops(block, holding)) {
                     GlowItem item = world.dropItemNaturally(block.getLocation(), drop);
                     item.setPickupDelay(30);
                     item.setBias(player);

--- a/src/main/resources/builtin/materialValues.yml
+++ b/src/main/resources/builtin/materialValues.yml
@@ -371,6 +371,7 @@ values:
     lightOpacity: 0
     flameResistance: 60
     fireResistance: 100
+    hardness: 0
   STANDING_BANNER:
   WALL_BANNER:
   DAYLIGHT_DETECTOR_INVERTED:


### PR DESCRIPTION
This PR fixes issues with Double Plant destroying:
- Missing hardness value for `DOUBLE_PLANT`(#246)
- Missing link between top/bottom part of the structure, causing a wrong MaterialData transfer

In order to fix these, the PR:
- adds he `hardness` material value of 0 for instant-breaking of Double Plant;
- transfers the destruction of the top part to the bottom part of the plant;
- made a small refactoring of the block destruction handler for Double Plants.
