### PR TITLE
Deny an incoming message if the player isn't 'online' yet

### DIFF
--- a/src/main/java/net/glowstone/net/handler/play/game/IncomingChatHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/game/IncomingChatHandler.java
@@ -8,6 +8,10 @@ public final class IncomingChatHandler implements MessageHandler<GlowSession, In
 
     @Override
     public void handle(GlowSession session, IncomingChatMessage message) {
+        if (!session.isOnline()) {
+            // deny the message if the player hasn't had the login procedure completed
+            return;
+        }
         if (!message.getText().isEmpty()) {
             session.getPlayer().chat(message.getText(), message.isAsync());
         }


### PR DESCRIPTION
Fixes issue #382, checks if the player has completed the login sequence when joining the server before allowing for incoming chat messages.