### PR TITLE
Fix warning loading Bukkit plugins also supporting Sponge

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -859,7 +859,14 @@ public final class GlowServer implements Server {
                 }
             }
 
-            if (!hasSponge) {
+            boolean spongeOnlyPlugins = false;
+            for (File spongePlugin: pluginTypeDetector.spongePlugins) {
+                if (!pluginTypeDetector.bukkitPlugins.contains(spongePlugin)) {
+                    spongeOnlyPlugins = true;
+                }
+            }
+
+            if (!hasSponge && spongeOnlyPlugins) {
                 logger.log(Level.WARNING, "SpongeAPI plugins found, but no Sponge bridge present! They will be ignored.");
                 for (File file : getSpongePlugins()) {
                     logger.log(Level.WARNING, "Ignored SpongeAPI plugin: " + file.getPath());


### PR DESCRIPTION
Trying to add Sponge support to one of my Bukkit plugins, so it supports both platforms, and Glowstone gives this warning:

```
18:36:22 [INFO] Scanning plugins...
18:36:22 [INFO] PluginTypeDetector: found 1 Bukkit, 1 Sponge, 0 Forge, 0 Canary, 0 unknown plugins (total 1)
18:36:22 [INFO] Set PluginClassLoader as parallel capable
18:36:22 [WARNING] SpongeAPI plugins found, but no Sponge bridge present! They will be ignored.
18:36:22 [WARNING] Ignored SpongeAPI plugin: plugins/WebSandboxMC.jar
18:36:22 [WARNING] Suggestion: install https://github.com/deathcap/Bukkit2Sponge to load these plugins
```

It is only a warning, granted, but its misleading since this plugin also supports Bukkit, so it will in fact be loaded successfully.

I'd like to suppress the warning (while also supporting Sponge within the Bukkit plugin) to not confuse server administrators, what is the best way to do this? This pull request checks if the Sponge plugin also supports Bukkit, and warns only if it doesn't.