### PR TITLE
Fix crash with codecs for SetPassengerMessage and AttachEntityMessage

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -106,7 +106,6 @@ public abstract class GlowEntity implements Entity {
      * Vehicle
      */
     protected GlowEntity vehicle;
-    protected boolean vehicleChanged;
     /**
      * This entity's unique id.
      */
@@ -135,6 +134,7 @@ public abstract class GlowEntity implements Entity {
      * Passenger
      */
     private GlowEntity passenger;
+    protected boolean passengerChanged;
     /**
      * Whether gravity applies to the entity.
      */
@@ -424,7 +424,7 @@ public abstract class GlowEntity implements Entity {
         metadata.resetChanges();
         teleported = false;
         velocityChanged = false;
-        vehicleChanged = false;
+        passengerChanged = false;
     }
 
     /**
@@ -549,9 +549,9 @@ public abstract class GlowEntity implements Entity {
             result.add(new EntityVelocityMessage(id, velocity));
         }
 
-        if (vehicleChanged) {
+        if (passengerChanged) {
             //this method will not call for this player, we don't need check SELF_ID
-            result.add(new AttachEntityMessage(getEntityId(), vehicle != null ? vehicle.getEntityId() : -1, false));
+            result.add(new SetPassengerMessage(getEntityId(), getPassenger() == null ? new int[0] : new int[] {getPassenger().getEntityId()}));
         }
 
         return result;
@@ -851,7 +851,7 @@ public abstract class GlowEntity implements Entity {
 
             EventFactory.callEvent(new EntityDismountEvent(passenger, this));
 
-            passenger.vehicleChanged = true;
+            passengerChanged = true;
             passenger.vehicle = null;
             passenger = null;
         } else {
@@ -876,13 +876,13 @@ public abstract class GlowEntity implements Entity {
 
             if (this.passenger != null) {
                 EventFactory.callEvent(new EntityDismountEvent(this.passenger, this));
-                this.passenger.vehicleChanged = true;
+                this.passengerChanged = true;
                 this.passenger.vehicle = null;
             }
 
             this.passenger = passenger;
             this.passenger.vehicle = this;
-            this.passenger.vehicleChanged = true;
+            this.passengerChanged = true;
         }
         return true;
     }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -609,8 +609,8 @@ public final class GlowPlayer extends GlowHumanEntity implements Player {
             }
         }
 
-        if (vehicleChanged) {
-            session.send(new AttachEntityMessage(SELF_ID, vehicle != null ? vehicle.getEntityId() : -1, false));
+        if (passengerChanged) {
+            session.send(new SetPassengerMessage(SELF_ID, getPassenger() == null ? new int[0] : new int[] {getPassenger().getEntityId()}));
         }
 
         getAttributeManager().sendMessages(session);

--- a/src/main/java/net/glowstone/net/codec/play/entity/AttachEntityCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/entity/AttachEntityCodec.java
@@ -9,17 +9,15 @@ import java.io.IOException;
 public final class AttachEntityCodec implements Codec<AttachEntityMessage> {
     @Override
     public AttachEntityMessage decode(ByteBuf buf) throws IOException {
-        int id = buf.readInt();
-        int vehicle = buf.readInt();
-        boolean leash = buf.readBoolean();
-        return new AttachEntityMessage(id, vehicle, leash);
+        int attached = buf.readInt();
+        int holding = buf.readInt();
+        return new AttachEntityMessage(attached, holding);
     }
 
     @Override
     public ByteBuf encode(ByteBuf buf, AttachEntityMessage message) throws IOException {
-        buf.writeInt(message.getId());
-        buf.writeInt(message.getVehicle());
-        buf.writeBoolean(message.isLeash());
+        buf.writeInt(message.getAttached());
+        buf.writeInt(message.getHolding());
         return buf;
     }
 }

--- a/src/main/java/net/glowstone/net/codec/play/entity/SetPassengerCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/entity/SetPassengerCodec.java
@@ -18,6 +18,7 @@ public class SetPassengerCodec implements Codec<SetPassengerMessage> {
     @Override
     public ByteBuf encode(ByteBuf buf, SetPassengerMessage message) throws IOException {
         ByteBufUtils.writeVarInt(buf, message.getEntityID());
+        ByteBufUtils.writeVarInt(buf, message.getPassengers().length);
         for (int passenger : message.getPassengers()) {
             ByteBufUtils.writeVarInt(buf, passenger);
         }

--- a/src/main/java/net/glowstone/net/message/play/entity/AttachEntityMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/entity/AttachEntityMessage.java
@@ -6,7 +6,6 @@ import lombok.Data;
 @Data
 public final class AttachEntityMessage implements Message {
 
-    private final int id, vehicle;
-    private final boolean leash;
+    private final int attached, holding;
 
 }

--- a/src/test/java/net/glowstone/net/PlayProtocolTest.java
+++ b/src/test/java/net/glowstone/net/PlayProtocolTest.java
@@ -80,7 +80,7 @@ public class PlayProtocolTest extends BaseProtocolTest {
             new RelativeEntityPositionMessage(1, (short) 2, (short) 3, (short) 4),
             new RelativeEntityPositionMessage(1, (short) 2, (short) 3, (short) 4, true),
             new KickMessage(ProtocolTestUtils.getTextMessage()),
-            new AttachEntityMessage(1, 2, true),
+            new AttachEntityMessage(1, 2),
             new EntityEffectMessage(1, (byte) 2, (byte) 3, 4, false),
             new EntityHeadRotationMessage(1, 2),
             new EntityMetadataMessage(1, ProtocolTestUtils.getMetadataEntry()),


### PR DESCRIPTION
Fixes issue #381, by fixing the crashes caused by incorrect codecs for `SetPassengerMessage` and `AtachEntityMessage`. Also I changed the tracking for passenger/vehicle changes to a passenger-based system instead of a vehicle-based one, since it's more logical when *setting* the passenger with `SetPassengerMessage`.