### PR TITLE
Add Glowkit dependency to CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,13 @@
 machine:
    java:
        version: oraclejdk8
+dependencies:
+    pre:
+        - git config --global user.email "momothereal"
+        - git config --global user.name "momothereal.mc@gmail.com"
+        - git clone --recursive https://github.com/GlowstoneMC/Glowkit.git glowkit
+        - (cd glowkit && chmod +x applyPatches.sh && ./applyPatches.sh)
+        - (cd glowkit/Glowkit-Patched && mvn package install)
 test:
     override:
         - ./setup.sh


### PR DESCRIPTION
Adds Glowkit dependency to CircleCI auto-build. Should fix issues like [these](https://circleci.com/gh/GlowstoneMC/Glowstone/77), in which case CircleCI doesn't use the correct Glowkit version with the latest changes.

**Not tested**, open for suggestion.
