### PR TITLE
Fix possible NPE when updating unattached blocks

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockNeedsAttached.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockNeedsAttached.java
@@ -20,6 +20,9 @@ public class BlockNeedsAttached extends BlockType {
     @Override
     public void updatePhysics(GlowBlock me) {
         BlockFace attachedTo = getAttachedFace(me);
+        if (attachedTo == null) {
+            return;
+        }
         if (me.getRelative(attachedTo).getType() == Material.AIR || !canPlaceAt(me, attachedTo.getOppositeFace())) {
             dropMe(me);
         }


### PR DESCRIPTION
`getAttachedFace()` can return null, but `me.getRelative()` requires a non-null parameter.

This will cause a NullPointerException when updating a block in certain conditions, for example, load this world: https://github.com/satoshinm/SignTestPlugin/blob/master/data/npe-getrelative166/r.0.0.mca and place a dirt block at (2, 78, -1) (on top of the white wool), causes this error:

```
19:39:40 [SEVERE] Error while handling DiggingMessage(state=0, x=2, y=78, z=-1, face=4) (handler: DiggingHandler)
java.lang.NullPointerException
	at net.glowstone.block.GlowBlock.getRelative(GlowBlock.java:166)
	at net.glowstone.block.blocktype.BlockNeedsAttached.updatePhysics(BlockNeedsAttached.java:23)
	at net.glowstone.block.blocktype.BlockNeedsAttached.onNearBlockChanged(BlockNeedsAttached.java:16)
	at net.glowstone.block.GlowBlock.applyPhysics(GlowBlock.java:555)
	at net.glowstone.block.GlowBlock.setTypeIdAndData(GlowBlock.java:243)
	at net.glowstone.block.GlowBlock.setTypeId(GlowBlock.java:222)
	at net.glowstone.block.GlowBlock.setTypeId(GlowBlock.java:217)
	at net.glowstone.block.GlowBlock.setType(GlowBlock.java:183)
	at net.glowstone.net.handler.play.player.DiggingHandler.handle(DiggingHandler.java:229)
	at net.glowstone.net.handler.play.player.DiggingHandler.handle(DiggingHandler.java:35)
	at com.flowpowered.network.session.BasicSession.handleMessage(BasicSession.java:80)
	at com.flowpowered.network.session.BasicSession.messageReceived(BasicSession.java:139)
	at net.glowstone.net.GlowSession.pulse(GlowSession.java:472)
	at java.util.concurrent.ConcurrentHashMap$KeySetView.forEach(ConcurrentHashMap.java:4649)
	at net.glowstone.net.SessionRegistry.pulse(SessionRegistry.java:23)
	at net.glowstone.scheduler.GlowScheduler.pulse(GlowScheduler.java:144)
	at net.glowstone.scheduler.GlowScheduler.lambda$start$0(GlowScheduler.java:83)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:748)
```

This pull request adds a null check, avoiding this error.