### PR TITLE
Respect Entity#setGravity(false). Closes GH-454

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -317,6 +317,14 @@ public abstract class GlowEntity implements Entity {
         this.gravityAccel = gravity;
     }
 
+    public Vector getGravityAccel() {
+        if (this.gravity) {
+            return this.gravityAccel;
+        } else {
+            return this.zeroG;
+        }
+    }
+
     public void setDrag(double drag, boolean liquid) {
         if (liquid) {
             liquidDrag = drag;
@@ -716,6 +724,7 @@ public abstract class GlowEntity implements Entity {
      * Gravity acceleration applied each tick.
      */
     protected Vector gravityAccel = new Vector(0, -0.04, 0);
+    private static final Vector zeroG = new Vector(0, 0, 0);
     /**
      * The slipperiness multiplier applied according to the block this entity was on.
      */
@@ -889,12 +898,12 @@ public abstract class GlowEntity implements Entity {
         // apply friction and gravity
         if (location.getBlock().getType() == Material.WATER) {
             velocity.multiply(liquidDrag);
-            velocity.setY(velocity.getY() + gravityAccel.getY() / 4d);
+            velocity.setY(velocity.getY() + getGravityAccel().getY() / 4d);
         } else if (location.getBlock().getType() == Material.LAVA) {
             velocity.multiply(liquidDrag - 0.3);
-            velocity.setY(velocity.getY() + gravityAccel.getY() / 4d);
+            velocity.setY(velocity.getY() + getGravityAccel().getY() / 4d);
         } else {
-            velocity.setY(airDrag * (velocity.getY() + gravityAccel.getY()));
+            velocity.setY(airDrag * (velocity.getY() + getGravityAccel().getY()));
             if (isOnGround()) {
                 velocity.setX(velocity.getX() * slipMultiplier);
                 velocity.setZ(velocity.getZ() * slipMultiplier);

--- a/src/main/java/net/glowstone/entity/objects/GlowFallingBlock.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowFallingBlock.java
@@ -146,7 +146,7 @@ public class GlowFallingBlock extends GlowEntity implements FallingBlock {
 
         Location nextBlock = location.clone().add(getVelocity());
         if (!nextBlock.getBlock().getType().isSolid()) {
-            velocity.add(gravityAccel);
+            velocity.add(getGravityAccel());
             location.add(getVelocity());
             velocity.multiply(airDrag);
         } else {


### PR DESCRIPTION
Adds support for calling `setGravity(false)` to disable gravity physics on an entity. This is useful for plugins to make their own entities which don't respect gravity:

<img width="938" alt="screen shot 2017-05-01 at 9 59 22 pm" src="https://cloud.githubusercontent.com/assets/26856618/25604635/cca2c694-2eb9-11e7-8946-b17a8cb28bca.png">

Implemented by adding a `getGravityAccel()` accessor to complement `setGravityAccel()` (and `getVelocity()`), which returns a zero vector if `!this.gravity`. 