### PR TITLE
Update to 1.9.4, compatibility with 1.9, 1.9.2, 1.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>Glowstone++</name>
     <groupId>net.glowstoneplusplus</groupId>
     <artifactId>glowstoneplusplus</artifactId>
-    <version>1.9.2-SNAPSHOT</version>
+    <version>1.9.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <inceptionYear>2015</inceptionYear>
     <url>https://www.glowstone.net</url>
@@ -24,7 +24,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <bukkit.version>1.9.2-R0.1-SNAPSHOT</bukkit.version>
+        <bukkit.version>1.9.4-R0.1-SNAPSHOT</bukkit.version>
     </properties>
 
     <repositories>

--- a/src/main/java/net/glowstone/GlowChunk.java
+++ b/src/main/java/net/glowstone/GlowChunk.java
@@ -13,6 +13,7 @@ import net.glowstone.entity.GlowEntity;
 import net.glowstone.net.message.play.game.ChunkDataMessage;
 import net.glowstone.util.NibbleArray;
 import net.glowstone.util.VariableValueArray;
+import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.Chunk;
 import org.bukkit.World.Environment;
 import org.bukkit.entity.Entity;
@@ -690,7 +691,14 @@ public final class GlowChunk implements Chunk {
             buf.writeBytes(biomes);
         }
 
-        return new ChunkDataMessage(x, z, entireChunk, sectionBitmask, buf);
+        ArrayList<CompoundTag> tiles = new ArrayList<>();
+        for (TileEntity tileEntity : getRawTileEntities()) {
+            CompoundTag tag = new CompoundTag();
+            tileEntity.saveNbt(tag);
+            tiles.add(tag);
+        }
+
+        return new ChunkDataMessage(x, z, entireChunk, sectionBitmask, buf, tiles.toArray(new CompoundTag[tiles.size()]));
     }
 
     /**

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -106,12 +106,22 @@ public final class GlowServer implements Server {
     /**
      * The game version supported by the server.
      */
-    public static final String GAME_VERSION = "1.9.2";
+    public static final String GAME_VERSION = "1.9.4";
 
     /**
      * The protocol version supported by the server.
      */
-    public static final int PROTOCOL_VERSION = 109;
+    public static final int PROTOCOL_VERSION = 110;
+
+    /**
+     * The legacy version supported by the server.
+     */
+    public static final int LEGACY_PROTOCOL_VERSION = 107;
+
+    /**
+     * The compatible version supported by the server.
+     */
+    public static final int COMPATIBLE_PROTOCOL_VERSION = 109;
     /**
      * A list of all the active {@link net.glowstone.net.GlowSession}s.
      */
