### PR TITLE
respawn on ground

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -383,22 +383,23 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         saveData();
 
         streamBlocks(); // stream the initial set of blocks
-        setCompassTarget(world.getSpawnLocation()); // set our compass target
-        sendTime();
         sendWeather();
         sendRainDensity();
         sendSkyDarkness();
         sendAbilities();
+
+        // send initial location
+        session.send(new PositionRotationMessage(location));
+
         session.send(((GlowWorldBorder) world.getWorldBorder()).createMessage());
+        sendTime();
+        setCompassTarget(world.getSpawnLocation()); // set our compass target
 
         scoreboard = server.getScoreboardManager().getMainScoreboard();
         scoreboard.subscribe(this);
 
         invMonitor = new InventoryMonitor(getOpenInventory());
         updateInventory(); // send inventory contents
-
-        // send initial location
-        session.send(new PositionRotationMessage(location));
 
         if (!server.getResourcePackURL().isEmpty()) {
             setResourcePack(server.getResourcePackURL(), server.getResourcePackHash());
@@ -798,11 +799,13 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         // spawn into world
         String type = world.getWorldType().getName().toLowerCase();
         session.send(new RespawnMessage(world.getEnvironment().getId(), world.getDifficulty().getValue(), getGameMode().getValue(), type));
+
         setRawLocation(location, false); // take us to spawn position
-        streamBlocks(); // stream blocks
-        setCompassTarget(world.getSpawnLocation()); // set our compass target
         session.send(new PositionRotationMessage(location));
         teleportedTo = location.clone();
+        setCompassTarget(world.getSpawnLocation()); // set our compass target
+
+        streamBlocks(); // stream blocks
 
         sendWeather();
         sendRainDensity();


### PR DESCRIPTION
This pr attempts to fix the sending order of the position and chunkdata, as well as some other minor stuff.

Currently the problem is, we send chunkdata before the position update on respawn. The client gets confused, and uses `x=8.5 y=? z=8.5` as its coordinates. These coordinates will also be send as first position update from the client. x and z appear to be static, y is somewhere on ground.
After this initial confusion, the server sends the real position of the player. The client accepts these coordinates correctly through a TeleportConfirmMessage.
However, when his first coordinates where above the real spawn location, he will fall to the ground, causing issue #460.

I adjusted the sending order to be (hopefully) vanilla like.

The same problem occurs on inital join in a freshly generated world, but vanilla does not handle this case as well -> no need to change something here.

I adjusted the sending order of the SPAWN_POSITION, TIME and WORLD_BORDER message for both respawn and join.

Logs used to figure this out:
join on paper: https://gist.github.com/Postremus/9ea304d277ec2f1850fded5252c158ef
join on glowstone: https://gist.github.com/Postremus/b8c590817b3a18ab3ce46df92f316a0f

/kill (respawn) on paper: https://gist.github.com/Postremus/e8f0e9c924b3e73e8199f80592cee020
/kill (respawn) on glowstone: https://gist.github.com/Postremus/57066a2bea42338d4b048bd3147fc42b

closes #460