### PR TITLE
Add (very) basic support for off-hand, in order to fix 276.

### DIFF
--- a/src/main/java/net/glowstone/inventory/GlowPlayerInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowPlayerInventory.java
@@ -18,12 +18,13 @@ import org.bukkit.inventory.*;
  */
 public class GlowPlayerInventory extends GlowInventory implements PlayerInventory, EntityEquipment {
 
-    private static final int SIZE = 36;
+    private static final int SIZE = 37;
 
-    private static final int BOOTS_SLOT = 36;
-    private static final int LEGGINGS_SLOT = 37;
-    private static final int CHESTPLATE_SLOT = 38;
-    private static final int HELMET_SLOT = 39;
+    private static final int OFF_HAND_SLOT = 36;
+    private static final int BOOTS_SLOT = 37;
+    private static final int LEGGINGS_SLOT = 38;
+    private static final int CHESTPLATE_SLOT = 39;
+    private static final int HELMET_SLOT = 40;
 
     /**
      * The armor contents.
@@ -273,22 +274,22 @@ public class GlowPlayerInventory extends GlowInventory implements PlayerInventor
 
     @Override
     public ItemStack getItemInMainHand() {
-        return null;
+        return getItemInHand();
     }
 
     @Override
     public void setItemInMainHand(ItemStack itemStack) {
-
+        setItemInHand(itemStack);
     }
 
     @Override
     public ItemStack getItemInOffHand() {
-        return null;
+        return getItem(OFF_HAND_SLOT);
     }
 
     @Override
     public void setItemInOffHand(ItemStack itemStack) {
-
+        setItem(OFF_HAND_SLOT, itemStack);
     }
 
     @Override

--- a/src/test/java/net/glowstone/inventory/PlayerInventoryTest.java
+++ b/src/test/java/net/glowstone/inventory/PlayerInventoryTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class PlayerInventoryTest {
 
-    private static final int SIZE = 36;
+    private static final int SIZE = 37;
 
     private static final ItemStack TEST_BOOTS = new ItemStack(Material.DIAMOND_BOOTS);
     private static final ItemStack TEST_LEGGINGS = null;


### PR DESCRIPTION
Fixes #276.

Basically the problem was that using the Destroy Item with shift-click to clear all items would loop through all slots; 1 through 45. Before this fix, Bukkit would see the size as 46 (correctly), but G++ only supported up to 44.

When shift-clicking on the Destroy Item button, the client sends the following packets:

```
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=0, item=null) - 0
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=1, item=null) - 1
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=2, item=null) - 2
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=3, item=null) - 3
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=4, item=null) - 4
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=5, item=null) - 5
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=6, item=null) - 6
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=7, item=null) - 7
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=8, item=null) - 8
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=9, item=null) - 9
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=10, item=null) - 10
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=11, item=null) - 11
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=12, item=null) - 12
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=13, item=null) - 13
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=14, item=null) - 14
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=15, item=null) - 15
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=16, item=null) - 16
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=17, item=null) - 17
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=18, item=null) - 18
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=19, item=null) - 19
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=20, item=null) - 20
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=21, item=null) - 21
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=22, item=null) - 22
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=23, item=null) - 23
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=24, item=null) - 24
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=25, item=null) - 25
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=26, item=null) - 26
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=27, item=null) - 27
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=28, item=null) - 28
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=29, item=null) - 29
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=30, item=null) - 30
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=31, item=null) - 31
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=32, item=null) - 32
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=33, item=null) - 33
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=34, item=null) - 34
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=35, item=null) - 35
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=36, item=null) - 36
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=37, item=null) - 37
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=38, item=null) - 38
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=39, item=null) - 39
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=40, item=null) - 40
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=41, item=null) - 41
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=42, item=null) - 42
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=43, item=null) - 43
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=44, item=null) - 44
2016/05/30 19:46:48 [INFO] CreativeItemMessage(slot=45, item=null) - 45   <----- Glowstone++ failed to set slot 45 to empty, since 45 wasn't supported.
```
