### PR TITLE
Make tnt explosions more vanilla like

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowTNTPrimed.java
+++ b/src/main/java/net/glowstone/entity/GlowTNTPrimed.java
@@ -24,6 +24,8 @@ public class GlowTNTPrimed extends GlowExplosive implements TNTPrimed {
 
     public GlowTNTPrimed(Location location, Entity source) {
         super(location, Explosion.POWER_TNT);
+        setSize(0.98f, 0.98f);
+
         fuseTicks = 0;
         ThreadLocalRandom rand = ThreadLocalRandom.current();
         int multiplier = rand.nextBoolean() ? 1 : -1;
@@ -64,7 +66,7 @@ public class GlowTNTPrimed extends GlowExplosive implements TNTPrimed {
 
         if (!event.isCancelled()) {
             Location location = getLocation();
-            double x = location.getX() + 0.5, y = location.getY() + 0.5, z = location.getZ() + 0.5;
+            double x = location.getX(), y = location.getY() + 0.06125, z = location.getZ();
             world.createExplosion(this, x, y, z, event.getRadius(), event.getFire(), true);
         }
 

--- a/src/main/resources/builtin/materialValues.yml
+++ b/src/main/resources/builtin/materialValues.yml
@@ -13,14 +13,12 @@ values:
   GRASS:
     blastResistance: 3
     hardness: 0.6
-    blastResistance: 3
   DIRT:
     blastResistance: 2.5
     hardness: 0.5
   COBBLESTONE:
     blastResistance: 30
     hardness: 2
-    blastResistance: 30
   WOOD:
     flameResistance: 5
     fireResistance: 20
@@ -557,7 +555,6 @@ values:
     blastResistance: 30
   QUARTZ_ORE:
     hardness: 3
-    blastResistance: 4
     blastResistance: 15
   HOPPER:
     hardness: 3

--- a/src/main/resources/builtin/materialValues.yml
+++ b/src/main/resources/builtin/materialValues.yml
@@ -13,16 +13,19 @@ values:
   GRASS:
     blastResistance: 3
     hardness: 0.6
+    blastResistance: 3
   DIRT:
     blastResistance: 2.5
     hardness: 0.5
   COBBLESTONE:
     blastResistance: 30
     hardness: 2
+    blastResistance: 30
   WOOD:
     flameResistance: 5
     fireResistance: 20
     hardness: 2
+    blastResistance: 15
   SAPLING:
     hardness: 0
     lightOpacity: 0
@@ -32,64 +35,85 @@ values:
   WATER:
     lightOpacity: 3
     hardness: 100
+    blastResistance: 500
   STATIONARY_WATER:
     lightOpacity: 3
     hardness: 100
+    blastResistance: 500
   LAVA:
     lightOpacity: 0
     hardness: 100
+    blastResistance: 500
   STATIONARY_LAVA:
     lightOpacity: 0
     hardness: 100
+    blastResistance: 500
   SAND:
     hardness: 0.5
   GRAVEL:
     hardness: 0.6
+    blastResistance: 3
   GOLD_ORE:
     hardness: 3
+    blastResistance: 15
   IRON_ORE:
     hardness: 3
+    blastResistance: 15
   COAL_ORE:
     hardness: 3
+    blastResistance: 15
   LOG:
     flameResistance: 5
     fireResistance: 5
     hardness: 2
+    blastResistance: 10
   LEAVES:
     lightOpacity: 1
     flameResistance: 30
     fireResistance: 60
     hardness: 0.2
+    blastResistance: 1
   SPONGE:
     hardness: 0.6
+    blastResistance: 3
   GLASS:
     lightOpacity: 0
     hardness: 0.3
+    blastResistance: 1.5
   LAPIS_ORE:
     hardness: 3
+    blastResistance: 15
   LAPIS_BLOCK:
     hardness: 3
+    blastResistance: 15
   DISPENSER:
     hardness: 3.5
+    blastResistance: 17.5
   SANDSTONE:
     hardness: 0.8
+    blastResistance: 4
   NOTE_BLOCK:
     hardness: 0.8
   BED_BLOCK:
     lightOpacity: 0
     hardness: 0.2
+    blastResistance: 1
   POWERED_RAIL:
     lightOpacity: 0
     hardness: 0.7
+    blastResistance: 3.5
   DETECTOR_RAIL:
     lightOpacity: 0
     hardness: 0.7
+    blastResistance: 3.5
   PISTON_STICKY_BASE:
     lightOpacity: 0
     hardness: 0.5
+    blastResistance: 2.5
   WEB:
     lightOpacity: 1
     hardness: 4
+    blastResistance: 20
   LONG_GRASS:
     hardness: 0
     lightOpacity: 0
@@ -103,16 +127,20 @@ values:
   PISTON_BASE:
     lightOpacity: 0
     hardness: 0.5
+    blastResistance: 2.5
   PISTON_EXTENSION:
     lightOpacity: 0
     hardness: 0.5
+    blastResistance: 2.5
   WOOL:
     flameResistance: 30
     fireResistance: 60
     hardness: 0.8
+    blastResistance: 4
   PISTON_MOVING_PIECE:
     lightOpacity: 0
     hardness: 0.5
+    blastResistance: 2.5
   YELLOW_FLOWER:
     hardness: 0
     lightOpacity: 0
@@ -131,15 +159,20 @@ values:
     lightOpacity: 0
   GOLD_BLOCK:
     hardness: 3
+    blastResistance: 30
   IRON_BLOCK:
     hardness: 5
+    blastResistance: 30
   DOUBLE_STEP:
     hardness: 2
+    blastResistance: 15
   STEP:
     lightOpacity: 0
     hardness: 2
+    blastResistance: 15
   BRICK:
     hardness: 2
+    blastResistance: 30
   TNT:
     hardness: 0
     flameResistance: 15
@@ -150,6 +183,7 @@ values:
     hardness: 1.5
   MOSSY_COBBLESTONE:
     hardness: 2
+    blastResistance: 30
   OBSIDIAN:
     hardness: 50
     blastResistance: 6000
@@ -162,6 +196,7 @@ values:
   MOB_SPAWNER:
     lightOpacity: 0
     hardness: 5
+    blastResistance: 25
   WOOD_STAIRS:
     lightOpacity: 0
     flameResistance: 5
@@ -170,15 +205,19 @@ values:
   CHEST:
     lightOpacity: 0
     hardness: 2.5
+    blastResistance: 12.5
   REDSTONE_WIRE:
     hardness: 0
     lightOpacity: 0
   DIAMOND_ORE:
     hardness: 3
+    blastResistance: 15
   DIAMOND_BLOCK:
     hardness: 5
+    blastResistance: 30
   WORKBENCH:
     hardness: 2.5
+    blastResistance: 12.5
   CROPS:
     hardness: 0
     lightOpacity: 0
@@ -187,42 +226,56 @@ values:
     hardness: 0.6
   FURNACE:
     hardness: 3.5
+    blastResistance: 17.5
   BURNING_FURNACE:
     hardness: 3.5
+    blastResistance: 17.5
   SIGN_POST:
     lightOpacity: 0
     hardness: 1
+    blastResistance: 5
   WOODEN_DOOR:
     lightOpacity: 0
     hardness: 3
+    blastResistance: 15
   LADDER:
     lightOpacity: 0
     hardness: 0.4
+    blastResistance: 2
   RAILS:
     lightOpacity: 0
     hardness: 0.7
+    blastResistance: 3.5
   COBBLESTONE_STAIRS:
     hardness: 2
     lightOpacity: 0
+    blastResistance: 30
   WALL_SIGN:
     hardness: 1
     lightOpacity: 0
+    blastResistance: 5
   LEVER:
     hardness: 0.5
     lightOpacity: 0
+    blastResistance: 2.5
   STONE_PLATE:
     hardness: 0.5
     lightOpacity: 0
+    blastResistance: 2.5
   IRON_DOOR_BLOCK:
     hardness: 5
     lightOpacity: 0
+    blastResistance: 25
   WOOD_PLATE:
     hardness: 2
     lightOpacity: 0
+    blastResistance: 2.5
   REDSTONE_ORE:
     hardness: 3
+    blastResistance: 15
   GLOWING_REDSTONE_ORE:
     hardness: 3
+    blastResistance: 15
   REDSTONE_TORCH_OFF:
     hardness: 0
     lightOpacity: 0
@@ -235,40 +288,52 @@ values:
   SNOW:
     hardness: 0.1
     lightOpacity: 0
+    blastResistance: 0.5
   ICE:
     hardness: 0.5
     lightOpacity: 3
+    blastResistance: 2.5
   SNOW_BLOCK:
     hardness: 0.2
+    blastResistance: 1
   CACTUS:
     hardness: 0.4
     lightOpacity: 0
+    blastResistance: 2
   CLAY:
     hardness: 0.6
+    blastResistance: 3
   SUGAR_CANE_BLOCK:
     hardness: 0
     lightOpacity: 0
   JUKEBOX:
     hardness: 2
+    blastResistance: 30
   FENCE:
     hardness: 2
     lightOpacity: 0
+    blastResistance: 15
   PUMPKIN:
     hardness: 1
+    blastResistance: 5
   NETHERRACK:
     hardness: 0.4
+    blastResistance: 2
   SOUL_SAND:
     hardness: 0.5
   GLOWSTONE:
     hardness: 0.3
+    blastResistance: 1.5
   PORTAL:
     lightOpacity: 0
     hardness: -1
   JACK_O_LANTERN:
     hardness: 1
+    blastResistance: 5
   CAKE_BLOCK:
     hardness: 0.5
     lightOpacity: 0
+    blastResistance: 2.5
   DIODE_BLOCK_OFF:
     hardness: 0
     lightOpacity: 0
@@ -278,25 +343,32 @@ values:
   STAINED_GLASS:
     hardness: 0.3
     lightOpacity: 0
+    blastResistance: 1.5
   TRAP_DOOR:
     hardness: 3
     lightOpacity: 0
+    blastResistance: 15
   MONSTER_EGGS:
     hardness: 0.75
+    blastResistance: 3.75
   SMOOTH_BRICK:
     hardness: 1.5
   HUGE_MUSHROOM_1:
     hardness: 0.2
+    blastResistance: 1
   HUGE_MUSHROOM_2:
     hardness: 0.2
+    blastResistance: 1
   IRON_FENCE:
     hardness: 5
     lightOpacity: 0
+    blastResistance: 30
   THIN_GLASS:
     hardness: 0.3
     lightOpacity: 0
   MELON_BLOCK:
     hardness: 1
+    blastResistance: 5
   PUMPKIN_STEM:
     hardness: 0
     lightOpacity: 0
@@ -308,74 +380,97 @@ values:
     lightOpacity: 0
     flameResistance: 15
     fireResistance: 100
+    blastResistance: 1
   FENCE_GATE:
     hardness: 2
     lightOpacity: 0
+    blastResistance: 15
   BRICK_STAIRS:
     hardness: 2
     lightOpacity: 0
+    blastResistance: 30
   SMOOTH_STAIRS:
     hardness: 1.5
     lightOpacity: 0
   MYCEL:
     hardness: 0.6
+    blastResistance: 2.5
   WATER_LILY:
     lightOpacity: 0
   NETHER_BRICK:
     hardness: 2
+    blastResistance: 30
   NETHER_FENCE:
     hardness: 2
     lightOpacity: 0
+    blastResistance: 30
   NETHER_BRICK_STAIRS:
     hardness: 2
     lightOpacity: 0
+    blastResistance: 30
   NETHER_WARTS:
     hardness: 0
     lightOpacity: 0
+    blastResistance: 5
   ENCHANTMENT_TABLE:
     hardness: 5
     lightOpacity: 0
+    blastResistance: 6000
   BREWING_STAND:
     hardness: 0.5
     lightOpacity: 0
+    blastResistance: 2.5
   CAULDRON:
     hardness: 2
     lightOpacity: 0
+    blastResistance: 10
   ENDER_PORTAL:
     hardness: -1
     lightOpacity: 0
+    blastResistance: 3000
   ENDER_PORTAL_FRAME:
     hardness: -1
     lightOpacity: 0
+    blastResistance: 18000000
   ENDER_STONE:
     hardness: 3
+    blastResistance: 45
   DRAGON_EGG:
     hardness: 3
     lightOpacity: 0
+    blastResistance: 45
   REDSTONE_LAMP_OFF:
     hardness: 0.3
+    blastResistance: 1.5
   REDSTONE_LAMP_ON:
     hardness: 0.3
+    blastResistance: 1.5
   WOOD_DOUBLE_STEP:
     hardness: 2
     flameResistance: 5
     fireResistance: 20
+    blastResistance: 15
   WOOD_STEP:
     hardness: 2
     lightOpacity: 0
     flameResistance: 5
     fireResistance: 20
+    blastResistance: 15
   COCOA:
     hardness: 0.2
     lightOpacity: 0
+    blastResistance: 15
   SANDSTONE_STAIRS:
     hardness: 0.8
     lightOpacity: 0
+    blastResistance: 4
   EMERALD_ORE:
     hardness: 3
+    blastResistance: 15
   ENDER_CHEST:
     hardness: 22.5
     lightOpacity: 0
+    blastResistance: 3000
   TRIPWIRE_HOOK:
     hardness: 0
     lightOpacity: 0
@@ -384,29 +479,36 @@ values:
     lightOpacity: 0
   EMERALD_BLOCK:
     hardness: 5
+    blastResistance: 30
   SPRUCE_WOOD_STAIRS:
     hardness: 2
     lightOpacity: 0
     flameResistance: 5
     fireResistance: 20
+    blastResistance: 15
   BIRCH_WOOD_STAIRS:
     hardness: 2
     lightOpacity: 0
     flameResistance: 5
     fireResistance: 20
+    blastResistance: 15
   JUNGLE_WOOD_STAIRS:
     hardness: 2
     lightOpacity: 0
     flameResistance: 5
     fireResistance: 20
+    blastResistance: 15
   COMMAND:
     hardness: -1
+    blastResistance: 18000000
   BEACON:
     hardness: 3
     lightOpacity: 0
+    blastResistance: 15
   COBBLE_WALL:
     hardness: 2
     lightOpacity: 0
+    blastResistance: 30
   FLOWER_POT:
     hardness: 0
     lightOpacity: 0
@@ -419,21 +521,27 @@ values:
   WOOD_BUTTON:
     hardness: 0.5
     lightOpacity: 0
+    blastResistance: 2.5
   SKULL:
     hardness: 1
     lightOpacity: 0
+    blastResistance: 5
   ANVIL:
     hardness: 5
     lightOpacity: 0
+    blastResistance: 6000
   TRAPPED_CHEST:
     hardness: 2.5
     lightOpacity: 0
+    blastResistance: 12.5
   GOLD_PLATE:
     hardness: 0.5
     lightOpacity: 0
+    blastResistance: 2.5
   IRON_PLATE:
     hardness: 0.5
     lightOpacity: 0
+    blastResistance: 2.5
   REDSTONE_COMPARATOR_OFF:
     hardness: 0
     lightOpacity: 0
@@ -443,33 +551,44 @@ values:
   DAYLIGHT_DETECTOR:
     hardness: 0.2
     lightOpacity: 0
+    blastResistance: 1
   REDSTONE_BLOCK:
     hardness: 5
+    blastResistance: 30
   QUARTZ_ORE:
     hardness: 3
+    blastResistance: 4
+    blastResistance: 15
   HOPPER:
     hardness: 3
     lightOpacity: 0
+    blastResistance: 24
   QUARTZ_BLOCK:
     hardness: 0.8
+    blastResistance: 4
   QUARTZ_STAIRS:
     hardness: 0.8
     lightOpacity: 0
+    blastResistance: 4
   ACTIVATOR_RAIL:
     hardness: 0.7
     lightOpacity: 0
+    blastResistance: 3.5
   DROPPER:
     hardness: 3.5
+    blastResistance: 17.5
   STAINED_CLAY:
     hardness: 1.4
   STAINED_GLASS_PANE:
     hardness: 0.3
     lightOpacity: 0
+    blastResistance: 1.5
   LEAVES_2:
     hardness: 0.2
     lightOpacity: 1
     flameResistance: 30
     fireResistance: 60
+    blastResistance: 1
   LOG_2:
     hardness: 2
     flameResistance: 5
@@ -488,30 +607,38 @@ values:
     hardness: 0
   BARRIER:
     hardness: -1
+    blastResistance: 18000003
   IRON_TRAPDOOR:
     hardness: 5
     lightOpacity: 0
+    blastResistance: 25
   PRISMARINE:
     hardness: 1.5
+    blastResistance: 30
   SEA_LANTERN:
     hardness: 0.3
+    blastResistance: 1.5
   HAY_BLOCK:
     hardness: 0.5
     flameResistance: 60
     fireResistance: 20
+    blastResistance: 2.5
   CARPET:
     hardness: 0.1
     lightOpacity: 0
     flameResistance: 60
     fireResistance: 20
+    blastResistance: 0.5
   HARD_CLAY:
     hardness: 1.25
   COAL_BLOCK:
     hardness: 5
     flameResistance: 5
     fireResistance: 5
+    blastResistance: 30
   PACKED_ICE:
     hardness: 0.5
+    blastResistance: 2.5
   DOUBLE_PLANT:
     lightOpacity: 0
     flameResistance: 60
@@ -519,16 +646,20 @@ values:
     hardness: 0
   STANDING_BANNER:
     hardness: 1
+    blastResistance: 5
   WALL_BANNER:
     hardness: 1
+    blastResistance: 5
   DAYLIGHT_DETECTOR_INVERTED:
     hardness: 0.2
     lightOpacity: 0
   RED_SANDSTONE:
     hardness: 0.8
+    blastResistance: 4
   RED_SANDSTONE_STAIRS:
     hardness: 0.8
     lightOpacity: 0
+    blastResistance: 4
   SPRUCE_FENCE_GATE:
     hardness: 2
     lightOpacity: 0


### PR DESCRIPTION
Made some changes, so that tnt-explosions behave more like they do in vanilla.

Fixed the size of the primed tnt entities.It is supposed to be 0.98x0.98.

Tnt explosions start a tiny bit above the source tnt's location.
According to the bukkit-api, x and z are unchanged for the explosion, only y is increased:
Location of tnt entity:
`
Location{world=CraftWorld{name=world},x=-1980.5099999904633,y=19.0,z=977.5099999904633,pitch=0.0,yaw=0.0}
`
Location of explosion:
`
Location{world=CraftWorld{name=world},x=-1980.5099999904633,y=19.061250001192093,z=977.5099999904633,pitch=0.0,yaw=0.0}
`

I also set the blastResistance for all currently known materials.

closes #507
