### PR TITLE
Add "Potion" NBT Item entry for potions/tipped arrows, fixes issue 280

### DIFF
--- a/src/main/java/net/glowstone/inventory/GlowItemFactory.java
+++ b/src/main/java/net/glowstone/inventory/GlowItemFactory.java
@@ -129,15 +129,12 @@ public final class GlowItemFactory implements ItemFactory {
             case FIREWORK_CHARGE:
                 return new GlowMetaFireworkEffect(meta);
             case POTION:
-                return new GlowMetaPotion(meta);
             case SPLASH_POTION:
-                return new GlowMetaPotion(meta);
             case LINGERING_POTION:
+            case TIPPED_ARROW:
                 return new GlowMetaPotion(meta);
             case MONSTER_EGG:
                 return new GlowMetaSpawn(meta);
-            case TIPPED_ARROW:
-                return new GlowMetaPotion(meta);
             default:
                 return new GlowMetaItem(meta);
         }

--- a/src/main/java/net/glowstone/inventory/GlowItemFactory.java
+++ b/src/main/java/net/glowstone/inventory/GlowItemFactory.java
@@ -130,8 +130,14 @@ public final class GlowItemFactory implements ItemFactory {
                 return new GlowMetaFireworkEffect(meta);
             case POTION:
                 return new GlowMetaPotion(meta);
+            case SPLASH_POTION:
+                return new GlowMetaPotion(meta);
+            case LINGERING_POTION:
+                return new GlowMetaPotion(meta);
             case MONSTER_EGG:
                 return new GlowMetaSpawn(meta);
+            case TIPPED_ARROW:
+                return new GlowMetaPotion(meta);
             default:
                 return new GlowMetaItem(meta);
         }


### PR DESCRIPTION
Adds the `Potion` 1.9 NBT meta for potions, which includes `POTION`, `SPLASH_POTION`, `LINGERING_POTION`, `TIPPED_ARROW`.

Fixes issue #280.
