### PR TITLE
Fix mistake in AnvilChunkIoService

### DIFF
--- a/src/main/java/net/glowstone/io/anvil/AnvilChunkIoService.java
+++ b/src/main/java/net/glowstone/io/anvil/AnvilChunkIoService.java
@@ -154,7 +154,7 @@ public final class AnvilChunkIoService implements ChunkIoService {
                     id = id.replace("minecraft:", "");
                     if (id.startsWith("flowing_")) {
                         id = id.replace("flowing_", "");
-                    } else if ("id".equals("water") || id.equals("lava")) {
+                    } else if (id.equals("water") || id.equals("lava")) {
                         id = "stationary_" + id;
                     }
                 }


### PR DESCRIPTION
Instead of comparing the variable 'id', the String constant "id" was compared instead.
