### PR TITLE
Add Kotlin Maven dependencies (Kotlin support)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,16 @@
             <version>1.14.8</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-runtime</artifactId>
+            <version>1.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-reflect</artifactId>
+            <version>1.1-SNAPSHOT</version>
+        </dependency>
         <!-- Automatically downloaded by Glowstone++'s library manager
         <dependency>
             <groupId>org.xerial</groupId>


### PR DESCRIPTION
Adds support for Kotlin in Glowstone. ([More info about Kotlin](https://en.wikipedia.org/wiki/Kotlin_%28programming_language%29))

Since Kotlin is a JVM-based language, it doesn't require any special loading. However, some basic functions like inheritance and reflection-related-stuff require the Kotlin runtime/reflection libraries.

For anyone curious, this is a sample Kotlin Bukkit plugin:

``` kotlin
import org.bukkit.plugin.java.JavaPlugin

class MyPlugin : JavaPlugin() {
    override fun onEnable() {
        logger.info("This is a Kotlin plugin... wew lad")
        getCommand("mycommand").executor = MyCommand()
        server.pluginManager.registerEvents(MyListener(), this)
    }
}
```

``` kotlin
import org.bukkit.command.Command
import org.bukkit.command.CommandExecutor
import org.bukkit.command.CommandSender

class MyCommand : CommandExecutor {
    override fun onCommand(sender: CommandSender, command: Command, label: String, args: Array<out String>): Boolean {
        var name = sender.name
        sender.sendMessage("Your name is " + name)
        return false
    }
}
```

``` kotlin
import org.bukkit.event.EventHandler
import org.bukkit.event.Listener
import org.bukkit.event.player.PlayerJoinEvent

class MyListener : Listener {
    @EventHandler
    fun onJoin(event: PlayerJoinEvent) {
        event.player.sendMessage("o shit waddup")
    }
}
```
