### PR TITLE
Use entity bounding boxes for block placement

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -11,7 +11,6 @@ import net.glowstone.block.itemtype.ItemType;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.physics.BlockBoundingBox;
-import net.glowstone.entity.physics.BoundingBox;
 import net.glowstone.util.SoundInfo;
 import net.glowstone.util.SoundUtil;
 import org.bukkit.*;
@@ -308,14 +307,9 @@ public class BlockType extends ItemType {
 
         if (getMaterial().isSolid()) {
             BlockBoundingBox box = new BlockBoundingBox(target);
-            BoundingBox searchBox = BoundingBox.copyOf(box);
-            Vector vec = new Vector(32, 32, 32);
-            searchBox.minCorner.subtract(vec);
-            searchBox.maxCorner.add(vec);
-            List<Entity> entities = target.getWorld().getEntityManager().getEntitiesInside(searchBox, null);
+            List<Entity> entities = target.getWorld().getEntityManager().getEntitiesInside(box, null);
             for (Entity e : entities) {
-                GlowEntity entity = (GlowEntity) e;
-                if (entity instanceof LivingEntity && entity.intersects(box)) {
+                if (e instanceof LivingEntity) {
                     return;
                 }
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -11,6 +11,7 @@ import net.glowstone.block.itemtype.ItemType;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.physics.BlockBoundingBox;
+import net.glowstone.entity.physics.BoundingBox;
 import net.glowstone.util.SoundInfo;
 import net.glowstone.util.SoundUtil;
 import org.bukkit.*;
@@ -306,27 +307,16 @@ public class BlockType extends ItemType {
         }
 
         if (getMaterial().isSolid()) {
-            GlowChunk[] chunks = new GlowChunk[]{
-                    target.getChunk(),
-                    target.getWorld().getChunkAt(target.getChunk().getX() + 1, target.getChunk().getZ()),
-                    target.getWorld().getChunkAt(target.getChunk().getX() + 1, target.getChunk().getZ() + 1),
-                    target.getWorld().getChunkAt(target.getChunk().getX(), target.getChunk().getZ() + 1),
-                    target.getWorld().getChunkAt(target.getChunk().getX() - 1, target.getChunk().getZ()),
-                    target.getWorld().getChunkAt(target.getChunk().getX() - 1, target.getChunk().getZ() - 1),
-                    target.getWorld().getChunkAt(target.getChunk().getX() - 1, target.getChunk().getZ() + 1),
-                    target.getWorld().getChunkAt(target.getChunk().getX(), target.getChunk().getZ() - 1),
-                    target.getWorld().getChunkAt(target.getChunk().getX() + 1, target.getChunk().getZ() - 1),
-            };
             BlockBoundingBox box = new BlockBoundingBox(target);
-            for (GlowChunk chunk : chunks) {
-                for (Entity e : chunk.getEntities()) {
-                    GlowEntity entity = (GlowEntity) e;
-                    if (!(entity instanceof LivingEntity)) {
-                        continue;
-                    }
-                    if (entity.intersects(box)) {
-                        return;
-                    }
+            BoundingBox searchBox = BoundingBox.copyOf(box);
+            Vector vec = new Vector(32, 32, 32);
+            searchBox.minCorner.subtract(vec);
+            searchBox.maxCorner.add(vec);
+            List<Entity> entities = target.getWorld().getEntityManager().getEntitiesInside(searchBox, null);
+            for (Entity e : entities) {
+                GlowEntity entity = (GlowEntity) e;
+                if (entity instanceof LivingEntity && entity.intersects(box)) {
+                    return;
                 }
             }
         }

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -305,20 +305,18 @@ public class BlockType extends ItemType {
             return;
         }
 
-        // TODO: check bounding box
         if (getMaterial().isSolid()) {
-            GlowChunk[] chunks = new GlowChunk[]
-                    {
-                            against.getChunk(),
-                            against.getWorld().getChunkAt(against.getChunk().getX() + 1, against.getChunk().getZ()),
-                            against.getWorld().getChunkAt(against.getChunk().getX() + 1, against.getChunk().getZ() + 1),
-                            against.getWorld().getChunkAt(against.getChunk().getX(), against.getChunk().getZ() + 1),
-                            against.getWorld().getChunkAt(against.getChunk().getX() - 1, against.getChunk().getZ()),
-                            against.getWorld().getChunkAt(against.getChunk().getX() - 1, against.getChunk().getZ() - 1),
-                            against.getWorld().getChunkAt(against.getChunk().getX() - 1, against.getChunk().getZ() + 1),
-                            against.getWorld().getChunkAt(against.getChunk().getX(), against.getChunk().getZ() - 1),
-                            against.getWorld().getChunkAt(against.getChunk().getX() + 1, against.getChunk().getZ() - 1),
-                    };
+            GlowChunk[] chunks = new GlowChunk[]{
+                    target.getChunk(),
+                    target.getWorld().getChunkAt(target.getChunk().getX() + 1, target.getChunk().getZ()),
+                    target.getWorld().getChunkAt(target.getChunk().getX() + 1, target.getChunk().getZ() + 1),
+                    target.getWorld().getChunkAt(target.getChunk().getX(), target.getChunk().getZ() + 1),
+                    target.getWorld().getChunkAt(target.getChunk().getX() - 1, target.getChunk().getZ()),
+                    target.getWorld().getChunkAt(target.getChunk().getX() - 1, target.getChunk().getZ() - 1),
+                    target.getWorld().getChunkAt(target.getChunk().getX() - 1, target.getChunk().getZ() + 1),
+                    target.getWorld().getChunkAt(target.getChunk().getX(), target.getChunk().getZ() - 1),
+                    target.getWorld().getChunkAt(target.getChunk().getX() + 1, target.getChunk().getZ() - 1),
+            };
             BlockBoundingBox box = new BlockBoundingBox(target);
             for (GlowChunk chunk : chunks) {
                 for (Entity e : chunk.getEntities()) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -8,7 +8,6 @@ import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.ItemTable;
 import net.glowstone.block.entity.TileEntity;
 import net.glowstone.block.itemtype.ItemType;
-import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.physics.BlockBoundingBox;
 import net.glowstone.util.SoundInfo;

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -143,6 +143,7 @@ public abstract class GlowEntity implements Entity {
      * Whether
      */
     private boolean silent;
+
     /**
      * Creates an entity and adds it to the specified world.
      *

--- a/src/main/java/net/glowstone/entity/monster/GlowBlaze.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowBlaze.java
@@ -10,6 +10,7 @@ public class GlowBlaze extends GlowMonster implements Blaze {
 
     public GlowBlaze(Location loc) {
         super(loc, EntityType.BLAZE, 20);
+        setBoundingBox(0.6, 1.8);
     }
 
     public boolean isOnFire() {

--- a/src/main/java/net/glowstone/entity/monster/GlowCaveSpider.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowCaveSpider.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.EntityType;
 public class GlowCaveSpider extends GlowMonster implements CaveSpider {
     public GlowCaveSpider(Location loc) {
         super(loc, EntityType.CAVE_SPIDER, 12);
+        setBoundingBox(0.7, 0.5);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/monster/GlowCreeper.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowCreeper.java
@@ -17,6 +17,7 @@ public class GlowCreeper extends GlowMonster implements Creeper {
 
     public GlowCreeper(Location loc) {
         super(loc, EntityType.CREEPER, 20);
+        setBoundingBox(0.6, 1.7);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/monster/GlowEnderman.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowEnderman.java
@@ -14,6 +14,7 @@ public class GlowEnderman extends GlowMonster implements Enderman {
 
     public GlowEnderman(Location loc) {
         super(loc, EntityType.ENDERMAN, 40);
+        setBoundingBox(0.6, 2.9);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/monster/GlowEndermite.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowEndermite.java
@@ -11,6 +11,7 @@ public class GlowEndermite extends GlowMonster implements Endermite {
 
     public GlowEndermite(Location loc) {
         super(loc, EntityType.ENDERMITE, 8);
+        setBoundingBox(0.4, 0.3);
     }
 
     public boolean isPlayerSpawned() {

--- a/src/main/java/net/glowstone/entity/monster/GlowGhast.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowGhast.java
@@ -12,6 +12,7 @@ public class GlowGhast extends GlowMonster implements Ghast {
 
     public GlowGhast(Location loc) {
         super(loc, EntityType.GHAST, 10);
+        setBoundingBox(4, 4);
     }
 
     public int getExplosionPower() {

--- a/src/main/java/net/glowstone/entity/monster/GlowGuardian.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowGuardian.java
@@ -11,6 +11,7 @@ public class GlowGuardian extends GlowMonster implements Guardian {
 
     public GlowGuardian(Location loc) {
         super(loc, EntityType.GUARDIAN, 30);
+        setBoundingBox(0.85, 0.85);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/monster/GlowIronGolem.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowIronGolem.java
@@ -10,6 +10,7 @@ public class GlowIronGolem extends GlowMonster implements IronGolem {
 
     public GlowIronGolem(Location loc) {
         super(loc, EntityType.IRON_GOLEM, 100);
+        setBoundingBox(1.4, 2.7);
     }
 
     public GlowIronGolem(Location loc, boolean playerCreated) {

--- a/src/main/java/net/glowstone/entity/monster/GlowSilverfish.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowSilverfish.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Silverfish;
 public class GlowSilverfish extends GlowMonster implements Silverfish {
     public GlowSilverfish(Location loc) {
         super(loc, EntityType.SILVERFISH, 8);
+        setBoundingBox(0.4, 0.3);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/monster/GlowSkeleton.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowSkeleton.java
@@ -11,6 +11,7 @@ public class GlowSkeleton extends GlowMonster implements Skeleton {
 
     public GlowSkeleton(Location loc) {
         super(loc, EntityType.SKELETON, 20);
+        setBoundingBox(0.6, 1.99);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/monster/GlowSlime.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowSlime.java
@@ -35,6 +35,7 @@ public class GlowSlime extends GlowMonster implements Slime {
                 health = 16;
                 break;
         }
+        setBoundingBox(0.51000005 * size, 0.51000005 * size);
         setSize(size);
         setMaxHealth(health);
         setHealth(health);

--- a/src/main/java/net/glowstone/entity/monster/GlowSnowman.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowSnowman.java
@@ -10,6 +10,7 @@ public class GlowSnowman extends GlowMonster implements Snowman {
 
     public GlowSnowman(Location loc) {
         super(loc, EntityType.SNOWMAN, 4);
+        setBoundingBox(0.7, 1.9);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/monster/GlowSpider.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowSpider.java
@@ -10,6 +10,7 @@ public class GlowSpider extends GlowMonster implements Spider {
 
     public GlowSpider(Location loc) {
         super(loc, EntityType.SPIDER, 16);
+        setBoundingBox(1.4, 0.9);
     }
 
     public boolean isClimbing() {

--- a/src/main/java/net/glowstone/entity/monster/GlowWitch.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowWitch.java
@@ -10,6 +10,7 @@ public class GlowWitch extends GlowMonster implements Witch {
 
     public GlowWitch(Location loc) {
         super(loc, EntityType.WITCH, 26);
+        setBoundingBox(0.6, 1.8);
     }
 
     public boolean isAggressive() {

--- a/src/main/java/net/glowstone/entity/monster/GlowZombie.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowZombie.java
@@ -23,6 +23,7 @@ public class GlowZombie extends GlowMonster implements Zombie {
 
     public GlowZombie(Location loc, EntityType type) {
         super(loc, type, 20);
+        setBoundingBox(0.6, 1.8);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/passive/GlowOcelot.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowOcelot.java
@@ -14,6 +14,7 @@ public class GlowOcelot extends GlowTameable implements Ocelot {
     public GlowOcelot(Location location) {
         super(location, EntityType.OCELOT, 10);
         setCatType(Type.WILD_OCELOT);
+        setBoundingBox(0.6, 0.8);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/passive/GlowPolarBear.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowPolarBear.java
@@ -11,6 +11,7 @@ public class GlowPolarBear extends GlowAnimal implements PolarBear {
 
     public GlowPolarBear(Location location) {
         super(location, EntityType.POLAR_BEAR, 30);
+        setBoundingBox(1.3, 1.4);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/passive/GlowVillager.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowVillager.java
@@ -21,6 +21,7 @@ public class GlowVillager extends GlowAgeable implements Villager {
         super(location, EntityType.VILLAGER, 20);
         Random r = new Random();
         setProfession(Profession.values()[r.nextInt(Profession.values().length - 2) + 1]);
+        setBoundingBox(0.6, 1.95);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/passive/GlowWolf.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowWolf.java
@@ -20,6 +20,7 @@ public class GlowWolf extends GlowTameable implements Wolf {
         super(location, EntityType.WOLF, 8);
         Random r = new Random();
         collarColor = DyeColor.getByData((byte) r.nextInt(DyeColor.values().length));
+        setBoundingBox(0.6, 0.85);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/physics/BlockBoundingBox.java
+++ b/src/main/java/net/glowstone/entity/physics/BlockBoundingBox.java
@@ -1,0 +1,21 @@
+package net.glowstone.entity.physics;
+
+import org.bukkit.block.Block;
+import org.bukkit.util.Vector;
+
+public class BlockBoundingBox extends BoundingBox {
+
+    public BlockBoundingBox(Block block) {
+        minCorner.setX(block.getX());
+        minCorner.setY(block.getY());
+        minCorner.setZ(block.getZ());
+        maxCorner.setX(block.getX() + 1);
+        maxCorner.setY(block.getY() + 0.95);
+        maxCorner.setZ(block.getZ() + 1);
+    }
+
+    @Override
+    public Vector getSize() {
+        return new Vector(1, 1, 1);
+    }
+}


### PR DESCRIPTION
This adds a check for nearby entities that have bounding boxes before placing a block.

Addresses issue #282.
