### PR TITLE
Fix death, call PlayerDeathEvent/EntityDeathEvent

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -23,6 +23,8 @@ import org.bukkit.entity.*;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -458,6 +460,13 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                 world.playSound(location, deathSound, 1.0f, 1.0f);
             }
             playEffect(EntityEffect.DEATH);
+            if (this instanceof GlowPlayer) {
+                PlayerDeathEvent event = new PlayerDeathEvent((GlowPlayer) this, new ArrayList<>(), 0, this.getName() + " died.");
+                EventFactory.callEvent(event);
+                server.broadcastMessage(event.getDeathMessage());
+            } else {
+                EventFactory.callEvent(new EntityDeathEvent(this, new ArrayList<>()));
+            }
             // todo: drop items
         }
     }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -781,6 +781,7 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
             session.send(new DestroyEntitiesMessage(entityIds));
             knownEntities.clear();
         }
+        active = true;
         spawnAt(event.getRespawnLocation());
 
         // just in case any items are left in their inventory after they respawn


### PR DESCRIPTION
Should fix #318.

Implements _death_, by "activating" the player when it respawns, and calling the death event.
