### PR TITLE
Implement entity features

### DIFF
--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -1225,6 +1225,8 @@ public final class GlowWorld implements World {
                     if (!spawnEvent.isCancelled()) {
                         List<Message> spawnMessage = entity.createSpawnMessage();
                         getRawPlayers().stream().filter(player -> player.canSeeEntity(impl)).forEach(player -> player.getSession().sendAll(spawnMessage.toArray(new Message[spawnMessage.size()])));
+                    } else {
+                        entity.remove();
                     }
                 }
             } catch (NoSuchMethodException e) {

--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -30,6 +30,7 @@ import org.bukkit.block.BlockState;
 import org.bukkit.entity.*;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
+import org.bukkit.event.entity.EntitySpawnEvent;
 import org.bukkit.event.weather.LightningStrikeEvent;
 import org.bukkit.event.weather.ThunderChangeEvent;
 import org.bukkit.event.weather.WeatherChangeEvent;
@@ -1209,7 +1210,7 @@ public final class GlowWorld implements World {
                 Constructor<? extends GlowEntity> constructor = clazz.getConstructor(Location.class);
                 entity = constructor.newInstance(location);
                 if (entity instanceof LivingEntity) {
-                    CreatureSpawnEvent spawnEvent = new CreatureSpawnEvent((LivingEntity) entity, reason);
+                    CreatureSpawnEvent spawnEvent = EventFactory.callEvent(new CreatureSpawnEvent((LivingEntity) entity, reason);
                     if (!spawnEvent.isCancelled()) {
                         entity.createSpawnMessage();
                     } else {
@@ -1217,7 +1218,9 @@ public final class GlowWorld implements World {
                         entity.remove();
                     }
                 } else {
-                    entity.createSpawnMessage();
+                    EntitySpawnEvent spawnEvent = EventFactory.callEvent(new EntitySpawnEvent(entity));
+                    if (!spawnEvent.isCancelled())
+                        entity.createSpawnMessage();
                 }
             } catch (NoSuchMethodException e) {
                 GlowServer.logger.log(Level.WARNING, "Invalid entity spawn: ", e);

--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -1211,23 +1211,18 @@ public final class GlowWorld implements World {
                 Constructor<? extends GlowEntity> constructor = clazz.getConstructor(Location.class);
                 entity = constructor.newInstance(location);
                 GlowEntity impl = entity;
+                EntitySpawnEvent spawnEvent;
                 if (entity instanceof LivingEntity) {
-                    CreatureSpawnEvent spawnEvent = EventFactory.callEvent(new CreatureSpawnEvent((LivingEntity) entity, reason));
-                    if (!spawnEvent.isCancelled()) {
-                        List<Message> spawnMessage = entity.createSpawnMessage();
-                        getRawPlayers().stream().filter(player -> player.canSeeEntity(impl)).forEach(player -> player.getSession().sendAll(spawnMessage.toArray(new Message[spawnMessage.size()])));
-                    } else {
-                        // TODO: separate spawning and construction for better event cancellation
-                        entity.remove();
-                    }
+                    spawnEvent = EventFactory.callEvent(new CreatureSpawnEvent((LivingEntity) entity, reason));
                 } else {
-                    EntitySpawnEvent spawnEvent = EventFactory.callEvent(new EntitySpawnEvent(entity));
-                    if (!spawnEvent.isCancelled()) {
-                        List<Message> spawnMessage = entity.createSpawnMessage();
-                        getRawPlayers().stream().filter(player -> player.canSeeEntity(impl)).forEach(player -> player.getSession().sendAll(spawnMessage.toArray(new Message[spawnMessage.size()])));
-                    } else {
-                        entity.remove();
-                    }
+                    spawnEvent = EventFactory.callEvent(new EntitySpawnEvent(entity));
+                }
+                if (!spawnEvent.isCancelled()) {
+                    List<Message> spawnMessage = entity.createSpawnMessage();
+                    getRawPlayers().stream().filter(player -> player.canSeeEntity(impl)).forEach(player -> player.getSession().sendAll(spawnMessage.toArray(new Message[spawnMessage.size()])));
+                } else {
+                    // TODO: separate spawning and construction for better event cancellation
+                    entity.remove();
                 }
             } catch (NoSuchMethodException e) {
                 GlowServer.logger.log(Level.WARNING, "Invalid entity spawn: ", e);

--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -1208,12 +1208,16 @@ public final class GlowWorld implements World {
             try {
                 Constructor<? extends GlowEntity> constructor = clazz.getConstructor(Location.class);
                 entity = constructor.newInstance(location);
-                CreatureSpawnEvent spawnEvent = new CreatureSpawnEvent((LivingEntity) entity, reason);
-                if (!spawnEvent.isCancelled()) {
-                    entity.createSpawnMessage();
+                if (entity instanceof LivingEntity) {
+                    CreatureSpawnEvent spawnEvent = new CreatureSpawnEvent((LivingEntity) entity, reason);
+                    if (!spawnEvent.isCancelled()) {
+                        entity.createSpawnMessage();
+                    } else {
+                        // TODO: separate spawning and construction for better event cancellation
+                        entity.remove();
+                    }
                 } else {
-                    // TODO: separate spawning and construction for better event cancellation
-                    entity.remove();
+                    entity.createSpawnMessage();
                 }
             } catch (NoSuchMethodException e) {
                 GlowServer.logger.log(Level.WARNING, "Invalid entity spawn: ", e);

--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -202,7 +202,7 @@ public final class ItemTable {
         reg(Material.SPONGE, new BlockSponge());
         reg(Material.TNT, new BlockTNT());
         reg(Material.DOUBLE_PLANT, new BlockDoublePlant());
-        reg(Material.PUMPKIN, new BlockDirectDrops(Material.PUMPKIN));
+        reg(Material.PUMPKIN, new BlockPumpkin());
         reg(Material.JACK_O_LANTERN, new BlockDirectDrops(Material.JACK_O_LANTERN));
         reg(Material.SEA_LANTERN, new BlockRandomDrops(Material.PRISMARINE_CRYSTALS, 2, 3));
         reg(Material.REDSTONE_LAMP_ON, new BlockLamp());

--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -2,6 +2,7 @@ package net.glowstone.block;
 
 import net.glowstone.block.blocktype.*;
 import net.glowstone.block.itemtype.*;
+import net.glowstone.entity.objects.GlowMinecart;
 import net.glowstone.inventory.ToolType;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -286,6 +287,12 @@ public final class ItemTable {
         reg(Material.SPIDER_EYE, new ItemFood(2, 3.2f)); // todo: effect
         reg(Material.ARMOR_STAND, new ItemArmorStand());
         reg(Material.MILK_BUCKET, new ItemMilk());
+        reg(Material.MINECART, new ItemMinecart(GlowMinecart.MinecartType.RIDEABLE));
+        reg(Material.COMMAND_MINECART, new ItemMinecart(GlowMinecart.MinecartType.COMMAND));
+        reg(Material.EXPLOSIVE_MINECART, new ItemMinecart(GlowMinecart.MinecartType.TNT));
+        reg(Material.HOPPER_MINECART, new ItemMinecart(GlowMinecart.MinecartType.HOPPER));
+        reg(Material.POWERED_MINECART, new ItemMinecart(GlowMinecart.MinecartType.FURNACE));
+        reg(Material.STORAGE_MINECART, new ItemMinecart(GlowMinecart.MinecartType.CHEST));
     }
 
     private void reg(Material material, ItemType type) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockPumpkin.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockPumpkin.java
@@ -4,8 +4,8 @@ import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.inventory.ToolType;
+import net.glowstone.util.pattern.BlockPattern;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
@@ -13,10 +13,26 @@ import org.bukkit.material.MaterialData;
 import org.bukkit.material.Pumpkin;
 import org.bukkit.util.Vector;
 
+import static org.bukkit.Material.*;
+
 public class BlockPumpkin extends BlockDirectDrops {
 
+    private static final BlockPattern IRONGOLEM_PATTERN = new BlockPattern(
+            new BlockPattern.PatternItem(PUMPKIN,       (byte) -1, 1, 0),
+            new BlockPattern.PatternItem(IRON_BLOCK,    (byte) 0, 0, 1),
+            new BlockPattern.PatternItem(IRON_BLOCK,    (byte) 0, 1, 1),
+            new BlockPattern.PatternItem(IRON_BLOCK,    (byte) 0, 2, 1),
+            new BlockPattern.PatternItem(IRON_BLOCK,    (byte) 0, 1, 2)
+    );
+
+    private static final BlockPattern SNOWMAN_PATTERN = new BlockPattern(
+            new BlockPattern.PatternItem(PUMPKIN,       (byte) -1, 0, 0),
+            new BlockPattern.PatternItem(SNOW_BLOCK,    (byte) 0, 0, 1),
+            new BlockPattern.PatternItem(SNOW_BLOCK,    (byte) 0, 0, 2)
+    );
+
     public BlockPumpkin() {
-        super(Material.PUMPKIN, ToolType.AXE);
+        super(PUMPKIN, ToolType.AXE);
     }
 
     @Override
@@ -42,36 +58,18 @@ public class BlockPumpkin extends BlockDirectDrops {
     }
 
     private boolean spawnIronGolem(Location location) {
-        Location[] blocks = new Location[]{location.clone().subtract(0, 1, 0), location.clone().subtract(0, 2, 0), null, null};
-        if (blocks[0].getBlock().getType() != Material.IRON_BLOCK || blocks[1].getBlock().getType() != Material.IRON_BLOCK) {
-            return false;
+        if (IRONGOLEM_PATTERN.matches(location, true, 1, 0)) {
+            location.getWorld().spawnEntity(location.clone().subtract(-0.5, 2, -0.5), EntityType.IRON_GOLEM);
+            return true;
         }
-        if ((location.clone().add(1, -1, 0).getBlock().getType() == Material.IRON_BLOCK && location.clone().add(-1, -1, 0).getBlock().getType() == Material.IRON_BLOCK)) {
-            blocks[2] = location.clone().add(1, -1, 0);
-            blocks[3] = location.clone().add(-1, -1, 0);
-        } else if ((location.clone().add(0, -1, 1).getBlock().getType() == Material.IRON_BLOCK && location.clone().add(0, -1, -1).getBlock().getType() == Material.IRON_BLOCK)) {
-            blocks[2] = location.clone().add(0, -1, 1);
-            blocks[3] = location.clone().add(0, -1, -1);
-        } else {
-            return false;
-        }
-        for (Location b : blocks) {
-            b.getBlock().setType(Material.AIR);
-        }
-        location.getBlock().setType(Material.AIR);
-        location.getWorld().spawnEntity(location.clone().subtract(-0.5, 2, -0.5), EntityType.IRON_GOLEM);
-        return true;
+        return false;
     }
 
     private boolean spawnSnowman(Location location) {
-        Location[] blocks = new Location[] {location, location.clone().subtract(0, 1, 0), location.clone().subtract(0, 2, 0)};
-        if (blocks[1].getBlock().getType() != Material.SNOW_BLOCK || blocks[2].getBlock().getType() != Material.SNOW_BLOCK) {
-            return false;
+        if (SNOWMAN_PATTERN.matches(location, true, 0, 0)) {
+            location.getWorld().spawnEntity(location.clone().subtract(-0.5, 2, -0.5), EntityType.SNOWMAN);
+            return true;
         }
-        for (Location b : blocks) {
-            b.getBlock().setType(Material.AIR);
-        }
-        location.getWorld().spawnEntity(location.clone().subtract(-0.5, 2, -0.5), EntityType.SNOWMAN);
-        return true;
+        return false;
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockPumpkin.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockPumpkin.java
@@ -1,0 +1,77 @@
+package net.glowstone.block.blocktype;
+
+import net.glowstone.block.GlowBlock;
+import net.glowstone.block.GlowBlockState;
+import net.glowstone.entity.GlowPlayer;
+import net.glowstone.inventory.ToolType;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.material.MaterialData;
+import org.bukkit.material.Pumpkin;
+import org.bukkit.util.Vector;
+
+public class BlockPumpkin extends BlockDirectDrops {
+
+    public BlockPumpkin() {
+        super(Material.PUMPKIN, ToolType.AXE);
+    }
+
+    @Override
+    public void placeBlock(GlowPlayer player, GlowBlockState state, BlockFace face, ItemStack holding, Vector clickedLoc) {
+        super.placeBlock(player, state, face, holding, clickedLoc);
+        MaterialData data = state.getData();
+        if (data instanceof Pumpkin) {
+            ((Pumpkin) data).setFacingDirection(player.getDirection());
+            state.setData(data);
+        } else {
+            warnMaterialData(Pumpkin.class, data);
+        }
+    }
+
+    @Override
+    public void afterPlace(GlowPlayer player, GlowBlock block, ItemStack holding, GlowBlockState oldState) {
+        super.afterPlace(player, block, holding, oldState);
+        // Golems
+        Location location = block.getLocation();
+        if (!spawnIronGolem(location.clone())) {
+            spawnSnowman(location.clone());
+        }
+    }
+
+    private boolean spawnIronGolem(Location location) {
+        Location[] blocks = new Location[]{location.clone().subtract(0, 1, 0), location.clone().subtract(0, 2, 0), null, null};
+        if (blocks[0].getBlock().getType() != Material.IRON_BLOCK || blocks[1].getBlock().getType() != Material.IRON_BLOCK) {
+            return false;
+        }
+        if ((location.clone().add(1, -1, 0).getBlock().getType() == Material.IRON_BLOCK && location.clone().add(-1, -1, 0).getBlock().getType() == Material.IRON_BLOCK)) {
+            blocks[2] = location.clone().add(1, -1, 0);
+            blocks[3] = location.clone().add(-1, -1, 0);
+        } else if ((location.clone().add(0, -1, 1).getBlock().getType() == Material.IRON_BLOCK && location.clone().add(0, -1, -1).getBlock().getType() == Material.IRON_BLOCK)) {
+            blocks[2] = location.clone().add(0, -1, 1);
+            blocks[3] = location.clone().add(0, -1, -1);
+        } else {
+            return false;
+        }
+        for (Location b : blocks) {
+            b.getBlock().setType(Material.AIR);
+        }
+        location.getBlock().setType(Material.AIR);
+        location.getWorld().spawnEntity(location.clone().subtract(-0.5, 2, -0.5), EntityType.IRON_GOLEM);
+        return true;
+    }
+
+    private boolean spawnSnowman(Location location) {
+        Location[] blocks = new Location[] {location, location.clone().subtract(0, 1, 0), location.clone().subtract(0, 2, 0)};
+        if (blocks[1].getBlock().getType() != Material.SNOW_BLOCK || blocks[2].getBlock().getType() != Material.SNOW_BLOCK) {
+            return false;
+        }
+        for (Location b : blocks) {
+            b.getBlock().setType(Material.AIR);
+        }
+        location.getWorld().spawnEntity(location.clone().subtract(-0.5, 2, -0.5), EntityType.SNOWMAN);
+        return true;
+    }
+}

--- a/src/main/java/net/glowstone/block/blocktype/BlockPumpkin.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockPumpkin.java
@@ -65,11 +65,9 @@ public class BlockPumpkin extends BlockDirectDrops {
         return false;
     }
 
-    private boolean spawnSnowman(Location location) {
+    private void spawnSnowman(Location location) {
         if (SNOWMAN_PATTERN.matches(location, true, 0, 0)) {
             location.getWorld().spawnEntity(location.clone().subtract(-0.5, 2, -0.5), EntityType.SNOWMAN);
-            return true;
         }
-        return false;
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockSkull.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSkull.java
@@ -7,9 +7,11 @@ import net.glowstone.block.entity.TESkull;
 import net.glowstone.block.entity.TileEntity;
 import net.glowstone.block.state.GlowSkull;
 import net.glowstone.entity.GlowPlayer;
+import net.glowstone.util.pattern.BlockPattern;
 import org.bukkit.Material;
 import org.bukkit.SkullType;
 import org.bukkit.block.BlockFace;
+import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.material.MaterialData;
@@ -19,7 +21,20 @@ import org.bukkit.util.Vector;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static org.bukkit.Material.SKULL;
+import static org.bukkit.Material.SOUL_SAND;
+
 public class BlockSkull extends BlockType {
+
+    private static final BlockPattern WITHER_PATTERN = new BlockPattern(
+            new BlockPattern.PatternItem(SKULL,     (byte) 1, 0, 0),
+            new BlockPattern.PatternItem(SKULL,     (byte) 1, 1, 0),
+            new BlockPattern.PatternItem(SKULL,     (byte) 1, 2, 0),
+            new BlockPattern.PatternItem(SOUL_SAND, (byte) 0, 0, 1),
+            new BlockPattern.PatternItem(SOUL_SAND, (byte) 0, 1, 1),
+            new BlockPattern.PatternItem(SOUL_SAND, (byte) 0, 2, 1),
+            new BlockPattern.PatternItem(SOUL_SAND, (byte) 0, 1, 2)
+    );
 
     public BlockSkull() {
         setDrops(new ItemStack(Material.SKULL_ITEM));
@@ -83,6 +98,14 @@ public class BlockSkull extends BlockType {
             skull.setRotation(player.getFacing().getOppositeFace());
         }
         skull.update();
+
+        // Wither
+        for (int i = 0; i < 3; i++) {
+            if (WITHER_PATTERN.matches(block.getLocation().clone(), true, i, 0)) {
+                block.getWorld().spawnEntity(block.getLocation().clone().subtract(0, 2, 0), EntityType.WITHER);
+                break;
+            }
+        }
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/itemtype/ItemMinecart.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemMinecart.java
@@ -1,0 +1,56 @@
+package net.glowstone.block.itemtype;
+
+import net.glowstone.block.GlowBlock;
+import net.glowstone.entity.GlowPlayer;
+import net.glowstone.entity.objects.GlowMinecart;
+import net.md_5.bungee.api.ChatColor;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.material.Rails;
+import org.bukkit.util.Vector;
+
+public class ItemMinecart extends ItemType {
+
+    private final GlowMinecart.MinecartType minecartType;
+
+    public ItemMinecart(GlowMinecart.MinecartType minecartType) {
+        this.minecartType = minecartType;
+    }
+
+    @Override
+    public void rightClickBlock(GlowPlayer player, GlowBlock target, BlockFace face, ItemStack holding, Vector clickedLoc) {
+        if (target == null || target.getType() != Material.RAILS) {
+            return;
+        }
+        if (minecartType.getMinecartClass() == null) {
+            player.sendMessage(ChatColor.RED + "Minecart type '" + minecartType.getName() + "' is not implemented.");
+            return;
+        }
+        Rails rails = (Rails) target.getState().getData();
+        Location location = target.getLocation().clone().add(Math.abs(rails.getDirection().getModX()) * 0.5, 0.1, Math.abs(rails.getDirection().getModZ()) * 0.5);
+        location.setYaw(getYaw(rails.getDirection()));
+        target.getWorld().spawn(location, minecartType.getEntityClass());
+        if (player.getGameMode() != GameMode.CREATIVE) {
+            player.getInventory().remove(holding);
+        }
+        super.rightClickBlock(player, target, face, holding, clickedLoc);
+    }
+
+    private float getYaw(BlockFace face) {
+        switch (face) {
+            case EAST:
+                return -90f;
+            case NORTH:
+                return -180f;
+            case WEST:
+                return 90f;
+            case SOUTH:
+                return 0f;
+        }
+        return getYaw(BlockFace.SOUTH);
+    }
+
+}

--- a/src/main/java/net/glowstone/block/itemtype/ItemMinecart.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemMinecart.java
@@ -52,5 +52,4 @@ public class ItemMinecart extends ItemType {
         }
         return getYaw(BlockFace.SOUTH);
     }
-
 }

--- a/src/main/java/net/glowstone/block/itemtype/ItemMinecart.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemMinecart.java
@@ -3,7 +3,7 @@ package net.glowstone.block.itemtype;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.objects.GlowMinecart;
-import net.md_5.bungee.api.ChatColor;
+import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/src/main/java/net/glowstone/command/SummonCommand.java
+++ b/src/main/java/net/glowstone/command/SummonCommand.java
@@ -1,7 +1,5 @@
 package net.glowstone.command;
 
-import net.glowstone.GlowWorld;
-import net.glowstone.entity.EntityRegistry;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.io.entity.EntityStorage;
 import net.glowstone.util.mojangson.Mojangson;
@@ -73,8 +71,7 @@ public class SummonCommand extends BukkitCommand {
             sender.sendMessage(ChatColor.RED + "Unknown entity type: " + entityName);
             return true;
         }
-        Class<? extends GlowEntity> spawn = EntityRegistry.getEntity(type);
-        GlowEntity entity = ((GlowWorld) location.getWorld()).spawn(location, spawn);
+        GlowEntity entity = (GlowEntity) location.getWorld().spawnEntity(location, type);
         if (tag != null) {
             EntityStorage.load(entity, tag);
         }

--- a/src/main/java/net/glowstone/command/SummonCommand.java
+++ b/src/main/java/net/glowstone/command/SummonCommand.java
@@ -1,10 +1,14 @@
 package net.glowstone.command;
 
+import com.google.common.collect.ImmutableList;
+import net.glowstone.entity.EntityRegistry;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.io.entity.EntityStorage;
 import net.glowstone.util.mojangson.Mojangson;
 import net.glowstone.util.mojangson.ex.MojangsonParseException;
 import net.glowstone.util.nbt.CompoundTag;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.BlockCommandSender;
@@ -18,6 +22,7 @@ import org.bukkit.entity.Player;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 public class SummonCommand extends BukkitCommand {
 
@@ -71,6 +76,10 @@ public class SummonCommand extends BukkitCommand {
             sender.sendMessage(ChatColor.RED + "Unknown entity type: " + entityName);
             return true;
         }
+        if (EntityRegistry.getEntity(type) == null) {
+            sender.sendMessage(ChatColor.RED + "The entity type '" + type.getName() + "' is not implemented yet.");
+            return true;
+        }
         GlowEntity entity = (GlowEntity) location.getWorld().spawnEntity(location, type);
         if (tag != null) {
             EntityStorage.load(entity, tag);
@@ -115,5 +124,27 @@ public class SummonCommand extends BukkitCommand {
         }
 
         return result;
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
+        Validate.notNull(sender, "Sender cannot be null", new Object[0]);
+        Validate.notNull(args, "Arguments cannot be null", new Object[0]);
+        Validate.notNull(alias, "Alias cannot be null", new Object[0]);
+        if (args.length == 1) {
+            String arg = args[0];
+            ArrayList<String> completion = new ArrayList<>();
+            for (EntityType type : EntityType.values()) {
+                if (type.getName() == null || EntityRegistry.getEntity(type) == null) {
+                    continue;
+                }
+                if (StringUtils.startsWithIgnoreCase(type.getName(), arg)) {
+                    completion.add(type.getName());
+                }
+            }
+            return completion;
+        } else {
+            return ImmutableList.of();
+        }
     }
 }

--- a/src/main/java/net/glowstone/command/SummonCommand.java
+++ b/src/main/java/net/glowstone/command/SummonCommand.java
@@ -116,10 +116,7 @@ public class SummonCommand extends BukkitCommand {
             String arg = args[0];
             ArrayList<String> completion = new ArrayList<>();
             for (EntityType type : EntityType.values()) {
-                if (!checkSummon(null, type)) {
-                    continue;
-                }
-                if (StringUtils.startsWithIgnoreCase(type.getName(), arg)) {
+                if (checkSummon(null, type) && StringUtils.startsWithIgnoreCase(type.getName(), arg)) {
                     completion.add(type.getName());
                 }
             }

--- a/src/main/java/net/glowstone/entity/EntityRegistry.java
+++ b/src/main/java/net/glowstone/entity/EntityRegistry.java
@@ -2,10 +2,7 @@ package net.glowstone.entity;
 
 import com.google.common.collect.ImmutableBiMap;
 import net.glowstone.entity.monster.*;
-import net.glowstone.entity.objects.GlowArmorStand;
-import net.glowstone.entity.objects.GlowFallingBlock;
-import net.glowstone.entity.objects.GlowItem;
-import net.glowstone.entity.objects.GlowItemFrame;
+import net.glowstone.entity.objects.*;
 import net.glowstone.entity.passive.*;
 import org.bukkit.entity.*;
 
@@ -44,7 +41,11 @@ public class EntityRegistry {
                     //TODO: Leash hitch
                     //TODO: Lightning
                     .put(MagmaCube.class, GlowMagmaCube.class)
-                    //TODO: Minecarts
+                    .put(GlowMinecart.MinecartType.RIDEABLE.getEntityClass(), GlowMinecart.MinecartType.RIDEABLE.getMinecartClass())
+                    .put(GlowMinecart.MinecartType.CHEST.getEntityClass(), GlowMinecart.MinecartType.CHEST.getMinecartClass())
+                    .put(GlowMinecart.MinecartType.FURNACE.getEntityClass(), GlowMinecart.MinecartType.FURNACE.getMinecartClass())
+                    .put(GlowMinecart.MinecartType.TNT.getEntityClass(), GlowMinecart.MinecartType.TNT.getMinecartClass())
+                    //TODO: Spawner and Command minecarts
                     .put(MushroomCow.class, GlowMooshroom.class)
                     .put(Ocelot.class, GlowOcelot.class)
                     //TODO: Painting

--- a/src/main/java/net/glowstone/entity/EntityRegistry.java
+++ b/src/main/java/net/glowstone/entity/EntityRegistry.java
@@ -72,6 +72,7 @@ public class EntityRegistry {
                     //TODO: Wither Skull
                     .put(Wolf.class, GlowWolf.class)
                     .put(Zombie.class, GlowZombie.class)
+                    .put(Shulker.class, GlowShulker.class)
                     .build();
 
     public static Class<? extends GlowEntity> getEntity(EntityType type) {

--- a/src/main/java/net/glowstone/entity/EntityRegistry.java
+++ b/src/main/java/net/glowstone/entity/EntityRegistry.java
@@ -45,7 +45,9 @@ public class EntityRegistry {
                     .put(GlowMinecart.MinecartType.CHEST.getEntityClass(), GlowMinecart.MinecartType.CHEST.getMinecartClass())
                     .put(GlowMinecart.MinecartType.FURNACE.getEntityClass(), GlowMinecart.MinecartType.FURNACE.getMinecartClass())
                     .put(GlowMinecart.MinecartType.TNT.getEntityClass(), GlowMinecart.MinecartType.TNT.getMinecartClass())
-                    //TODO: Spawner and Command minecarts
+                    .put(GlowMinecart.MinecartType.HOPPER.getEntityClass(), GlowMinecart.MinecartType.HOPPER.getMinecartClass())
+                    .put(GlowMinecart.MinecartType.SPAWNER.getEntityClass(), GlowMinecart.MinecartType.SPAWNER.getMinecartClass())
+                    //TODO: Command Block minecart
                     .put(MushroomCow.class, GlowMooshroom.class)
                     .put(Ocelot.class, GlowOcelot.class)
                     //TODO: Painting

--- a/src/main/java/net/glowstone/entity/EntityRegistry.java
+++ b/src/main/java/net/glowstone/entity/EntityRegistry.java
@@ -68,7 +68,7 @@ public class EntityRegistry {
                     .put(Villager.class, GlowVillager.class)
                     .put(Weather.class, GlowWeather.class)
                     .put(Witch.class, GlowWitch.class)
-                    //TODO: Wither
+                    .put(Wither.class, GlowWither.class)
                     //TODO: Wither Skull
                     .put(Wolf.class, GlowWolf.class)
                     .put(Zombie.class, GlowZombie.class)

--- a/src/main/java/net/glowstone/entity/meta/MetadataIndex.java
+++ b/src/main/java/net/glowstone/entity/meta/MetadataIndex.java
@@ -87,7 +87,7 @@ public enum MetadataIndex {
     WOLF_BEGGING(16, BOOLEAN, Wolf.class),
     WOLF_COLOR(21, BYTE, Wolf.class),
 
-    VILLAGER_TYPE(13, INT, Villager.class), //TODO 1.9 - Currently Unknown on wiki.vg
+    VILLAGER_PROFESSION(13, INT, Villager.class),
 
     GOLEM_PLAYER_BUILT(12, BYTE, IronGolem.class),
 
@@ -107,7 +107,7 @@ public enum MetadataIndex {
     GUARDIAN_TARGET(13, INT, Guardian.class),
 
     SKELETON_TYPE(12, INT, Skeleton.class),
-    SKELETON_UNKNOWN(13, BOOLEAN, Skeleton.class), //TODO 1.9 - Something hand related according to wiki.vg
+    SKELETON_HANDS_RISEN_UP(13, BOOLEAN, Skeleton.class),
 
     SPIDER_CLIMBING(12, BYTE, Spider.class),
 

--- a/src/main/java/net/glowstone/entity/meta/MetadataIndex.java
+++ b/src/main/java/net/glowstone/entity/meta/MetadataIndex.java
@@ -93,9 +93,9 @@ public enum MetadataIndex {
 
     SNOWMAN_NOHAT(12, BYTE, Snowman.class),
 
-    //SHULKER_FACING_DIRECTION(11, DIRECTION, Golem.class), //TODO 1.9 - New mob?
-    //SHULKER_ATTACHMENT_POSITION(12, OPTPOSITION, Golem.class), //TODO 1.9 - New mob?
-    //SHULKER_SHIELD_HEIGHT(13, BYTE, Golem.class), //TODO 1.9 - New mob?
+    SHULKER_FACING_DIRECTION(12, DIRECTION, Shulker.class),
+    SHULKER_ATTACHMENT_POSITION(13, OPTPOSITION, Shulker.class),
+    SHULKER_SHIELD_HEIGHT(14, BYTE, Shulker.class),
 
     BLAZE_ON_FIRE(12, BYTE, Blaze.class),
 

--- a/src/main/java/net/glowstone/entity/meta/MetadataMap.java
+++ b/src/main/java/net/glowstone/entity/meta/MetadataMap.java
@@ -46,11 +46,9 @@ public class MetadataMap {
                         break;
                 }
             }
-
             if (!index.getType().getDataType().isAssignableFrom(value.getClass())) {
                 throw new IllegalArgumentException("Cannot assign " + value + " to " + index + ", expects " + index.getType());
             }
-
             if (!index.appliesTo(entityClass)) {
                 throw new IllegalArgumentException("Index " + index + " does not apply to " + entityClass.getSimpleName() + ", only " + index.getAppliesTo().getSimpleName());
             }

--- a/src/main/java/net/glowstone/entity/meta/MetadataMap.java
+++ b/src/main/java/net/glowstone/entity/meta/MetadataMap.java
@@ -31,27 +31,29 @@ public class MetadataMap {
 
     public void set(MetadataIndex index, Object value) {
         // take numbers down to the correct precision
-        if (value instanceof Number) {
-            Number n = (Number) value;
-            switch (index.getType()) {
-                case BYTE:
-                    value = n.byteValue();
-                    break;
-                case INT:
-                    value = n.intValue();
-                    break;
-                case FLOAT:
-                    value = n.floatValue();
-                    break;
+        if (value != null) {
+            if (value instanceof Number) {
+                Number n = (Number) value;
+                switch (index.getType()) {
+                    case BYTE:
+                        value = n.byteValue();
+                        break;
+                    case INT:
+                        value = n.intValue();
+                        break;
+                    case FLOAT:
+                        value = n.floatValue();
+                        break;
+                }
             }
-        }
 
-        if (!index.getType().getDataType().isAssignableFrom(value.getClass())) {
-            throw new IllegalArgumentException("Cannot assign " + value + " to " + index + ", expects " + index.getType());
-        }
+            if (!index.getType().getDataType().isAssignableFrom(value.getClass())) {
+                throw new IllegalArgumentException("Cannot assign " + value + " to " + index + ", expects " + index.getType());
+            }
 
-        if (!index.appliesTo(entityClass)) {
-            throw new IllegalArgumentException("Index " + index + " does not apply to " + entityClass.getSimpleName() + ", only " + index.getAppliesTo().getSimpleName());
+            if (!index.appliesTo(entityClass)) {
+                throw new IllegalArgumentException("Index " + index + " does not apply to " + entityClass.getSimpleName() + ", only " + index.getAppliesTo().getSimpleName());
+            }
         }
 
         Object prev = map.put(index, value);

--- a/src/main/java/net/glowstone/entity/meta/MetadataType.java
+++ b/src/main/java/net/glowstone/entity/meta/MetadataType.java
@@ -11,24 +11,26 @@ import java.util.UUID;
  * The types of values that entity metadata can contain.
  */
 public enum MetadataType {
-    BYTE(Byte.class),
-    INT(Integer.class),
-    FLOAT(Float.class),
-    STRING(String.class),
-    CHAT(TextMessage.class),
-    ITEM(ItemStack.class),
-    BOOLEAN(Boolean.class),
-    VECTOR(EulerAngle.class),
-    POSITION(BlockVector.class),
-    OPTPOSITION(BlockVector.class),
-    DIRECTION(Integer.class),
-    OPTUUID(UUID.class),
-    BLOCKID(Integer.class);
+    BYTE(Byte.class, false),
+    INT(Integer.class, false),
+    FLOAT(Float.class, false),
+    STRING(String.class, false),
+    CHAT(TextMessage.class, false),
+    ITEM(ItemStack.class, false),
+    BOOLEAN(Boolean.class, false),
+    VECTOR(EulerAngle.class, false),
+    POSITION(BlockVector.class, false),
+    OPTPOSITION(BlockVector.class, true),
+    DIRECTION(Integer.class, false),
+    OPTUUID(UUID.class, true),
+    BLOCKID(Integer.class, false);
 
     private final Class<?> dataType;
+    private final boolean optional;
 
-    MetadataType(Class<?> dataType) {
+    MetadataType(Class<?> dataType, boolean optional) {
         this.dataType = dataType;
+        this.optional = optional;
     }
 
     public static MetadataType byId(int id) {
@@ -41,5 +43,9 @@ public enum MetadataType {
 
     public int getId() {
         return ordinal();
+    }
+
+    public boolean isOptional() {
+        return optional;
     }
 }

--- a/src/main/java/net/glowstone/entity/meta/MetadataType.java
+++ b/src/main/java/net/glowstone/entity/meta/MetadataType.java
@@ -1,8 +1,8 @@
 package net.glowstone.entity.meta;
 
 import net.glowstone.util.TextMessage;
-import org.bukkit.Location;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.BlockVector;
 import org.bukkit.util.EulerAngle;
 
 import java.util.UUID;
@@ -19,8 +19,8 @@ public enum MetadataType {
     ITEM(ItemStack.class),
     BOOLEAN(Boolean.class),
     VECTOR(EulerAngle.class),
-    POSITION(Location.class),
-    OPTPOSITION(Location.class),
+    POSITION(BlockVector.class),
+    OPTPOSITION(BlockVector.class),
     DIRECTION(Integer.class),
     OPTUUID(UUID.class),
     BLOCKID(Integer.class);

--- a/src/main/java/net/glowstone/entity/meta/MetadataType.java
+++ b/src/main/java/net/glowstone/entity/meta/MetadataType.java
@@ -1,7 +1,7 @@
 package net.glowstone.entity.meta;
 
-import net.glowstone.util.Position;
 import net.glowstone.util.TextMessage;
+import org.bukkit.Location;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.EulerAngle;
 
@@ -19,8 +19,8 @@ public enum MetadataType {
     ITEM(ItemStack.class),
     BOOLEAN(Boolean.class),
     VECTOR(EulerAngle.class),
-    POSITION(Position.class),
-    OPTPOSITION(Position.class),
+    POSITION(Location.class),
+    OPTPOSITION(Location.class),
     DIRECTION(Integer.class),
     OPTUUID(UUID.class),
     BLOCKID(Integer.class);

--- a/src/main/java/net/glowstone/entity/monster/GlowGuardian.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowGuardian.java
@@ -1,13 +1,12 @@
 package net.glowstone.entity.monster;
 
+import net.glowstone.entity.meta.MetadataIndex;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Guardian;
 
 public class GlowGuardian extends GlowMonster implements Guardian {
-
-    private boolean elder;
 
     public GlowGuardian(Location loc) {
         super(loc, EntityType.GUARDIAN, 30);
@@ -16,12 +15,12 @@ public class GlowGuardian extends GlowMonster implements Guardian {
 
     @Override
     public boolean isElder() {
-        return elder;
+        return metadata.getBit(MetadataIndex.GUARDIAN_FLAGS, 0x04);
     }
 
     @Override
-    public void setElder(boolean shouldBeElder) {
-        elder = shouldBeElder;
+    public void setElder(boolean elder) {
+        metadata.setBit(MetadataIndex.GUARDIAN_FLAGS, 0x04, elder);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/monster/GlowShulker.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowShulker.java
@@ -1,0 +1,65 @@
+package net.glowstone.entity.monster;
+
+import net.glowstone.entity.meta.MetadataIndex;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Shulker;
+
+public class GlowShulker extends GlowMonster implements Shulker {
+
+    private Facing direction;
+    private byte height;
+    private Location attachment;
+
+    public GlowShulker(Location loc) {
+        super(loc, EntityType.SHULKER, 30);
+        setDirection(Facing.DOWN); // todo
+        setHeight((byte) 0);
+        setAttachment(null); // todo
+    }
+
+    public Facing getFacingDirection() {
+        return direction;
+    }
+
+    public void setDirection(Facing direction) {
+        this.direction = direction;
+        this.metadata.set(MetadataIndex.SHULKER_FACING_DIRECTION, direction.ordinal());
+    }
+
+    public byte getHeight() {
+        return height;
+    }
+
+    public void setHeight(byte height) {
+        this.height = height;
+        this.metadata.set(MetadataIndex.SHULKER_SHIELD_HEIGHT, height);
+    }
+
+    public Location getAttachment() {
+        return attachment;
+    }
+
+    public void setAttachment(Location attachment) {
+        this.attachment = attachment;
+        this.metadata.set(MetadataIndex.SHULKER_ATTACHMENT_POSITION, attachment);
+    }
+
+    @Override
+    protected Sound getDeathSound() {
+        return Sound.ENTITY_SHULKER_DEATH;
+    }
+
+    @Override
+    protected Sound getHurtSound() {
+        if (height == 0) {
+            return Sound.ENTITY_SHULKER_HURT_CLOSED;
+        }
+        return Sound.ENTITY_SHULKER_HURT;
+    }
+
+    public enum Facing {
+        DOWN, UP, NORTH, SOUTH, WEST, EAST
+    }
+}

--- a/src/main/java/net/glowstone/entity/monster/GlowShulker.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowShulker.java
@@ -5,6 +5,7 @@ import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Shulker;
+import org.bukkit.util.BlockVector;
 
 public class GlowShulker extends GlowMonster implements Shulker {
 
@@ -43,7 +44,7 @@ public class GlowShulker extends GlowMonster implements Shulker {
 
     public void setAttachment(Location attachment) {
         this.attachment = attachment;
-        this.metadata.set(MetadataIndex.SHULKER_ATTACHMENT_POSITION, attachment);
+        this.metadata.set(MetadataIndex.SHULKER_ATTACHMENT_POSITION, new BlockVector(attachment.toVector()));
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/monster/GlowShulker.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowShulker.java
@@ -44,7 +44,11 @@ public class GlowShulker extends GlowMonster implements Shulker {
 
     public void setAttachment(Location attachment) {
         this.attachment = attachment;
-        this.metadata.set(MetadataIndex.SHULKER_ATTACHMENT_POSITION, new BlockVector(attachment.toVector()));
+        if (attachment != null) {
+            this.metadata.set(MetadataIndex.SHULKER_ATTACHMENT_POSITION, new BlockVector(attachment.toVector()));
+        } else {
+            this.metadata.set(MetadataIndex.SHULKER_ATTACHMENT_POSITION, null);
+        }
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/monster/GlowWither.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowWither.java
@@ -17,10 +17,11 @@ public class GlowWither extends GlowMonster implements Wither {
 
     public GlowWither(Location loc) {
         super(loc, EntityType.WITHER, 300);
-        setInvulnerableTicks(100);
+        setInvulnerableTicks(220);
         setCenterTarget(null);
         setLeftTarget(null);
         setRightTarget(null);
+        setHealth(getMaxHealth() / 3);
     }
 
     @Override
@@ -72,12 +73,17 @@ public class GlowWither extends GlowMonster implements Wither {
         super.pulse();
         if (getInvulnerableTicks() > 0) {
             setInvulnerableTicks(getInvulnerableTicks() - 1);
-            if (getInvulnerableTicks() == 0) {
+            if (ticksLived % 10 == 0) {
+                setHealth(getHealth() + 10);
+            }
+            if (getInvulnerableTicks() == 1) {
                 getWorld().createExplosion(getLocation(), Explosion.POWER_WITHER_CREATION);
                 for (Player player : getServer().getOnlinePlayers()) {
                     player.playSound(player.getLocation(), Sound.ENTITY_WITHER_SPAWN, 1.0f, 1.0f);
                 }
             }
+        } else if (ticksLived % 20 == 0) {
+            setHealth(getHealth() + 1);
         }
     }
 

--- a/src/main/java/net/glowstone/entity/monster/GlowWither.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowWither.java
@@ -1,0 +1,93 @@
+package net.glowstone.entity.monster;
+
+import net.glowstone.Explosion;
+import net.glowstone.entity.meta.MetadataIndex;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Wither;
+import org.bukkit.event.entity.EntityDamageEvent;
+
+public class GlowWither extends GlowMonster implements Wither {
+
+    private int invulnerableTicks;
+    private Entity centerTarget, leftTarget, rightTarget;
+
+    public GlowWither(Location loc) {
+        super(loc, EntityType.WITHER, 300);
+        setInvulnerableTicks(100);
+        setCenterTarget(null);
+        setLeftTarget(null);
+        setRightTarget(null);
+    }
+
+    @Override
+    public void damage(double amount, Entity source, EntityDamageEvent.DamageCause cause) {
+        if (invulnerableTicks > 0) {
+            return;
+        }
+        super.damage(amount, source, cause);
+    }
+
+    public int getInvulnerableTicks() {
+        return invulnerableTicks;
+    }
+
+    public void setInvulnerableTicks(int invulnerableTicks) {
+        this.invulnerableTicks = invulnerableTicks;
+        this.metadata.set(MetadataIndex.WITHER_INVULN_TIME, invulnerableTicks);
+    }
+
+    public Entity getCenterTarget() {
+        return centerTarget;
+    }
+
+    public void setCenterTarget(Entity centerTarget) {
+        this.centerTarget = centerTarget;
+        this.metadata.set(MetadataIndex.WITHER_TARGET_1, centerTarget == null ? 0 : centerTarget.getEntityId());
+    }
+
+    public Entity getLeftTarget() {
+        return leftTarget;
+    }
+
+    public void setLeftTarget(Entity leftTarget) {
+        this.leftTarget = leftTarget;
+        this.metadata.set(MetadataIndex.WITHER_TARGET_2, leftTarget == null ? 0 : leftTarget.getEntityId());
+    }
+
+    public Entity getRightTarget() {
+        return rightTarget;
+    }
+
+    public void setRightTarget(Entity rightTarget) {
+        this.rightTarget = rightTarget;
+        this.metadata.set(MetadataIndex.WITHER_TARGET_3, rightTarget == null ? 0 : rightTarget.getEntityId());
+    }
+
+    @Override
+    public void pulse() {
+        super.pulse();
+        if (getInvulnerableTicks() > 0) {
+            setInvulnerableTicks(getInvulnerableTicks() - 1);
+            if (getInvulnerableTicks() == 0) {
+                getWorld().createExplosion(getLocation(), Explosion.POWER_WITHER_CREATION);
+                for (Player player : getServer().getOnlinePlayers()) {
+                    player.playSound(player.getLocation(), Sound.ENTITY_WITHER_SPAWN, 1.0f, 1.0f);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected Sound getHurtSound() {
+        return Sound.ENTITY_WITHER_HURT;
+    }
+
+    @Override
+    protected Sound getDeathSound() {
+        return Sound.ENTITY_WITHER_DEATH;
+    }
+}

--- a/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
@@ -1,0 +1,294 @@
+package net.glowstone.entity.objects;
+
+import com.flowpowered.network.Message;
+import net.glowstone.entity.GlowEntity;
+import net.glowstone.entity.GlowPlayer;
+import net.glowstone.inventory.GlowInventory;
+import net.glowstone.net.message.play.entity.SpawnObjectMessage;
+import net.glowstone.net.message.play.player.InteractEntityMessage;
+import net.glowstone.util.Position;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Minecart;
+import org.bukkit.entity.minecart.*;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.material.MaterialData;
+import org.bukkit.util.Vector;
+
+import java.util.Collections;
+import java.util.List;
+
+public abstract class GlowMinecart extends GlowEntity implements Minecart {
+
+    private final MinecartType type;
+
+    public GlowMinecart(Location location, MinecartType type) {
+        super(location);
+        this.type = type;
+    }
+
+    @Override
+    public List<Message> createSpawnMessage() {
+        double x = location.getX();
+        double y = location.getY();
+        double z = location.getZ();
+
+        int yaw = Position.getIntYaw(location);
+        int pitch = Position.getIntPitch(location);
+
+        return Collections.singletonList(new SpawnObjectMessage(id, getUniqueId(), 10, x, y, z, pitch, yaw, type.ordinal()));
+    }
+
+    @Override
+    public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
+        if (message.getAction() == InteractEntityMessage.Action.ATTACK.ordinal()) {
+            // todo: damage points
+            if (this instanceof InventoryHolder) {
+                InventoryHolder inv = (InventoryHolder) this;
+                if (inv.getInventory() != null) {
+                    for (ItemStack drop : inv.getInventory().getContents()) {
+                        if (drop == null || drop.getType() == Material.AIR || drop.getAmount() < 1) {
+                            continue;
+                        }
+                        GlowItem item = world.dropItemNaturally(getLocation(), drop);
+                        item.setPickupDelay(30);
+                        item.setBias(player);
+                    }
+                }
+            }
+            remove();
+        }
+        return true;
+    }
+
+    @Override
+    public void _INVALID_setDamage(int i) {
+
+    }
+
+    @Override
+    public void setDamage(double v) {
+
+    }
+
+    @Override
+    public int _INVALID_getDamage() {
+        return 0;
+    }
+
+    @Override
+    public double getDamage() {
+        return 0;
+    }
+
+    @Override
+    public double getMaxSpeed() {
+        return 0;
+    }
+
+    @Override
+    public void setMaxSpeed(double v) {
+
+    }
+
+    @Override
+    public boolean isSlowWhenEmpty() {
+        return false;
+    }
+
+    @Override
+    public void setSlowWhenEmpty(boolean b) {
+
+    }
+
+    @Override
+    public Vector getFlyingVelocityMod() {
+        return null;
+    }
+
+    @Override
+    public void setFlyingVelocityMod(Vector vector) {
+
+    }
+
+    @Override
+    public Vector getDerailedVelocityMod() {
+        return null;
+    }
+
+    @Override
+    public void setDerailedVelocityMod(Vector vector) {
+
+    }
+
+    @Override
+    public void setDisplayBlock(MaterialData materialData) {
+
+    }
+
+    @Override
+    public MaterialData getDisplayBlock() {
+        return null;
+    }
+
+    @Override
+    public void setDisplayBlockOffset(int i) {
+
+    }
+
+    @Override
+    public int getDisplayBlockOffset() {
+        return 0;
+    }
+
+    @Override
+    public void setGlowing(boolean b) {
+
+    }
+
+    @Override
+    public boolean isGlowing() {
+        return false;
+    }
+
+    @Override
+    public void setInvulnerable(boolean b) {
+
+    }
+
+    @Override
+    public boolean isInvulnerable() {
+        return false;
+    }
+
+    @Override
+    public Location getOrigin() {
+        return null;
+    }
+
+    public MinecartType getMinecartType() {
+        return type;
+    }
+
+    public enum MinecartType {
+        RIDEABLE(Rideable.class, "MinecartRideable", RideableMinecart.class),
+        CHEST(Storage.class, "MinecartChest", StorageMinecart.class),
+        FURNACE(Powered.class, "MinecartFurnace", PoweredMinecart.class),
+        TNT(Explosive.class, "MinecartTNT", ExplosiveMinecart.class),
+        SPAWNER(null, "MinecartSpawner", SpawnerMinecart.class), // todo
+        HOPPER(Hopper.class, "MinecartHopper", HopperMinecart.class),
+        COMMAND(null, "MinecartCommandBlock", CommandMinecart.class); // todo
+
+        private final Class<? extends GlowMinecart> clazz;
+        private final String name;
+        private final Class<? extends Minecart> entityClass;
+
+        MinecartType(Class<? extends GlowMinecart> clazz, String name, Class<? extends Minecart> entityClass) {
+            this.clazz = clazz;
+            this.name = name;
+            this.entityClass = entityClass;
+        }
+
+        public Class<? extends GlowMinecart> getMinecartClass() {
+            return clazz;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Class<? extends Minecart> getEntityClass() {
+            return entityClass;
+        }
+    }
+
+    public static class Rideable extends GlowMinecart implements RideableMinecart {
+        public Rideable(Location location) {
+            super(location, MinecartType.RIDEABLE);
+        }
+
+        @Override
+        public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
+            super.entityInteract(player, message);
+            if (message.getAction() != InteractEntityMessage.Action.INTERACT.ordinal()) {
+                return false;
+            }
+            if (player.isSneaking()) {
+                return false;
+            }
+            if (isEmpty()) {
+                // todo: fix passengers
+                // setPassenger(player);
+                return true;
+            }
+            return false;
+        }
+    }
+
+    public static class Storage extends GlowMinecart implements StorageMinecart {
+
+        private Inventory inventory;
+
+        public Storage(Location location) {
+            super(location, MinecartType.CHEST);
+            inventory = new GlowInventory(this, InventoryType.CHEST);
+        }
+
+        @Override
+        public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
+            super.entityInteract(player, message);
+            if (message.getAction() != InteractEntityMessage.Action.INTERACT.ordinal()) {
+                return false;
+            }
+            if (player.isSneaking()) {
+                return false;
+            }
+            player.openInventory(inventory);
+            return true;
+        }
+
+        @Override
+        public Inventory getInventory() {
+            return inventory;
+        }
+    }
+
+    public static class Powered extends GlowMinecart implements PoweredMinecart {
+        public Powered(Location location) {
+            super(location, MinecartType.FURNACE);
+        }
+    }
+
+    public static class Explosive extends GlowMinecart implements ExplosiveMinecart {
+        public Explosive(Location location) {
+            super(location, MinecartType.TNT);
+        }
+    }
+
+    public static class Hopper extends GlowMinecart implements HopperMinecart {
+
+        private boolean enabled = true;
+
+        public Hopper(Location location) {
+            super(location, MinecartType.HOPPER);
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        @Override
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        @Override
+        public Inventory getInventory() {
+            return null;
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
@@ -178,7 +178,7 @@ public abstract class GlowMinecart extends GlowEntity implements Minecart {
         CHEST(Storage.class, "MinecartChest", StorageMinecart.class),
         FURNACE(Powered.class, "MinecartFurnace", PoweredMinecart.class),
         TNT(Explosive.class, "MinecartTNT", ExplosiveMinecart.class),
-        SPAWNER(null, "MinecartSpawner", SpawnerMinecart.class), // todo
+        SPAWNER(Spawner.class, "MinecartMobSpawner", SpawnerMinecart.class),
         HOPPER(Hopper.class, "MinecartHopper", HopperMinecart.class),
         COMMAND(null, "MinecartCommandBlock", CommandMinecart.class); // todo
 
@@ -230,11 +230,11 @@ public abstract class GlowMinecart extends GlowEntity implements Minecart {
 
     public static class Storage extends GlowMinecart implements StorageMinecart {
 
-        private Inventory inventory;
+        private final Inventory inventory;
 
         public Storage(Location location) {
             super(location, MinecartType.CHEST);
-            inventory = new GlowInventory(this, InventoryType.CHEST);
+            inventory = new GlowInventory(this, InventoryType.CHEST, InventoryType.CHEST.getDefaultSize(), "Minecart with Chest");
         }
 
         @Override
@@ -271,11 +271,11 @@ public abstract class GlowMinecart extends GlowEntity implements Minecart {
     public static class Hopper extends GlowMinecart implements HopperMinecart {
 
         private boolean enabled = true;
-        private Inventory inventory;
+        private final Inventory inventory;
 
         public Hopper(Location location) {
             super(location, MinecartType.HOPPER);
-            inventory = new GlowInventory(this, InventoryType.HOPPER);
+            inventory = new GlowInventory(this, InventoryType.HOPPER, InventoryType.HOPPER.getDefaultSize(), "Minecart with Hopper");
         }
 
         @Override
@@ -291,6 +291,25 @@ public abstract class GlowMinecart extends GlowEntity implements Minecart {
         @Override
         public Inventory getInventory() {
             return inventory;
+        }
+
+        @Override
+        public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
+            super.entityInteract(player, message);
+            if (message.getAction() != InteractEntityMessage.Action.INTERACT.ordinal()) {
+                return false;
+            }
+            if (player.isSneaking()) {
+                return false;
+            }
+            player.openInventory(inventory);
+            return true;
+        }
+    }
+
+    public static class Spawner extends GlowMinecart implements SpawnerMinecart {
+        public Spawner(Location location) {
+            super(location, MinecartType.SPAWNER);
         }
     }
 }

--- a/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
@@ -271,9 +271,11 @@ public abstract class GlowMinecart extends GlowEntity implements Minecart {
     public static class Hopper extends GlowMinecart implements HopperMinecart {
 
         private boolean enabled = true;
+        private Inventory inventory;
 
         public Hopper(Location location) {
             super(location, MinecartType.HOPPER);
+            inventory = new GlowInventory(this, InventoryType.HOPPER);
         }
 
         @Override
@@ -288,7 +290,7 @@ public abstract class GlowMinecart extends GlowEntity implements Minecart {
 
         @Override
         public Inventory getInventory() {
-            return null;
+            return inventory;
         }
     }
 }

--- a/src/main/java/net/glowstone/entity/passive/GlowVillager.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowVillager.java
@@ -32,7 +32,7 @@ public class GlowVillager extends GlowAgeable implements Villager {
     @Override
     public void setProfession(Profession profession) {
         this.profession = profession;
-        metadata.set(MetadataIndex.VILLAGER_TYPE, profession.ordinal() - 1);
+        metadata.set(MetadataIndex.VILLAGER_PROFESSION, profession.ordinal() - 1);
     }
 
     @Override

--- a/src/main/java/net/glowstone/io/entity/EntityStorage.java
+++ b/src/main/java/net/glowstone/io/entity/EntityStorage.java
@@ -3,6 +3,7 @@ package net.glowstone.io.entity;
 import net.glowstone.GlowWorld;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.monster.*;
+import net.glowstone.entity.objects.GlowMinecart;
 import net.glowstone.entity.passive.GlowCow;
 import net.glowstone.entity.passive.GlowMooshroom;
 import net.glowstone.entity.passive.GlowPolarBear;
@@ -81,6 +82,11 @@ public final class EntityStorage {
         bind(new ItemFrameStore());
         bind(new ItemStore());
         bind(new TNTPrimedStorage());
+        for (GlowMinecart.MinecartType type : GlowMinecart.MinecartType.values()) {
+            if (type != null) {
+                bind(new MinecartStore(type));
+            }
+        }
     }
 
     private EntityStorage() {

--- a/src/main/java/net/glowstone/io/entity/EntityStorage.java
+++ b/src/main/java/net/glowstone/io/entity/EntityStorage.java
@@ -72,6 +72,7 @@ public final class EntityStorage {
         bind(new MonsterStore<>(GlowGiant.class, "Giant"));
         bind(new MonsterStore<>(GlowSilverfish.class, "Silverfish"));
         bind(new MonsterStore<>(GlowWitch.class, "Witch"));
+        bind(new ShulkerStore());
 
 
         bind(new ArmorStandStore());

--- a/src/main/java/net/glowstone/io/entity/EntityStorage.java
+++ b/src/main/java/net/glowstone/io/entity/EntityStorage.java
@@ -73,6 +73,7 @@ public final class EntityStorage {
         bind(new MonsterStore<>(GlowSilverfish.class, "Silverfish"));
         bind(new MonsterStore<>(GlowWitch.class, "Witch"));
         bind(new ShulkerStore());
+        bind(new WitherStore());
 
 
         bind(new ArmorStandStore());

--- a/src/main/java/net/glowstone/io/entity/GuardianStore.java
+++ b/src/main/java/net/glowstone/io/entity/GuardianStore.java
@@ -12,12 +12,7 @@ class GuardianStore extends MonsterStore<GlowGuardian> {
     @Override
     public void load(GlowGuardian entity, CompoundTag compound) {
         super.load(entity, compound);
-        if (compound.isByte("Elder")) {
-            entity.setElder(compound.getBool("Elder"));
-        } else {
-            entity.setElder(false);
-        }
-
+        entity.setElder(compound.getBool("Elder"));
     }
 
     @Override

--- a/src/main/java/net/glowstone/io/entity/MinecartStore.java
+++ b/src/main/java/net/glowstone/io/entity/MinecartStore.java
@@ -1,0 +1,55 @@
+package net.glowstone.io.entity;
+
+import net.glowstone.entity.objects.GlowMinecart;
+import net.glowstone.io.nbt.NbtSerialization;
+import net.glowstone.util.nbt.CompoundTag;
+import org.bukkit.Location;
+import org.bukkit.inventory.InventoryHolder;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+public class MinecartStore extends EntityStore<GlowMinecart> {
+
+    private GlowMinecart.MinecartType type;
+
+    public MinecartStore(GlowMinecart.MinecartType type) {
+        super((Class<GlowMinecart>) type.getMinecartClass(), type.getName());
+        this.type = type;
+    }
+
+    @Override
+    public GlowMinecart createEntity(Location location, CompoundTag compound) {
+        try {
+            Constructor<? extends GlowMinecart> constructor = type.getMinecartClass().getConstructor(Location.class);
+            return constructor.newInstance(location);
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override
+    public void load(GlowMinecart entity, CompoundTag tag) {
+        super.load(entity, tag);
+        if (entity instanceof InventoryHolder) {
+            InventoryHolder inv = (InventoryHolder) entity;
+            if (inv.getInventory() != null) {
+                inv.getInventory().setContents(NbtSerialization.readInventory(tag.getCompoundList("Items"), 0, inv.getInventory().getSize()));
+            }
+        }
+        // todo
+    }
+
+    @Override
+    public void save(GlowMinecart entity, CompoundTag tag) {
+        super.save(entity, tag);
+        if (entity instanceof InventoryHolder) {
+            InventoryHolder inv = (InventoryHolder) entity;
+            if (inv.getInventory() != null) {
+                tag.putCompoundList("Items", NbtSerialization.writeInventory(inv.getInventory().getContents(), 0));
+            }
+        }
+        // todo
+    }
+}

--- a/src/main/java/net/glowstone/io/entity/ShulkerStore.java
+++ b/src/main/java/net/glowstone/io/entity/ShulkerStore.java
@@ -1,0 +1,31 @@
+package net.glowstone.io.entity;
+
+import net.glowstone.entity.monster.GlowShulker;
+import net.glowstone.util.nbt.CompoundTag;
+
+public class ShulkerStore extends MonsterStore<GlowShulker> {
+    public ShulkerStore() {
+        super(GlowShulker.class, "Shulker");
+    }
+
+    @Override
+    public void load(GlowShulker entity, CompoundTag tag) {
+        super.load(entity, tag);
+        if (tag.isByte("Peek")) {
+            entity.setHeight(tag.getByte("Peek"));
+        }
+        if (tag.isByte("AttachFace")) {
+            entity.setDirection(GlowShulker.Facing.values()[tag.getByte("AttachFace")]);
+        }
+    }
+
+    @Override
+    public void save(GlowShulker entity, CompoundTag tag) {
+        super.save(entity, tag);
+        tag.putByte("Peek", entity.getHeight());
+        tag.putByte("AttachFace", entity.getFacingDirection().ordinal());
+        tag.putInt("APX", entity.getLocation().getBlockX());
+        tag.putInt("APY", entity.getLocation().getBlockY());
+        tag.putInt("APZ", entity.getLocation().getBlockZ());
+    }
+}

--- a/src/main/java/net/glowstone/io/entity/WitherStore.java
+++ b/src/main/java/net/glowstone/io/entity/WitherStore.java
@@ -1,0 +1,22 @@
+package net.glowstone.io.entity;
+
+import net.glowstone.entity.monster.GlowWither;
+import net.glowstone.util.nbt.CompoundTag;
+
+public class WitherStore extends MonsterStore<GlowWither> {
+    public WitherStore() {
+        super(GlowWither.class, "WitherBoss");
+    }
+
+    @Override
+    public void load(GlowWither entity, CompoundTag tag) {
+        super.load(entity, tag);
+        entity.setInvulnerableTicks(tag.getInt("Invul"));
+    }
+
+    @Override
+    public void save(GlowWither entity, CompoundTag tag) {
+        super.save(entity, tag);
+        tag.putInt("Invul", entity.getInvulnerableTicks());
+    }
+}

--- a/src/main/java/net/glowstone/net/GlowBufUtils.java
+++ b/src/main/java/net/glowstone/net/GlowBufUtils.java
@@ -14,6 +14,7 @@ import net.glowstone.util.nbt.CompoundTag;
 import net.glowstone.util.nbt.NBTInputStream;
 import net.glowstone.util.nbt.NBTOutputStream;
 import net.glowstone.util.nbt.NBTReadLimiter;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.BlockVector;
@@ -144,11 +145,17 @@ public final class GlowBufUtils {
                     buf.writeFloat((float) Math.toDegrees(angle.getZ()));
                     break;
                 case POSITION:
+                    {
+                        Location location = (Location) value;
+                        long position = ((location.getBlockX() & 0x3FFFFFF) << 38) | ((location.getBlockY() & 0xFFF) << 26) | (location.getBlockZ() & 0x3FFFFFF);
+                        buf.writeLong(position);
+                    }
                     break; //TODO
                 case OPTPOSITION:
-                    buf.writeBoolean(value != null);
                     if (value != null) {
-                        //TODO
+                        Location location = (Location) value;
+                        long position = ((location.getBlockX() & 0x3FFFFFF) << 38) | ((location.getBlockY() & 0xFFF) << 26) | (location.getBlockZ() & 0x3FFFFFF);
+                        buf.writeLong(position);
                     }
                     break;
                 case DIRECTION:
@@ -157,7 +164,6 @@ public final class GlowBufUtils {
                 case OPTUUID:
                     buf.writeBoolean(value != null);
                     if (value != null) {
-
                         writeUuid(buf, (UUID) value);
                     }
                     break;

--- a/src/main/java/net/glowstone/net/GlowBufUtils.java
+++ b/src/main/java/net/glowstone/net/GlowBufUtils.java
@@ -106,12 +106,20 @@ public final class GlowBufUtils {
             MetadataIndex index = entry.index;
             Object value = entry.value;
 
-            if (value == null) continue;
-
             int type = index.getType().getId();
             int id = index.getIndex();
             buf.writeByte(id);
             buf.writeByte(type);
+
+            if (!index.getType().isOptional() && value == null) {
+                continue;
+            }
+            if (index.getType().isOptional()) {
+                buf.writeBoolean(value != null);
+                if (value == null) {
+                    continue;
+                }
+            }
 
             switch (index.getType()) {
                 case BYTE:
@@ -142,25 +150,15 @@ public final class GlowBufUtils {
                     buf.writeFloat((float) Math.toDegrees(angle.getZ()));
                     break;
                 case POSITION:
-                    {
-                        BlockVector vector = (BlockVector) value;
-                        buf.writeLong(Position.getPosition(vector));
-                    }
-                    break; //TODO
                 case OPTPOSITION:
-                    if (value != null) {
-                        BlockVector vector = (BlockVector) value;
-                        buf.writeLong(Position.getPosition(vector));
-                    }
+                    BlockVector vector = (BlockVector) value;
+                    buf.writeLong(Position.getPosition(vector));
                     break;
                 case DIRECTION:
                     ByteBufUtils.writeVarInt(buf, (Integer) value);
                     break;
                 case OPTUUID:
-                    buf.writeBoolean(value != null);
-                    if (value != null) {
-                        writeUuid(buf, (UUID) value);
-                    }
+                    writeUuid(buf, (UUID) value);
                     break;
                 case BLOCKID:
                     ByteBufUtils.writeVarInt(buf, (Integer) value);

--- a/src/main/java/net/glowstone/net/GlowBufUtils.java
+++ b/src/main/java/net/glowstone/net/GlowBufUtils.java
@@ -9,12 +9,12 @@ import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.entity.meta.MetadataMap.Entry;
 import net.glowstone.entity.meta.MetadataType;
 import net.glowstone.inventory.GlowItemFactory;
+import net.glowstone.util.Position;
 import net.glowstone.util.TextMessage;
 import net.glowstone.util.nbt.CompoundTag;
 import net.glowstone.util.nbt.NBTInputStream;
 import net.glowstone.util.nbt.NBTOutputStream;
 import net.glowstone.util.nbt.NBTReadLimiter;
-import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.BlockVector;
@@ -76,11 +76,8 @@ public final class GlowBufUtils {
                     entries.add(new MetadataMap.Entry(index, new EulerAngle(x, y, z)));
                     break;
                 case POSITION:
-                    break; //TODO
                 case OPTPOSITION:
-                    if (buf.readBoolean()) {
-                        //TODO
-                    }
+                    entries.add(new Entry(index, Position.getPosition(buf.readLong())));
                     break;
                 case DIRECTION:
                     entries.add(new Entry(index, ByteBufUtils.readVarInt(buf)));
@@ -146,16 +143,14 @@ public final class GlowBufUtils {
                     break;
                 case POSITION:
                     {
-                        Location location = (Location) value;
-                        long position = ((location.getBlockX() & 0x3FFFFFF) << 38) | ((location.getBlockY() & 0xFFF) << 26) | (location.getBlockZ() & 0x3FFFFFF);
-                        buf.writeLong(position);
+                        BlockVector vector = (BlockVector) value;
+                        buf.writeLong(Position.getPosition(vector));
                     }
                     break; //TODO
                 case OPTPOSITION:
                     if (value != null) {
-                        Location location = (Location) value;
-                        long position = ((location.getBlockX() & 0x3FFFFFF) << 38) | ((location.getBlockY() & 0xFFF) << 26) | (location.getBlockZ() & 0x3FFFFFF);
-                        buf.writeLong(position);
+                        BlockVector vector = (BlockVector) value;
+                        buf.writeLong(Position.getPosition(vector));
                     }
                     break;
                 case DIRECTION:

--- a/src/main/java/net/glowstone/util/Position.java
+++ b/src/main/java/net/glowstone/util/Position.java
@@ -3,6 +3,7 @@ package net.glowstone.util;
 import com.google.common.collect.ImmutableList;
 import org.bukkit.Location;
 import org.bukkit.block.BlockFace;
+import org.bukkit.util.BlockVector;
 
 import java.util.List;
 
@@ -121,4 +122,21 @@ public final class Position {
         return (byte) ROTATIONS.indexOf(rotation);
     }
 
+    /**
+     * Gets the serialized position value for a block vector.
+     * @param vector the block vector to serialize
+     * @return the serialized position value
+     */
+    public static long getPosition(BlockVector vector) {
+        return ((vector.getBlockX() & 0x3FFFFFF) << 38) | ((vector.getBlockY() & 0xFFF) << 26) | (vector.getBlockZ() & 0x3FFFFFF);
+    }
+
+    /**
+     * Decodes the block vector from a serialized position value.
+     * @param position the position to decode
+     * @return the decoded block vector
+     */
+    public static BlockVector getPosition(long position) {
+        return new BlockVector(position >> 38, (position >> 26) & 0xFFF, position << 38 >> 38);
+    }
 }

--- a/src/main/java/net/glowstone/util/nbt/CompoundTag.java
+++ b/src/main/java/net/glowstone/util/nbt/CompoundTag.java
@@ -63,35 +63,59 @@ public final class CompoundTag extends Tag<Map<String, Tag>> {
     // Simple gets
 
     public boolean getBool(String key) {
-        if (isInt(key)) {
-            int val = get(key, IntTag.class);
-            remove(key);
-            putByte(key, val);
+        if (!containsKey(key)) {
+            return false;
         }
-        return get(key, ByteTag.class) != 0;
+        return getByte(key) != 0;
     }
 
     public byte getByte(String key) {
+        if (isInt(key)) {
+            return (byte) getInt(key);
+        }
         return get(key, ByteTag.class);
     }
 
     public short getShort(String key) {
+        if (isInt(key)) {
+            return (short) getInt(key);
+        }
         return get(key, ShortTag.class);
     }
 
     public int getInt(String key) {
+        if (isByte(key)) {
+            return (int) getByte(key);
+        } else if (isShort(key)) {
+            return (int) getShort(key);
+        } else if (isLong(key)) {
+            return (int) getLong(key);
+        }
         return get(key, IntTag.class);
     }
 
     public long getLong(String key) {
+        if (isInt(key)) {
+            return (long) getInt(key);
+        }
         return get(key, LongTag.class);
     }
 
     public float getFloat(String key) {
+        if (isDouble(key)) {
+            return (float) getDouble(key);
+        } else if (isInt(key)) {
+            return (float) getInt(key);
+        }
         return get(key, FloatTag.class);
     }
 
     public double getDouble(String key) {
+        if (isFloat(key)) {
+            return (double) getFloat(key);
+        } else if (isInt(key)) {
+            return (double) getInt(key);
+        }
         return get(key, DoubleTag.class);
     }
 

--- a/src/main/java/net/glowstone/util/pattern/BlockPattern.java
+++ b/src/main/java/net/glowstone/util/pattern/BlockPattern.java
@@ -1,6 +1,5 @@
 package net.glowstone.util.pattern;
 
-import net.glowstone.GlowServer;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -76,9 +75,7 @@ public class BlockPattern {
         }
 
         public boolean matches(Block block) {
-            boolean b = block.getType() == getType() && block.getData() == getData();
-            GlowServer.logger.info(b + " - " + toString() + " vs " + block.getType() + "/" + block.getData());
-            return b;
+            return block.getType() == getType() && block.getData() == getData();
         }
 
         @Override
@@ -96,7 +93,7 @@ public class BlockPattern {
         }
     }
 
-    public enum Alignment {
+    private enum Alignment {
         X(1, 0), Z(0, 1);
 
         private final int x;

--- a/src/main/java/net/glowstone/util/pattern/BlockPattern.java
+++ b/src/main/java/net/glowstone/util/pattern/BlockPattern.java
@@ -1,0 +1,110 @@
+package net.glowstone.util.pattern;
+
+import net.glowstone.GlowServer;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+
+public class BlockPattern {
+
+    private PatternItem[] blocks;
+
+    public BlockPattern(PatternItem... blocks) {
+        this.blocks = blocks;
+    }
+
+    public PatternItem[] getBlocks() {
+        return blocks;
+    }
+
+    public boolean matches(Location location, boolean clear, int xz, int y) {
+        for (Alignment alignment : Alignment.values()) {
+            Location[] matches = matches(location, xz, y, alignment);
+            if (matches != null) {
+                if (clear) {
+                    for (Location match : matches) {
+                        match.getBlock().setType(Material.AIR);
+                    }
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public Location[] matches(Location location, int xz, int y, Alignment alignment) {
+        int i = 0;
+        Location[] r = new Location[blocks.length];
+        for (PatternItem block : blocks) {
+            int xzDiff = block.xz - xz;
+            int yDiff = block.y - y;
+            Location relative = location.clone().add(xzDiff * alignment.x, -yDiff, xzDiff * alignment.z);
+            if (relative.getBlock().getType() != block.getType() || ((relative.getBlock().getData() != block.getData()) && block.getData() != -1)) {
+                return null;
+            }
+            r[i++] = relative;
+        }
+        return r;
+    }
+
+    public static class PatternItem {
+        private Material type;
+        private byte data;
+        private int xz, y;
+
+        public PatternItem(Material type, byte data, int xz, int y) {
+            this.type = type;
+            this.data = data;
+            this.xz = xz;
+            this.y = y;
+        }
+
+        public Material getType() {
+            return type;
+        }
+
+        public byte getData() {
+            return data;
+        }
+
+        public int getXZ() {
+            return xz;
+        }
+
+        public int getY() {
+            return y;
+        }
+
+        public boolean matches(Block block) {
+            boolean b = block.getType() == getType() && block.getData() == getData();
+            GlowServer.logger.info(b + " - " + toString() + " vs " + block.getType() + "/" + block.getData());
+            return b;
+        }
+
+        @Override
+        public String toString() {
+            return "{xz=" + xz + ",y=" + y + ",type=" + getType() + ",data=" + data + "}";
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj.getClass() != getClass()) {
+                return false;
+            }
+            PatternItem item = (PatternItem) obj;
+            return item.xz == xz && item.y == y && item.type == type && item.data == data;
+        }
+    }
+
+    public enum Alignment {
+        X(1, 0), Z(0, 1);
+
+        private final int x;
+        private final int z;
+
+        Alignment(int x, int z) {
+            this.x = x;
+            this.z = z;
+        }
+    }
+}


### PR DESCRIPTION
Among other things, this aims to implement some missing entity features.
- Shulkers
  - Make them spawnable
  - Save/Load NBT data
  - Send entity metadata values
  - Implement `POSITION` and `OPTPOSITION` data types

---
- Iron Golem & Snowman
  - Make them spawnable via their statue

---
- Wither
  - Make them spawnable via `/summon WitherBoss`
  - Invulnerability state + spawning effect, health regeneration
  - Spawning statue

---
- Guardian
  - Make the Elder guardian state visible via metadata.

---
- Minecarts
  - Implement Rideable, Storage, Furnace, Spawner, Hopper and Explosive minecarts
  - Store inventory for storage & hopper minecarts

---
- Misc
  - Fix `/summon` command from recent changes to spawning API
  - Add tab-completion to `/summon` command
  - Smoothen numerical type compatibility for NBT (e.g. `{Elder:1}` can be accessed as `tag.getByte("Elder");`
  - New _BlockPattern_ "API" - ease-of-use for matching block patterns like entity statues
