### PR TITLE
RegionFile improvements (memory and CPU)

### DIFF
--- a/src/main/java/net/glowstone/io/anvil/RegionFile.java
+++ b/src/main/java/net/glowstone/io/anvil/RegionFile.java
@@ -200,11 +200,11 @@ public class RegionFile {
         if (version == VERSION_GZIP) {
             byte[] data = new byte[length - 1];
             file.read(data);
-            return new DataInputStream(new GZIPInputStream(new ByteArrayInputStream(data), 2 * SECTOR_BYTES));
+            return new DataInputStream(new BufferedInputStream(new GZIPInputStream(new ByteArrayInputStream(data))));
         } else if (version == VERSION_DEFLATE) {
             byte[] data = new byte[length - 1];
             file.read(data);
-            return new DataInputStream(new InflaterInputStream(new ByteArrayInputStream(data), new Inflater(), 2 * SECTOR_BYTES));
+            return new DataInputStream(new BufferedInputStream(new InflaterInputStream(new ByteArrayInputStream(data))));
         }
 
         throw new IOException("Unknown version: " + version);
@@ -212,7 +212,7 @@ public class RegionFile {
 
     public DataOutputStream getChunkDataOutputStream(int x, int z) {
         checkBounds(x, z);
-        return new DataOutputStream(new DeflaterOutputStream(new ChunkBuffer(x, z), new Deflater(Deflater.BEST_SPEED)));
+        return new DataOutputStream(new BufferedOutputStream(new DeflaterOutputStream(new ChunkBuffer(x, z))));
     }
 
     /* write a chunk at (x,z) with length bytes of data to disk */
@@ -335,7 +335,7 @@ public class RegionFile {
         private final int x, z;
 
         public ChunkBuffer(int x, int z) {
-            super(2 * SECTOR_BYTES); // initialize to 8KB
+            super(SECTOR_BYTES); // initialize to 4KB
             this.x = x;
             this.z = z;
         }

--- a/src/main/java/net/glowstone/io/anvil/RegionFile.java
+++ b/src/main/java/net/glowstone/io/anvil/RegionFile.java
@@ -68,9 +68,7 @@ import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.util.BitSet;
-import java.util.zip.DeflaterOutputStream;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.InflaterInputStream;
+import java.util.zip.*;
 
 public class RegionFile {
 
@@ -214,11 +212,11 @@ public class RegionFile {
         if (version == VERSION_GZIP) {
             byte[] data = new byte[length - 1];
             file.read(data);
-            return new DataInputStream(new BufferedInputStream(new GZIPInputStream(new ByteArrayInputStream(data))));
+            return new DataInputStream(new BufferedInputStream(new GZIPInputStream(new ByteArrayInputStream(data), 2048)));
         } else if (version == VERSION_DEFLATE) {
             byte[] data = new byte[length - 1];
             file.read(data);
-            return new DataInputStream(new BufferedInputStream(new InflaterInputStream(new ByteArrayInputStream(data))));
+            return new DataInputStream(new BufferedInputStream(new InflaterInputStream(new ByteArrayInputStream(data), new Inflater(), 2048)));
         }
 
         throw new IOException("Unknown version: " + version);
@@ -226,7 +224,7 @@ public class RegionFile {
 
     public DataOutputStream getChunkDataOutputStream(int x, int z) {
         checkBounds(x, z);
-        return new DataOutputStream(new BufferedOutputStream(new DeflaterOutputStream(new ChunkBuffer(x, z))));
+        return new DataOutputStream(new BufferedOutputStream(new DeflaterOutputStream(new ChunkBuffer(x, z), new Deflater(), 2048)));
     }
 
     /* write a chunk at (x,z) with length bytes of data to disk */

--- a/src/main/java/net/glowstone/io/anvil/RegionFile.java
+++ b/src/main/java/net/glowstone/io/anvil/RegionFile.java
@@ -66,7 +66,9 @@ import net.glowstone.GlowServer;
 
 import java.io.*;
 import java.util.BitSet;
-import java.util.zip.*;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
 
 public class RegionFile {
 


### PR DESCRIPTION
This should improve memory usage, CPU and performance, especially on servers that load and save a lot of chunks.

The changes (edited late on 10/30/16 to reflect new changes):
- `sectorFree` was changed from an `ArrayList<Boolean>` to a `BitSet`. This is where most of the memory savings comes from (replacing a collection of boxed primitives with a primitive array). The effect is most pronounced with more heavily populated region files - smaller regions will not see as much of an impact.
- `GZIPInputStream`, `InflaterInputStream` and `DeflaterOutputStream` should be buffered. This should increase performance, specifically for chunk loading and saving.
- `ChunkBuffer`'s buffer size was decreased to 4096 bytes, as most chunks are one sector in size.

Here's one instance from a heavily populated region (for this chunk, this was an approximately 15% decrease in memory usage). This is from a memory capture done soon after the server begins listening for connections (no connections were made).

Before:

![screenshot from 2016-10-30 20-30-45](https://cloud.githubusercontent.com/assets/979956/19841294/d270b58c-9edf-11e6-99d1-2679d0c847c3.png)

After:

![screenshot from 2016-10-30 20-30-57](https://cloud.githubusercontent.com/assets/979956/19841295/d90433d8-9edf-11e6-882e-2ffe30a3f683.png)
