### PR TITLE
Added support for legacy pings/queries.

### DIFF
--- a/src/main/java/net/glowstone/net/GlowNetworkServer.java
+++ b/src/main/java/net/glowstone/net/GlowNetworkServer.java
@@ -59,5 +59,9 @@ public final class GlowNetworkServer implements ConnectionManager {
         bossGroup.shutdownGracefully();
     }
 
+    public GlowServer getServer() {
+        return server;
+    }
+
 }
 

--- a/src/main/java/net/glowstone/net/handler/legacyping/LegacyPingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/legacyping/LegacyPingHandler.java
@@ -1,0 +1,100 @@
+package net.glowstone.net.handler.legacyping;
+
+import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+
+import org.bukkit.event.server.ServerListPingEvent;
+
+import com.google.common.base.Charsets;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import net.glowstone.EventFactory;
+import net.glowstone.GlowServer;
+import net.glowstone.net.GlowNetworkServer;
+
+public class LegacyPingHandler extends ChannelInboundHandlerAdapter {
+
+    GlowNetworkServer networkServer;
+
+    public LegacyPingHandler(GlowNetworkServer networkServer) {
+        this.networkServer = networkServer;
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext channelHandlerContext, Object object) throws Exception {
+        ByteBuf bytebuf = (ByteBuf) object;
+
+        bytebuf.markReaderIndex();
+        boolean legacyPingProtocol = false;
+
+        try {
+            if (bytebuf.readByte() == (byte) 0xFE) {
+                GlowServer server = networkServer.getServer();
+                int readableBytes = bytebuf.readableBytes();
+
+                InetSocketAddress inetsocketaddress = (InetSocketAddress) channelHandlerContext.channel().remoteAddress();
+
+                ServerListPingEvent legacyPingEvent = new ServerListPingEvent(inetsocketaddress.getAddress(), server.getMotd(), server.getOnlinePlayers().size(), server.getMaxPlayers());
+                EventFactory.callEvent(legacyPingEvent);
+
+                switch (readableBytes) {
+                    case 0:
+                        sendByteBuf(channelHandlerContext, responseToByteBuf(channelHandlerContext, String.format("%s\u00a7%d\u00a7%d", legacyPingEvent.getMotd(), legacyPingEvent.getNumPlayers(), legacyPingEvent.getMaxPlayers())));
+                        legacyPingProtocol = true;
+                        break;
+                    case 1:
+                        if (bytebuf.readByte() == (byte) 0x01) {
+                            sendByteBuf(channelHandlerContext, responseToByteBuf(channelHandlerContext, String.format("\u00a71\u0000%d\u0000%s\u0000%s\u0000%d\u0000%d", GlowServer.PROTOCOL_VERSION, GlowServer.GAME_VERSION, legacyPingEvent.getMotd(), legacyPingEvent.getNumPlayers(), legacyPingEvent.getMaxPlayers())));
+                            legacyPingProtocol = true;
+                        }
+                        break;
+                    default:
+                        if (bytebuf.readByte() == (byte) 0x01 && bytebuf.readByte() == (byte) 0xFA && "MC|PingHost".equals(new String(bytebuf.readBytes(bytebuf.readShort() * 2).array(), Charsets.UTF_16BE))) {
+                            int dataLength = bytebuf.readUnsignedShort();
+                            short clientVersion = bytebuf.readUnsignedByte();
+                            String hostname = bytebuf.readBytes(bytebuf.readShort() * 2).toString(Charsets.UTF_16BE);
+                            @SuppressWarnings("unused")
+                            int port = bytebuf.readInt();
+
+                            if (clientVersion >= 73 && 7 + (hostname.length() * 2) == dataLength && bytebuf.readableBytes() == 0) {
+                                sendByteBuf(channelHandlerContext, responseToByteBuf(channelHandlerContext, String.format("\u00a71\u0000%d\u0000%s\u0000%s\u0000%d\u0000%d", GlowServer.PROTOCOL_VERSION, GlowServer.GAME_VERSION, legacyPingEvent.getMotd(), legacyPingEvent.getNumPlayers(), legacyPingEvent.getMaxPlayers())));
+                                legacyPingProtocol = true;
+                            }
+                        }
+                        break;
+                }
+            }
+        } catch (RuntimeException e) {
+            // Silently catch the exception
+            ;
+        } finally {
+            // check if not successful, otherwise the connection has already been closed
+            if (!legacyPingProtocol) {
+                bytebuf.resetReaderIndex();
+                channelHandlerContext.pipeline().remove("legacy_ping");
+                channelHandlerContext.fireChannelRead(object);
+            }
+        }
+    }
+
+    private void sendByteBuf(ChannelHandlerContext channelhandlercontext, ByteBuf bytebuf) {
+        channelhandlercontext.writeAndFlush(bytebuf).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    private ByteBuf responseToByteBuf(ChannelHandlerContext ctx, String string) {
+        ByteBuf bytebuf = ctx.alloc().buffer(3 + string.length());
+
+        bytebuf.writeByte(0xFF);
+        bytebuf.writeShort(string.length());
+        try {
+            bytebuf.writeBytes(string.getBytes("UTF-16BE"));
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+
+        return bytebuf;
+    }
+}

--- a/src/main/java/net/glowstone/net/pipeline/GlowChannelInitializer.java
+++ b/src/main/java/net/glowstone/net/pipeline/GlowChannelInitializer.java
@@ -5,6 +5,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import net.glowstone.net.GlowNetworkServer;
+import net.glowstone.net.handler.legacyping.LegacyPingHandler;
 import net.glowstone.net.protocol.ProtocolType;
 
 /**
@@ -37,6 +38,7 @@ public final class GlowChannelInitializer extends ChannelInitializer<SocketChann
         FramingHandler framing = new FramingHandler();
 
         c.pipeline()
+                .addLast("legacy_ping", new LegacyPingHandler(connectionManager))
                 .addLast("encryption", NoopHandler.INSTANCE)
                 .addLast("framing", framing)
                 .addLast("compression", NoopHandler.INSTANCE)


### PR DESCRIPTION
This pull request is intended to add support for legacy pings/queries. These come mostly from automated scripts that use the simpler form of pinging compared to the more modern complicated method.

The [WIP] tag is because I was not sure if there was a better method to get the instance of GlowServer in LegacyPingHandler.channelRead than to add another method to GlowNetworkServer. Any comments on these would be appreciated.

~~Also I would like to warn that the normal notchian servers have less checks on legacy pings than this. Specifically in the `case 1` switch block (line 49 of LegacyPingHandler), they don't check if the second byte is 0x01 (they just check if it has a second byte) while this implementation does. If others believe that I should do exactly what the notchian server does I will revise it to do so.~~

This pull request should address #186.