@@ -1058,6 +1068,10 @@ public final class GlowServer implements Server {
      */
     public boolean getAnnounceAchievements() {
         return config.getBoolean(Key.ANNOUNCE_ACHIEVEMENTS);
+    }
+
+    public boolean canSupportLegacyClients() {
+        return config.getBoolean(Key.ALLOW_LEGACY_CLIENTS);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -117,12 +117,12 @@ public final class GlowServer implements Server {
     /**
      * The legacy version supported by the server.
      */
-    public static final int LEGACY_PROTOCOL_VERSION = 107;
+    public static final int LEGACY_PROTOCOL_1_9 = 107;
 
     /**
      * The compatible version supported by the server.
      */
-    public static final int COMPATIBLE_PROTOCOL_VERSION = 109;
+    public static final int LEGACY_PROTOCOL_1_9_2 = 109;
     /**
      * A list of all the active {@link net.glowstone.net.GlowSession}s.
      */

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -10,6 +10,7 @@ import net.glowstone.block.BuiltinMaterialValueManager;
 import net.glowstone.block.MaterialValueManager;
 import net.glowstone.block.state.GlowDispenser;
 import net.glowstone.command.ColorCommand;
+import net.glowstone.command.StopsoundCommand;
 import net.glowstone.command.TellrawCommand;
 import net.glowstone.command.TitleCommand;
 import net.glowstone.constants.GlowEnchantment;
@@ -732,6 +733,7 @@ public final class GlowServer implements Server {
         commandMap.register("glowstone", new ColorCommand());
         commandMap.register("glowstone", new TellrawCommand());
         commandMap.register("glowstone", new TitleCommand());
+        commandMap.register("glowstone", new StopsoundCommand());
 
         File folder = new File(config.getString(Key.PLUGIN_FOLDER));
         if (!folder.isDirectory() && !folder.mkdirs()) {

--- a/src/main/java/net/glowstone/block/entity/TESign.java
+++ b/src/main/java/net/glowstone/block/entity/TESign.java
@@ -27,7 +27,7 @@ public class TESign extends TileEntity {
 
     @Override
     public void update(GlowPlayer player) {
-        player.sendSignChange(getBlock().getLocation(), lines);
+        player.sendSignChange(this, getBlock().getLocation(), lines);
     }
 
     @Override

--- a/src/main/java/net/glowstone/command/StopsoundCommand.java
+++ b/src/main/java/net/glowstone/command/StopsoundCommand.java
@@ -1,0 +1,44 @@
+package net.glowstone.command;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.defaults.BukkitCommand;
+import org.bukkit.entity.Player;
+
+import java.util.Collections;
+
+public class StopsoundCommand extends BukkitCommand {
+
+    public StopsoundCommand() {
+        super("stopsound", "Stops sounds for a player.", "/stopsound <player> [source] [sound]", Collections.<String>emptyList());
+        setPermission("glowstone.command.stopsound");
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String commandLabel, String[] args) {
+
+        if (args.length == 0) {
+            sender.sendMessage(usageMessage);
+            return false;
+        }
+
+        Player player = Bukkit.getServer().getPlayer(args[0]);
+        if (player == null) {
+            sender.sendMessage(ChatColor.RED + "The player '" + args[0] + "' is not online, or does not exist.");
+            return false;
+        }
+
+        String source = "", sound = "";
+        String message = "Stopped all sounds for player '" + player.getName() + "'.";
+        if (args.length > 1) {
+            source = args[1];
+            message = "Stopped sounds from source " + source + " for player '" + player.getName() + "'.";
+        }
+        if (args.length > 2) {
+            sound = args[2];
+            message = "Stopped sound '" + sound + "' for player '" + player.getName() + "'.";
+        }
+        return true;
+    }
+}

--- a/src/main/java/net/glowstone/command/StopsoundCommand.java
+++ b/src/main/java/net/glowstone/command/StopsoundCommand.java
@@ -1,11 +1,17 @@
 package net.glowstone.command;
 
+import com.flowpowered.network.util.ByteBufUtils;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import net.glowstone.entity.GlowPlayer;
+import net.glowstone.net.message.play.game.PluginMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.defaults.BukkitCommand;
 import org.bukkit.entity.Player;
 
+import java.io.IOException;
 import java.util.Collections;
 
 public class StopsoundCommand extends BukkitCommand {
@@ -39,6 +45,18 @@ public class StopsoundCommand extends BukkitCommand {
             sound = args[2];
             message = "Stopped sound '" + sound + "' for player '" + player.getName() + "'.";
         }
+
+        ByteBuf buffer = Unpooled.buffer();
+        try {
+            ByteBufUtils.writeUTF8(buffer, source);
+            ByteBufUtils.writeUTF8(buffer, sound);
+            ((GlowPlayer) player).getSession().send(new PluginMessage("MC|StopSound", buffer.array()));
+            buffer.release();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+        sender.sendMessage(message);
         return true;
     }
 }

--- a/src/main/java/net/glowstone/constants/GlowBlockEntity.java
+++ b/src/main/java/net/glowstone/constants/GlowBlockEntity.java
@@ -9,7 +9,10 @@ public enum GlowBlockEntity {
     BEACON(3),
     SKULL(4),
     FLOWER_POT(5),
-    BANNER(6);
+    BANNER(6),
+    STRUCTURE(7),
+    END_GATEWAY(8),
+    SIGN(9);
 
     private final int value;
 

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -327,10 +327,10 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
 
         switch (session.getVersion()) {
             case GlowServer.LEGACY_PROTOCOL_VERSION:
-                session.setProtocol(ProtocolType.PLAY_LEGACY);
+                session.setProtocol(ProtocolType.PLAY_107);
                 break;
             case GlowServer.COMPATIBLE_PROTOCOL_VERSION:
-                session.setProtocol(ProtocolType.PLAY_COMPATIBLE);
+                session.setProtocol(ProtocolType.PLAY_109);
                 break;
             default:
                 session.setProtocol(ProtocolType.PLAY);

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -326,10 +326,10 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
         session.send(new LoginSuccessMessage(profile.getUniqueId().toString(), profile.getName()));
 
         switch (session.getVersion()) {
-            case GlowServer.LEGACY_PROTOCOL_VERSION:
+            case GlowServer.LEGACY_PROTOCOL_1_9:
                 session.setProtocol(ProtocolType.PLAY_107);
                 break;
-            case GlowServer.COMPATIBLE_PROTOCOL_VERSION:
+            case GlowServer.LEGACY_PROTOCOL_1_9_2:
                 session.setProtocol(ProtocolType.PLAY_109);
                 break;
             default:
@@ -704,7 +704,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
 
         for (Key key : newChunks) {
             GlowChunk chunk = world.getChunkAt(key.getX(), key.getZ());
-            if (session.getVersion() == GlowServer.LEGACY_PROTOCOL_VERSION || session.getVersion() == GlowServer.COMPATIBLE_PROTOCOL_VERSION) {
+            if (session.getVersion() == GlowServer.LEGACY_PROTOCOL_1_9 || session.getVersion() == GlowServer.LEGACY_PROTOCOL_1_9_2) {
                 session.send(chunk.toMessage(skylight).toLegacy());
             } else {
                 session.send(chunk.toMessage(skylight));

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -13,6 +13,7 @@ import net.glowstone.GlowChunk.Key;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.ItemTable;
 import net.glowstone.block.blocktype.BlockBed;
+import net.glowstone.block.entity.TESign;
 import net.glowstone.block.entity.TileEntity;
 import net.glowstone.block.itemtype.ItemFood;
 import net.glowstone.block.itemtype.ItemType;
@@ -1992,12 +1993,18 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
      * @throws IllegalArgumentException if location is null
      * @throws IllegalArgumentException if lines is non-null and has a length less than 4
      */
-    public void sendSignChange(Location location, TextMessage[] lines) throws IllegalArgumentException {
+    public void sendSignChange(TESign sign, Location location, TextMessage[] lines) throws IllegalArgumentException {
         checkNotNull(location, "location cannot be null");
         checkNotNull(lines, "lines cannot be null");
         checkArgument(lines.length == 4, "lines.length must equal 4");
 
-        afterBlockChanges.add(new UpdateSignMessage(location.getBlockX(), location.getBlockY(), location.getBlockZ(), lines));
+        if (session.getProtocolType() == ProtocolType.PLAY) {
+            CompoundTag tag = new CompoundTag();
+            sign.saveNbt(tag);
+            afterBlockChanges.add(new UpdateBlockEntityMessage(location.getBlockX(), location.getBlockY(), location.getBlockZ(), GlowBlockEntity.SIGN.getValue(), tag));
+        } else {
+            afterBlockChanges.add(new UpdateSignMessage(location.getBlockX(), location.getBlockY(), location.getBlockZ(), lines));
+        }
     }
 
     /**

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -375,12 +375,14 @@ public final class GlowSession extends BasicSession {
     }
 
     public ProtocolType getProtocolType() {
-        if (version == GlowServer.PROTOCOL_VERSION)
-            return ProtocolType.PLAY;
-        if (version == GlowServer.LEGACY_PROTOCOL_VERSION)
-            return ProtocolType.PLAY_107;
-        if (version == GlowServer.COMPATIBLE_PROTOCOL_VERSION)
-            return ProtocolType.PLAY_109;
+        switch (version) {
+            case GlowServer.PROTOCOL_VERSION:
+                return ProtocolType.PLAY;
+            case GlowServer.LEGACY_PROTOCOL_VERSION:
+                return ProtocolType.PLAY_107;
+            case GlowServer.COMPATIBLE_PROTOCOL_VERSION:
+                return ProtocolType.PLAY_109;
+        }
         return null;
     }
 

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -378,9 +378,9 @@ public final class GlowSession extends BasicSession {
         switch (version) {
             case GlowServer.PROTOCOL_VERSION:
                 return ProtocolType.PLAY;
-            case GlowServer.LEGACY_PROTOCOL_VERSION:
+            case GlowServer.LEGACY_PROTOCOL_1_9:
                 return ProtocolType.PLAY_107;
-            case GlowServer.COMPATIBLE_PROTOCOL_VERSION:
+            case GlowServer.LEGACY_PROTOCOL_1_9_2:
                 return ProtocolType.PLAY_109;
         }
         return null;

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -374,6 +374,16 @@ public final class GlowSession extends BasicSession {
         send(new UserListItemMessage(Action.ADD_PLAYER, entries));
     }
 
+    public ProtocolType getProtocolType() {
+        if (version == GlowServer.PROTOCOL_VERSION)
+            return ProtocolType.PLAY;
+        if (version == GlowServer.LEGACY_PROTOCOL_VERSION)
+            return ProtocolType.PLAY_LEGACY;
+        if (version == GlowServer.COMPATIBLE_PROTOCOL_VERSION)
+            return ProtocolType.PLAY_COMPATIBLE;
+        return null;
+    }
+
     @Override
     public ChannelFuture sendWithFuture(Message message) {
         if (!isActive()) {

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -378,9 +378,9 @@ public final class GlowSession extends BasicSession {
         if (version == GlowServer.PROTOCOL_VERSION)
             return ProtocolType.PLAY;
         if (version == GlowServer.LEGACY_PROTOCOL_VERSION)
-            return ProtocolType.PLAY_LEGACY;
+            return ProtocolType.PLAY_107;
         if (version == GlowServer.COMPATIBLE_PROTOCOL_VERSION)
-            return ProtocolType.PLAY_COMPATIBLE;
+            return ProtocolType.PLAY_109;
         return null;
     }
 

--- a/src/main/java/net/glowstone/net/codec/play/game/ChunkDataCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/game/ChunkDataCodec.java
@@ -29,7 +29,7 @@ public final class ChunkDataCodec implements Codec<ChunkDataMessage> {
         } finally {
             data.release();
         }
-        buf.writeInt(message.getTileEntities().length);
+        ByteBufUtils.writeVarInt(buf, message.getTileEntities().length);
         for (CompoundTag tag : message.getTileEntities()) {
             GlowBufUtils.writeCompound(buf, tag);
         }

--- a/src/main/java/net/glowstone/net/codec/play/game/ChunkDataLegacyCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/game/ChunkDataLegacyCodec.java
@@ -3,21 +3,19 @@ package net.glowstone.net.codec.play.game;
 import com.flowpowered.network.Codec;
 import com.flowpowered.network.util.ByteBufUtils;
 import io.netty.buffer.ByteBuf;
-import net.glowstone.net.GlowBufUtils;
-import net.glowstone.net.message.play.game.ChunkDataMessage;
-import net.glowstone.util.nbt.CompoundTag;
+import net.glowstone.net.message.play.game.ChunkDataLegacyMessage;
 
 import java.io.IOException;
 
-public final class ChunkDataCodec implements Codec<ChunkDataMessage> {
+public final class ChunkDataLegacyCodec implements Codec<ChunkDataLegacyMessage> {
 
     @Override
-    public ChunkDataMessage decode(ByteBuf buffer) throws IOException {
-        throw new RuntimeException("Cannot decode ChunkDataMessage");
+    public ChunkDataLegacyMessage decode(ByteBuf buffer) throws IOException {
+        throw new RuntimeException("Cannot decode ChunkDataLegacyMessage");
     }
 
     @Override
-    public ByteBuf encode(ByteBuf buf, ChunkDataMessage message) throws IOException {
+    public ByteBuf encode(ByteBuf buf, ChunkDataLegacyMessage message) throws IOException {
         buf.writeInt(message.getX());
         buf.writeInt(message.getZ());
         buf.writeBoolean(message.isContinuous());
@@ -28,10 +26,6 @@ public final class ChunkDataCodec implements Codec<ChunkDataMessage> {
             buf.writeBytes(data);
         } finally {
             data.release();
-        }
-        buf.writeInt(message.getTileEntities().length);
-        for (CompoundTag tag : message.getTileEntities()) {
-            GlowBufUtils.writeCompound(buf, tag);
         }
         return buf;
     }

--- a/src/main/java/net/glowstone/net/handler/handshake/HandshakeHandler.java
+++ b/src/main/java/net/glowstone/net/handler/handshake/HandshakeHandler.java
@@ -49,7 +49,7 @@ public class HandshakeHandler implements MessageHandler<GlowSession, HandshakeMe
         session.setProtocol(protocol);
 
         if (protocol == ProtocolType.LOGIN) {
-            if ((message.getVersion() < GlowServer.LEGACY_PROTOCOL_VERSION) || (message.getVersion() == GlowServer.LEGACY_PROTOCOL_VERSION && !session.getServer().canSupportLegacyClients())) {
+            if ((message.getVersion() < GlowServer.LEGACY_PROTOCOL_1_9) || (message.getVersion() == GlowServer.LEGACY_PROTOCOL_1_9 && !session.getServer().canSupportLegacyClients())) {
                 session.disconnect("Outdated client! I'm running " + GlowServer.GAME_VERSION);
             } else if (message.getVersion() > GlowServer.PROTOCOL_VERSION) {
                 session.disconnect("Outdated server! I'm running " + GlowServer.GAME_VERSION);

--- a/src/main/java/net/glowstone/net/handler/handshake/HandshakeHandler.java
+++ b/src/main/java/net/glowstone/net/handler/handshake/HandshakeHandler.java
@@ -49,7 +49,7 @@ public class HandshakeHandler implements MessageHandler<GlowSession, HandshakeMe
         session.setProtocol(protocol);
 
         if (protocol == ProtocolType.LOGIN) {
-            if (message.getVersion() < 107) {
+            if ((message.getVersion() < GlowServer.LEGACY_PROTOCOL_VERSION) || (message.getVersion() == GlowServer.LEGACY_PROTOCOL_VERSION && !session.getServer().canSupportLegacyClients())) {
                 session.disconnect("Outdated client! I'm running " + GlowServer.GAME_VERSION);
             } else if (message.getVersion() > GlowServer.PROTOCOL_VERSION) {
                 session.disconnect("Outdated server! I'm running " + GlowServer.GAME_VERSION);

--- a/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
+++ b/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
@@ -42,8 +42,11 @@ public final class StatusRequestHandler implements MessageHandler<GlowSession, S
         JSONObject version = new JSONObject();
         version.put("name", "Glowstone++ " + GlowServer.GAME_VERSION);
         int protocolVersion = session.getVersion();
-        boolean compatible = protocolVersion == GlowServer.PROTOCOL_VERSION || protocolVersion == GlowServer.COMPATIBLE_PROTOCOL_VERSION || (protocolVersion == GlowServer.LEGACY_PROTOCOL_VERSION && server.canSupportLegacyClients());
-        if (!compatible) protocolVersion = GlowServer.PROTOCOL_VERSION;
+        boolean compatible = protocolVersion == GlowServer.PROTOCOL_VERSION
+                || protocolVersion == GlowServer.LEGACY_PROTOCOL_1_9_2
+                || (protocolVersion == GlowServer.LEGACY_PROTOCOL_1_9 && server.canSupportLegacyClients());
+        if (!compatible)
+            protocolVersion = GlowServer.PROTOCOL_VERSION;
         version.put("protocol", protocolVersion);
         json.put("version", version);
 

--- a/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
+++ b/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
@@ -42,7 +42,8 @@ public final class StatusRequestHandler implements MessageHandler<GlowSession, S
         JSONObject version = new JSONObject();
         version.put("name", "Glowstone++ " + GlowServer.GAME_VERSION);
         int protocolVersion = session.getVersion();
-        if (protocolVersion > 109 || protocolVersion < 107) protocolVersion = GlowServer.PROTOCOL_VERSION;
+        boolean compatible = protocolVersion == GlowServer.PROTOCOL_VERSION || protocolVersion == GlowServer.COMPATIBLE_PROTOCOL_VERSION || (protocolVersion == GlowServer.LEGACY_PROTOCOL_VERSION && server.canSupportLegacyClients());
+        if (!compatible) protocolVersion = GlowServer.PROTOCOL_VERSION;
         version.put("protocol", protocolVersion);
         json.put("version", version);
 

--- a/src/main/java/net/glowstone/net/message/play/game/ChunkDataLegacyMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/game/ChunkDataLegacyMessage.java
@@ -1,0 +1,15 @@
+package net.glowstone.net.message.play.game;
+
+import com.flowpowered.network.Message;
+import io.netty.buffer.ByteBuf;
+import lombok.Data;
+
+@Data
+public class ChunkDataLegacyMessage implements Message {
+
+    private final int x, z;
+    private final boolean continuous;
+    private final int primaryMask;
+    private final ByteBuf data;
+
+}

--- a/src/main/java/net/glowstone/net/message/play/game/ChunkDataMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/game/ChunkDataMessage.java
@@ -3,13 +3,20 @@ package net.glowstone.net.message.play.game;
 import com.flowpowered.network.Message;
 import io.netty.buffer.ByteBuf;
 import lombok.Data;
+import net.glowstone.util.nbt.CompoundTag;
 
 @Data
-public final class ChunkDataMessage implements Message {
+public final class ChunkDataMessage extends ChunkDataLegacyMessage implements Message {
 
-    private final int x, z;
-    private final boolean continuous;
-    private final int primaryMask;
-    private final ByteBuf data;
+    private final CompoundTag[] tileEntities;
+
+    public ChunkDataMessage(int x, int z, boolean continuous, int primaryMask, ByteBuf data, CompoundTag[] tileEntities) {
+        super(x, z, continuous, primaryMask, data);
+        this.tileEntities = tileEntities;
+    }
+
+    public ChunkDataLegacyMessage toLegacy() {
+        return new ChunkDataLegacyMessage(getX(), getZ(), isContinuous(), getPrimaryMask(), getData());
+    }
 
 }

--- a/src/main/java/net/glowstone/net/protocol/AbstractPlayProtocol.java
+++ b/src/main/java/net/glowstone/net/protocol/AbstractPlayProtocol.java
@@ -145,9 +145,9 @@ public abstract class AbstractPlayProtocol extends GlowProtocol {
     }
 
     // 1.9.2
-    public static final class PlayCompatibleProtocol extends AbstractPlayProtocol {
-        public PlayCompatibleProtocol() {
-            super("PLAY_COMPATIBLE", 0x4C);
+    public static final class Play109Protocol extends AbstractPlayProtocol {
+        public Play109Protocol() {
+            super("PLAY_109", 0x4C);
             outbound(0x20, ChunkDataLegacyMessage.class, ChunkDataLegacyCodec.class);
             outbound(0x23, JoinGameMessage.class, JoinGameCodec.class);
             outbound(0x46, UpdateSignMessage.class, UpdateSignCodec.class);
@@ -161,9 +161,9 @@ public abstract class AbstractPlayProtocol extends GlowProtocol {
     }
 
     // 1.9
-    public static final class PlayLegacyProtocol extends AbstractPlayProtocol {
-        public PlayLegacyProtocol() {
-            super("PLAY_LEGACY", 0x4C);
+    public static final class Play107Protocol extends AbstractPlayProtocol {
+        public Play107Protocol() {
+            super("PLAY_107", 0x4C);
             outbound(0x20, ChunkDataLegacyMessage.class, ChunkDataLegacyCodec.class);
             outbound(0x23, JoinGameMessage.class, JoinGameLegacyCodec.class);
             outbound(0x46, UpdateSignMessage.class, UpdateSignCodec.class);

--- a/src/main/java/net/glowstone/net/protocol/AbstractPlayProtocol.java
+++ b/src/main/java/net/glowstone/net/protocol/AbstractPlayProtocol.java
@@ -23,8 +23,8 @@ import net.glowstone.net.message.play.scoreboard.ScoreboardScoreMessage;
 import net.glowstone.net.message.play.scoreboard.ScoreboardTeamMessage;
 
 public abstract class AbstractPlayProtocol extends GlowProtocol {
-    private AbstractPlayProtocol() {
-        super("PLAY", 0x4C);
+    private AbstractPlayProtocol(String name, int max) {
+        super(name, max);
 
         inbound(0x00, TeleportConfirmMessage.class, TeleportConfirmCodec.class, TeleportConfirmHandler.class);
         inbound(0x01, TabCompleteMessage.class, TabCompleteCodec.class, TabCompleteHandler.class);
@@ -89,7 +89,6 @@ public abstract class AbstractPlayProtocol extends GlowProtocol {
         outbound(0x1D, UnloadChunkMessage.class, UnloadChunkCodec.class);
         outbound(0x1E, StateChangeMessage.class, StateChangeCodec.class);
         outbound(0x1F, PingMessage.class, PingCodec.class);
-        outbound(0x20, ChunkDataMessage.class, ChunkDataCodec.class);
         outbound(0x21, PlayEffectMessage.class, PlayEffectCodec.class);
         outbound(0x22, PlayParticleMessage.class, PlayParticleCodec.class);
         // join bellow
@@ -127,27 +126,53 @@ public abstract class AbstractPlayProtocol extends GlowProtocol {
         outbound(0x43, SpawnPositionMessage.class, SpawnPositionCodec.class);
         outbound(0x44, TimeMessage.class, TimeCodec.class);
         outbound(0x45, TitleMessage.class, TitleCodec.class);
-        outbound(0x46, UpdateSignMessage.class, UpdateSignCodec.class);
-        outbound(0x47, SoundEffectMessage.class, SoundEffectCodec.class);
-        outbound(0x48, UserListHeaderFooterMessage.class, UserListHeaderFooterCodec.class);
-        outbound(0x49, CollectItemMessage.class, CollectItemCodec.class);
-        outbound(0x4A, EntityTeleportMessage.class, EntityTeleportCodec.class);
-        outbound(0x4B, EntityPropertyMessage.class, EntityPropertyCodec.class);
-        outbound(0x4C, EntityEffectMessage.class, EntityEffectCodec.class);
 
     }
 
+    // 1.9.4
     public static final class PlayProtocol extends AbstractPlayProtocol {
         public PlayProtocol() {
-            super();
+            super("PLAY", 0x4B);
+            outbound(0x20, ChunkDataMessage.class, ChunkDataCodec.class);
             outbound(0x23, JoinGameMessage.class, JoinGameCodec.class);
+            outbound(0x46, SoundEffectMessage.class, SoundEffectCodec.class);
+            outbound(0x47, UserListHeaderFooterMessage.class, UserListHeaderFooterCodec.class);
+            outbound(0x48, CollectItemMessage.class, CollectItemCodec.class);
+            outbound(0x49, EntityTeleportMessage.class, EntityTeleportCodec.class);
+            outbound(0x4A, EntityPropertyMessage.class, EntityPropertyCodec.class);
+            outbound(0x4B, EntityEffectMessage.class, EntityEffectCodec.class);
         }
     }
 
+    // 1.9.2
+    public static final class PlayCompatibleProtocol extends AbstractPlayProtocol {
+        public PlayCompatibleProtocol() {
+            super("PLAY_COMPATIBLE", 0x4C);
+            outbound(0x20, ChunkDataLegacyMessage.class, ChunkDataLegacyCodec.class);
+            outbound(0x23, JoinGameMessage.class, JoinGameCodec.class);
+            outbound(0x46, UpdateSignMessage.class, UpdateSignCodec.class);
+            outbound(0x47, SoundEffectMessage.class, SoundEffectCodec.class);
+            outbound(0x48, UserListHeaderFooterMessage.class, UserListHeaderFooterCodec.class);
+            outbound(0x49, CollectItemMessage.class, CollectItemCodec.class);
+            outbound(0x4A, EntityTeleportMessage.class, EntityTeleportCodec.class);
+            outbound(0x4B, EntityPropertyMessage.class, EntityPropertyCodec.class);
+            outbound(0x4C, EntityEffectMessage.class, EntityEffectCodec.class);
+        }
+    }
+
+    // 1.9
     public static final class PlayLegacyProtocol extends AbstractPlayProtocol {
         public PlayLegacyProtocol() {
-            super();
+            super("PLAY_LEGACY", 0x4C);
+            outbound(0x20, ChunkDataLegacyMessage.class, ChunkDataLegacyCodec.class);
             outbound(0x23, JoinGameMessage.class, JoinGameLegacyCodec.class);
+            outbound(0x46, UpdateSignMessage.class, UpdateSignCodec.class);
+            outbound(0x47, SoundEffectMessage.class, SoundEffectCodec.class);
+            outbound(0x48, UserListHeaderFooterMessage.class, UserListHeaderFooterCodec.class);
+            outbound(0x49, CollectItemMessage.class, CollectItemCodec.class);
+            outbound(0x4A, EntityTeleportMessage.class, EntityTeleportCodec.class);
+            outbound(0x4B, EntityPropertyMessage.class, EntityPropertyCodec.class);
+            outbound(0x4C, EntityEffectMessage.class, EntityEffectCodec.class);
         }
     }
 }

--- a/src/main/java/net/glowstone/net/protocol/ProtocolType.java
+++ b/src/main/java/net/glowstone/net/protocol/ProtocolType.java
@@ -8,8 +8,8 @@ public enum ProtocolType {
     STATUS(new StatusProtocol()),
     LOGIN(new LoginProtocol()),
     PLAY(new AbstractPlayProtocol.PlayProtocol()),
-    PLAY_COMPATIBLE(new AbstractPlayProtocol.PlayCompatibleProtocol()),
-    PLAY_LEGACY(new AbstractPlayProtocol.PlayLegacyProtocol());
+    PLAY_109(new AbstractPlayProtocol.Play109Protocol()),
+    PLAY_107(new AbstractPlayProtocol.Play107Protocol());
 
     private final GlowProtocol protocol;
 

--- a/src/main/java/net/glowstone/net/protocol/ProtocolType.java
+++ b/src/main/java/net/glowstone/net/protocol/ProtocolType.java
@@ -8,6 +8,7 @@ public enum ProtocolType {
     STATUS(new StatusProtocol()),
     LOGIN(new LoginProtocol()),
     PLAY(new AbstractPlayProtocol.PlayProtocol()),
+    PLAY_COMPATIBLE(new AbstractPlayProtocol.PlayCompatibleProtocol()),
     PLAY_LEGACY(new AbstractPlayProtocol.PlayLegacyProtocol());
 
     private final GlowProtocol protocol;

--- a/src/main/java/net/glowstone/util/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/ServerConfig.java
@@ -331,6 +331,7 @@ public final class ServerConfig {
         WHITELIST("server.whitelisted", false, Migrate.PROPS, "white-list"),
         MOTD("server.motd", "Glowstone++ server", Migrate.PROPS, "motd"),
         SHUTDOWN_MESSAGE("server.shutdown-message", "Server shutting down.", Migrate.BUKKIT, "settings.shutdown-message"),
+        ALLOW_LEGACY_CLIENTS("server.allow-legacy-clients", false),
 
         // console
         USE_JLINE("console.use-jline", true),

--- a/src/main/java/net/glowstone/util/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/ServerConfig.java
@@ -331,7 +331,7 @@ public final class ServerConfig {
         WHITELIST("server.whitelisted", false, Migrate.PROPS, "white-list"),
         MOTD("server.motd", "Glowstone++ server", Migrate.PROPS, "motd"),
         SHUTDOWN_MESSAGE("server.shutdown-message", "Server shutting down.", Migrate.BUKKIT, "settings.shutdown-message"),
-        ALLOW_LEGACY_CLIENTS("server.allow-legacy-clients", false),
+        ALLOW_LEGACY_CLIENTS("server.allow-legacy-clients", true),
 
         // console
         USE_JLINE("console.use-jline", true),


### PR DESCRIPTION
Adds compatibility with 1.9.X clients (1.9-1.9.4), as well as the new `/stopsound` command for 1.9.4 clients.

Changes made:
- Added new protocol: Compatible_Play
  - 1.9 protocol is `PLAY_107`, can be turned off in glowstone.yml
  - 1.9.2-3 protocol is `PLAY_109`
  - 1.9.4 protocol is `PLAY`
  - Protocol changes [here](http://wiki.vg/Protocol_History#1.9.3-pre2)
- `/stopsound` command, only works on 1.9.4 clients
- `allow-legacy-clients` glowstone.yml entry to enable/disable 1.9 clients to connect

Glowkit PR for version change: [18](https://github.com/GlowstonePlusPlus/Glowkit/pull/18)
