### PR TITLE
Add ability to register custom entities

### DIFF
--- a/src/main/java/net/glowstone/entity/EntityManager.java
+++ b/src/main/java/net/glowstone/entity/EntityManager.java
@@ -68,7 +68,7 @@ public final class EntityManager implements Iterable<GlowEntity> {
      * @param entity The entity.
      */
     @SuppressWarnings("unchecked")
-    void register(GlowEntity entity) {
+    public void register(GlowEntity entity) {
         if (entity.id == 0) {
             throw new IllegalStateException("Entity has not been assigned an id.");
         }
@@ -82,7 +82,7 @@ public final class EntityManager implements Iterable<GlowEntity> {
      *
      * @param entity The entity.
      */
-    void unregister(GlowEntity entity) {
+    public void unregister(GlowEntity entity) {
         entities.remove(entity.id);
         getAll(entity.getClass()).remove(entity);
         ((GlowChunk) entity.location.getChunk()).getRawEntities().remove(entity);
@@ -95,7 +95,7 @@ public final class EntityManager implements Iterable<GlowEntity> {
      * @param entity      The entity.
      * @param newLocation The new location.
      */
-    void move(GlowEntity entity, Location newLocation) {
+    public void move(GlowEntity entity, Location newLocation) {
         Chunk prevChunk = entity.location.getChunk();
         Chunk newChunk = newLocation.getChunk();
         if (prevChunk != newChunk) {


### PR DESCRIPTION
This allows for people to get the EntityManager from GlowServer#getEntityManager or GlowWorld#getEntityManger, and register their own custom entities, remove those entities, or move those entities. Before, the methods were package-private, so no one was able to use those methods.

**WIP:** Not actually sure how to get this working. I am going to be fiddling around with a couple of different things, until I get it working, then I will post a thread on the forums.