### PR TITLE
Save player achievements and stats in stats/ directory.

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -22,6 +22,7 @@ import net.glowstone.inventory.GlowInventory;
 import net.glowstone.inventory.GlowItemFactory;
 import net.glowstone.inventory.crafting.CraftingManager;
 import net.glowstone.io.PlayerDataService;
+import net.glowstone.io.PlayerStatisticIoService;
 import net.glowstone.io.ScoreboardIoService;
 import net.glowstone.map.GlowMapView;
 import net.glowstone.net.GlowNetworkServer;
@@ -969,6 +970,15 @@ public final class GlowServer implements Server {
      */
     public ScoreboardIoService getScoreboardIoService() {
         return worlds.getWorlds().get(0).getStorage().getScoreboardIoService();
+    }
+
+    /**
+     * Returns the player statitics I/O service attached to the first world.
+     *
+     * @return the server's statistics I/O service
+     */
+    public PlayerStatisticIoService getPlayerStatisticIoService() {
+        return worlds.getWorlds().get(0).getStorage().getPlayerStatisticIoService();
     }
 
     /**

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -144,7 +144,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
     /**
      * The player's statistics, achievements, and related data.
      */
-    private StatisticMap stats = new StatisticMap();
+    private final StatisticMap stats = new StatisticMap();
 
     /**
      * Whether the player has played before (will be false on first join).

--- a/src/main/java/net/glowstone/io/PlayerStatisticIoService.java
+++ b/src/main/java/net/glowstone/io/PlayerStatisticIoService.java
@@ -1,0 +1,80 @@
+package net.glowstone.io;
+
+import net.glowstone.GlowServer;
+import net.glowstone.entity.GlowPlayer;
+import net.glowstone.util.StatisticMap;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.UUID;
+
+public class PlayerStatisticIoService {
+
+    private GlowServer server;
+    private File statsDir;
+
+    public PlayerStatisticIoService(GlowServer server, File statsDir) {
+        this.server = server;
+        this.statsDir = statsDir;
+    }
+
+    /**
+     * Gets the statistics file for the given UUID
+     *
+     * @param uuid the UUID of the player
+     * @return the stasticics file of the given UUID
+     */
+    private File getPlayerFile(UUID uuid) {
+        if (!statsDir.isDirectory() && !statsDir.mkdirs()) {
+            server.getLogger().warning("Failed to create directory: " + statsDir);
+        }
+        return new File(statsDir, uuid + ".json");
+    }
+
+    /**
+     * Reads the stats of a player from its statistics file and writes the values to the StatisticMap.
+     *
+     * @param player the player to read the statistics from
+     */
+    public void readStats(GlowPlayer player) {
+        File statsFile = getPlayerFile(player.getUniqueId());
+        player.getStatisticMap().getValues().clear();
+        if (statsFile.exists()) {
+            try {
+                JSONParser parser = new JSONParser();
+                JSONObject json = (JSONObject) parser.parse(new FileReader(statsFile));
+                for (Object o : json.keySet()) {
+                    String key = (String) o;
+                    int value = (int) (long) json.get(o);
+                    player.getStatisticMap().getValues().put(key, value);
+                }
+            } catch (ParseException | IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Writes the statistics of the player into its statistics file.
+     *
+     * @param player the player to write the statistics file from
+     */
+    public void writeStats(GlowPlayer player) {
+        File file = getPlayerFile(player.getUniqueId());
+        StatisticMap map = player.getStatisticMap();
+        JSONObject json = new JSONObject(map.getValues());
+        try {
+            FileWriter writer = new FileWriter(file, false);
+            writer.write(json.toJSONString());
+            writer.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/net/glowstone/io/PlayerStatisticIoService.java
+++ b/src/main/java/net/glowstone/io/PlayerStatisticIoService.java
@@ -50,7 +50,7 @@ public class PlayerStatisticIoService {
                 JSONObject json = (JSONObject) parser.parse(new FileReader(statsFile));
                 for (Object o : json.keySet()) {
                     String key = (String) o;
-                    int value = (int) (long) json.get(o);
+                    int value = ((Long) json.get(o)).intValue();
                     player.getStatisticMap().getValues().put(key, value);
                 }
             } catch (ParseException | IOException e) {

--- a/src/main/java/net/glowstone/io/WorldStorageProvider.java
+++ b/src/main/java/net/glowstone/io/WorldStorageProvider.java
@@ -51,4 +51,6 @@ public interface WorldStorageProvider {
     StructureDataService getStructureDataService();
 
     ScoreboardIoService getScoreboardIoService();
+
+    PlayerStatisticIoService getPlayerStatisticIoService();
 }

--- a/src/main/java/net/glowstone/io/anvil/AnvilWorldStorageProvider.java
+++ b/src/main/java/net/glowstone/io/anvil/AnvilWorldStorageProvider.java
@@ -21,6 +21,7 @@ public class AnvilWorldStorageProvider implements WorldStorageProvider {
     private StructureDataService structures;
     private PlayerDataService players;
     private ScoreboardIoService scoreboard;
+    private PlayerStatisticIoService statitic;
 
     public AnvilWorldStorageProvider(File dir) {
         this.dir = dir;
@@ -70,5 +71,13 @@ public class AnvilWorldStorageProvider implements WorldStorageProvider {
             scoreboard = new NbtScoreboardIoService(world.getServer(), new File(dir, "data"));
         }
         return scoreboard;
+    }
+
+    @Override
+    public PlayerStatisticIoService getPlayerStatisticIoService() {
+        if (statitic == null) {
+            statitic = new PlayerStatisticIoService(world.getServer(), new File(dir, "stats"));
+        }
+        return statitic;
     }
 }

--- a/src/main/java/net/glowstone/util/StatisticMap.java
+++ b/src/main/java/net/glowstone/util/StatisticMap.java
@@ -107,4 +107,8 @@ public final class StatisticMap {
         String name = name(stat, entityType);
         setValue(name, getValue(name) + modify);
     }
+
+    public Map<String, Integer> getValues() {
+        return values;
+    }
 }


### PR DESCRIPTION
Resolves issue #275.

StatisticMaps (from GlowPlayer) will now be saved when needed to the appropriate stats/ directory, as well as read when the player is loaded.
