### PR TITLE
[WIP] Added new requestSinglePulse in GlowWorld

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockFire.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockFire.java
@@ -24,7 +24,7 @@ public class BlockFire extends BlockNeedsAttached {
 
     private static final BlockFace[] FLAMMABLE_FACES = {BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN};
     private static final BlockFace[] RAIN_FACES = {BlockFace.SELF, BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST};
-    private static final int TICK_RATE = 1;
+    private static final int TICK_RATE = 20;
     private static final int MAX_FIRE_AGE = 15;
     private static final LinkedHashMap<BlockFace, Integer> BURNRESISTANCE_MAP = new LinkedHashMap<>();
 
@@ -43,6 +43,11 @@ public class BlockFire extends BlockNeedsAttached {
     }
 
     @Override
+    public void onBlockChanged(GlowBlock block, Material oldType, byte oldData, Material newType, byte data) {
+        block.getWorld().requestSinglePulse(block, TICK_RATE);
+    }
+
+    @Override
     public boolean canOverride(GlowBlock block, BlockFace face, ItemStack holding) {
         return true;
     }
@@ -51,6 +56,7 @@ public class BlockFire extends BlockNeedsAttached {
     public void placeBlock(GlowPlayer player, GlowBlockState state, BlockFace face, ItemStack holding, Vector clickedLoc) {
         super.placeBlock(player, state, face, holding, clickedLoc);
         state.setRawData((byte) 0);
+        updateBlock(state.getBlock());
     }
 
     @Override
@@ -81,11 +87,23 @@ public class BlockFire extends BlockNeedsAttached {
 
         GlowWorld world = block.getWorld();
         Material type = block.getRelative(BlockFace.DOWN).getType();
-        boolean isInfiniteFire = type == Material.NETHERRACK || world.getEnvironment() == Environment.THE_END && type == Material.BEDROCK;
+        boolean isInfiniteFire;
+        switch (type) {
+            case NETHERRACK:
+                isInfiniteFire = true;
+                break;
+            case BEDROCK:
+                if (world.getEnvironment() == Environment.THE_END) {
+                    isInfiniteFire = true;
+                    break;
+                }
+            default:
+                isInfiniteFire = false;
+                break;
+        }
         if (!isInfiniteFire && world.hasStorm() && isRainingAround(block)) {
             // if it's raining around, stop fire
             block.breakNaturally();
-            world.cancelPulse(block);
             return;
         }
 
@@ -98,21 +116,19 @@ public class BlockFire extends BlockNeedsAttached {
             state.update(true);
         }
 
-        // request pulse for this block
-        world.requestPulse(block, TICK_RATE);
-
         if (!isInfiniteFire) {
             if (!hasNearFlammableBlock(block)) {
-                // there's no flammable blocks around, stop fire
-                if (age > 3 || block.getRelative(BlockFace.DOWN).isEmpty()) {
+                if (block.getRelative(BlockFace.DOWN).isEmpty() || age > 3) {
+                    // no nearby flammable blocks and nothing below it
                     block.breakNaturally();
-                    world.cancelPulse(block);
+                } else {
+                    world.requestSinglePulse(block, TICK_RATE);
                 }
             } else if (age == MAX_FIRE_AGE && !block.getRelative(BlockFace.DOWN).isFlammable() && random.nextInt(4) == 0) {
                 // if fire reached max age, bottom block is not flammable, 25% chance to stop fire
                 block.breakNaturally();
-                world.cancelPulse(block);
             } else {
+                world.requestSinglePulse(block, TICK_RATE);
                 // fire propagation / block burning
 
                 // burn blocks around
@@ -122,23 +138,36 @@ public class BlockFire extends BlockNeedsAttached {
                 }
 
                 Difficulty difficulty = world.getDifficulty();
-                int difficultyModifier = difficulty == Difficulty.EASY ? 7 : difficulty == Difficulty.NORMAL ? 14 : difficulty == Difficulty.HARD ? 21 : 0;
+                int difficultyModifier;
+                switch (difficulty) {
+                    case EASY:
+                        difficultyModifier = 7;
+                        break;
+                    case NORMAL:
+                        difficultyModifier = 14;
+                        break;
+                    case HARD:
+                        difficultyModifier = 21;
+                        break;
+                    default:
+                        difficultyModifier = 0;
+                        break;
+                }
 
                 // try to propagate fire in a 3x3x6 box
-                for (int x = 0; x < 3; x++) {
-                    for (int z = 0; z < 3; z++) {
-                        for (int y = 0; y < 6; y++) {
-                            if (x != 1 || z != 1 || y != 1) {
-                                GlowBlock propagationBlock = world.getBlockAt(block.getLocation().add(x - 1, y - 1, z - 1));
-                                int flameResistance = propagationBlock.getMaterialValues().getFlameResistance();
-                                if (flameResistance >= 0) {
-                                    int resistance = 40 + difficultyModifier + flameResistance;
-                                    resistance /= 30 + age;
+                for (int x = -1; x <= 1; x++) {
+                    for (int z = -1; z <= 1; z++) {
+                        for (int y = -1; y <= 4; y++) {
+                            if (x != 0 || z != 0 || y != 0) {
+                                GlowBlock propagationBlock = world.getBlockAt(block.getLocation().add(x, y, z));
+                                int flameResistance = getFlameResistance(propagationBlock);
+                                if (flameResistance > 0) {
+                                    int resistance = (40 + difficultyModifier + flameResistance) / (30 + age);
                                     if (isWet) {
                                         resistance /= 2;
                                     }
                                     if ((!world.hasStorm() || !isRainingAround(propagationBlock))
-                                            && resistance > 0 && random.nextInt(y > 2 ? 100 + 100 * (y - 2) : 100) <= resistance) {
+                                            && resistance > 0 && random.nextInt(y > 1 ? 100 + 100 * (y - 1) : 100) <= resistance) {
                                         BlockIgniteEvent igniteEvent = new BlockIgniteEvent(propagationBlock, IgniteCause.SPREAD, block);
                                         EventFactory.callEvent(igniteEvent);
                                         if (!igniteEvent.isCancelled()) {
@@ -175,6 +204,18 @@ public class BlockFire extends BlockNeedsAttached {
             }
         }
         return false;
+    }
+
+    private int getFlameResistance(GlowBlock block) {
+        if (!block.isEmpty()) {
+            return 0;
+        } else {
+            int flameResistance = 0;
+            for (BlockFace face : FLAMMABLE_FACES) {
+                flameResistance = Math.max(flameResistance, block.getRelative(face).getMaterialValues().getFlameResistance());
+            }
+            return flameResistance;
+        }
     }
 
     private boolean isRainingAround(GlowBlock block) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockLiquid.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLiquid.java
@@ -92,7 +92,7 @@ public abstract class BlockLiquid extends BlockType {
         // 0 = Full liquid block
         state.setType(getMaterial());
         state.setRawData((byte) 0);
-        state.getBlock().getWorld().requestSinglePulse(state.getBlock(), 0);
+        state.getBlock().getWorld().requestSinglePulse(state.getBlock(), isWater(state.getType()) || state.getBlock().getBiome() == Biome.HELL ? TICK_RATE_WATER : TICK_RATE_LAVA);
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/blocktype/BlockLiquid.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLiquid.java
@@ -92,7 +92,7 @@ public abstract class BlockLiquid extends BlockType {
         // 0 = Full liquid block
         state.setType(getMaterial());
         state.setRawData((byte) 0);
-        state.getBlock().getWorld().requestPulse(state.getBlock(), isWater(state.getBlock().getType()) || state.getBlock().getBiome() == Biome.HELL ? TICK_RATE_WATER : TICK_RATE_LAVA);
+        state.getBlock().getWorld().requestSinglePulse(state.getBlock(), 0);
     }
 
     @Override
@@ -100,7 +100,7 @@ public abstract class BlockLiquid extends BlockType {
         if (block.getState().getFlowed() && !(isWater(newType) || newType == Material.LAVA || newType == Material.STATIONARY_LAVA)) {
             block.getState().setFlowed(false);
         }
-        block.getWorld().requestPulse(block, isWater(block.getType()) || block.getBiome() == Biome.HELL ? TICK_RATE_WATER : TICK_RATE_LAVA);
+        block.getWorld().requestSinglePulse(block, isWater(block.getType()) || block.getBiome() == Biome.HELL ? TICK_RATE_WATER : TICK_RATE_LAVA);
     }
 
     /**
@@ -188,7 +188,7 @@ public abstract class BlockLiquid extends BlockType {
         }
         // flow to the target
         ((GlowBlock) fromToEvent.getToBlock()).setType(fromToEvent.getBlock().getType(), strength, true);
-        ((GlowWorld) fromToEvent.getToBlock().getWorld()).requestPulse(((GlowBlock) fromToEvent.getToBlock()), isWater(fromToEvent.getToBlock().getType()) || fromToEvent.getToBlock().getBiome() == Biome.HELL ? TICK_RATE_WATER : TICK_RATE_LAVA);
+        ((GlowWorld) fromToEvent.getToBlock().getWorld()).requestSinglePulse(((GlowBlock) fromToEvent.getToBlock()), isWater(fromToEvent.getToBlock().getType()) || fromToEvent.getToBlock().getBiome() == Biome.HELL ? TICK_RATE_WATER : TICK_RATE_LAVA);
     }
 
     private void mix(GlowBlock target, BlockFace direction, Material flowingMaterial, Material targetMaterial) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstone.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstone.java
@@ -233,7 +233,7 @@ public class BlockRedstone extends BlockNeedsAttached {
         if (power != me.getData()) {
             me.setData(power);
             extraUpdate(me);
-            me.getWorld().requestPulse(me, 1);
+            me.getWorld().requestSinglePulse(me, 1);
         }
     }
 

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneTorch.java
@@ -55,7 +55,7 @@ public class BlockRedstoneTorch extends BlockNeedsAttached {
     @Override
     public void updatePhysics(GlowBlock me) {
         super.updatePhysics(me);
-        me.getWorld().requestPulse(me, 2);
+        me.getWorld().requestSinglePulse(me, 2);
     }
 
     @Override
@@ -85,8 +85,6 @@ public class BlockRedstoneTorch extends BlockNeedsAttached {
                 return;
             }
         }
-
-        me.getWorld().cancelPulse(me);
     }
 
     private void extraUpdate(GlowBlock block) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -218,8 +218,7 @@ public class BlockType extends ItemType {
      * @param block The block that was pulsed pulsed
      */
     public void receivePulse(GlowBlock block) {
-        // Cancel if pulse sent to empty block data (caused when updated and not removed).
-        block.getWorld().cancelPulse(block);
+
     }
 
     /**

--- a/src/main/java/net/glowstone/block/entity/TEFurnace.java
+++ b/src/main/java/net/glowstone/block/entity/TEFurnace.java
@@ -121,7 +121,7 @@ public class TEFurnace extends TEContainer {
                 FurnaceSmeltEvent smeltEvent = new FurnaceSmeltEvent(block, inv.getSmelting(), recipe.getResult());
                 EventFactory.callEvent(smeltEvent);
                 if (!smeltEvent.isCancelled()) {
-                    if (inv.getSmelting().getType().equals(Material.SPONGE) && inv.getSmelting().getData().getData() == 1 && inv.getFuel().getType().equals(Material.BUCKET) && inv.getFuel().getAmount() == 1) {
+                    if (inv.getSmelting().getType().equals(Material.SPONGE) && inv.getSmelting().getData().getData() == 1 && inv.getFuel() != null && inv.getFuel().getType().equals(Material.BUCKET) && inv.getFuel().getAmount() == 1) {
                         inv.setFuel(new ItemStack(Material.WATER_BUCKET));
                     }
                     if (inv.getResult() == null || inv.getResult().getType().equals(Material.AIR)) {
@@ -144,8 +144,8 @@ public class TEFurnace extends TEContainer {
             human.setWindowProperty(Property.COOK_TIME, cookTime);
             human.setWindowProperty(Property.TICKS_FOR_CURRENT_SMELTING, 200);
         });
-        if (!isBurnable && burnTime == 0 && cookTime == 0) {
-            getState().getBlock().getWorld().requestPulse(getState().getBlock(), 0);
+        if (!(!isBurnable && burnTime == 0 && cookTime == 0)) {
+            getState().getBlock().getWorld().requestSinglePulse(getState().getBlock(), 1);
         }
     }
 

--- a/src/main/java/net/glowstone/generator/decorators/nether/LavaDecorator.java
+++ b/src/main/java/net/glowstone/generator/decorators/nether/LavaDecorator.java
@@ -52,8 +52,7 @@ public class LavaDecorator extends BlockDecorator {
                 BlockState state = block.getState();
                 state.setType(Material.LAVA);
                 state.update(true);
-                // 10 instead of the default 5 because lava should flow faster in the nether
-                ((GlowWorld) block.getWorld()).requestPulse((GlowBlock) block, 10);
+                ((GlowWorld) block.getWorld()).requestSinglePulse((GlowBlock) block, 0);
             }
         }
     }

--- a/src/main/java/net/glowstone/generator/decorators/overworld/FlowingLiquidDecorator.java
+++ b/src/main/java/net/glowstone/generator/decorators/overworld/FlowingLiquidDecorator.java
@@ -51,7 +51,7 @@ public class FlowingLiquidDecorator extends BlockDecorator {
                     BlockState state = block.getState();
                     state.setType(type);
                     state.update(true);
-                    ((GlowWorld) block.getWorld()).requestPulse((GlowBlock) block, 20);
+                    ((GlowWorld) block.getWorld()).requestSinglePulse((GlowBlock) block, 0);
                 }
             }
         }

--- a/src/main/java/net/glowstone/inventory/GlowFurnaceInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowFurnaceInventory.java
@@ -26,14 +26,13 @@ public class GlowFurnaceInventory extends GlowInventory implements FurnaceInvent
         getSlot(RESULT_SLOT).setType(SlotType.RESULT);
 
         GlowBlock block = (GlowBlock) owner.getBlock();
-        block.getWorld().requestPulse(block, 1);
     }
 
     @Override
     public void setItem(int index, ItemStack item) {
         super.setItem(index, item);
         GlowBlock block = (GlowBlock) getHolder().getBlock();
-        block.getWorld().requestPulse(block, 1);
+        block.getWorld().requestSinglePulse(block, 1);
     }
 
     @Override


### PR DESCRIPTION
Added new requestSinglePulse in GlowWorld.java and changed liquid blocks (water, and lava) to use this method instead of the forever looping requestPulse method.

This fixes the issue with #284 and stops the memory from forever spiking after new chunks are spawned.
