### PR TITLE
#499 - Implement toggledownfall, spawnpoint, setidletimeout and setworldspawn

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -854,6 +854,7 @@ public final class GlowServer implements Server {
         commandMap.register("minecraft", new XpCommand());
         commandMap.register("minecraft", new DefaultGameModeCommand());
         commandMap.register("minecraft", new SetIdleTimeoutCommand());
+        commandMap.register("minecraft", new SpawnPointCommand());
 
         File folder = new File(config.getString(Key.PLUGIN_FOLDER));
         if (!folder.isDirectory() && !folder.mkdirs()) {

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -856,6 +856,7 @@ public final class GlowServer implements Server {
         commandMap.register("minecraft", new SetIdleTimeoutCommand());
         commandMap.register("minecraft", new SpawnPointCommand());
         commandMap.register("minecraft", new ToggleDownfallCommand());
+        commandMap.register("minecraft", new SetWorldSpawnCommand());
 
         File folder = new File(config.getString(Key.PLUGIN_FOLDER));
         if (!folder.isDirectory() && !folder.mkdirs()) {

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -855,6 +855,7 @@ public final class GlowServer implements Server {
         commandMap.register("minecraft", new DefaultGameModeCommand());
         commandMap.register("minecraft", new SetIdleTimeoutCommand());
         commandMap.register("minecraft", new SpawnPointCommand());
+        commandMap.register("minecraft", new ToggleDownfallCommand());
 
         File folder = new File(config.getString(Key.PLUGIN_FOLDER));
         if (!folder.isDirectory() && !folder.mkdirs()) {

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -853,6 +853,7 @@ public final class GlowServer implements Server {
         commandMap.register("minecraft", new SeedCommand());
         commandMap.register("minecraft", new XpCommand());
         commandMap.register("minecraft", new DefaultGameModeCommand());
+        commandMap.register("minecraft", new SetIdleTimeoutCommand());
 
         File folder = new File(config.getString(Key.PLUGIN_FOLDER));
         if (!folder.isDirectory() && !folder.mkdirs()) {
@@ -1883,6 +1884,8 @@ public final class GlowServer implements Server {
     @Override
     public void setIdleTimeout(int timeout) {
         idleTimeout = timeout;
+        config.set(Key.PLAYER_IDLE_TIMEOUT, timeout);
+        config.save();
     }
 
     @Override

--- a/src/main/java/net/glowstone/command/minecraft/SetIdleTimeoutCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/SetIdleTimeoutCommand.java
@@ -35,12 +35,12 @@ public class SetIdleTimeoutCommand extends VanillaCommand {
         }
 
         if (timeout <= 0) {
-            sender.sendMessage(ChatColor.RED + "Timeout has to be positive");
+            sender.sendMessage(ChatColor.RED + "The number you have entered (" + timeout + ") is too small, it must be at least 1");
             return false;
         }
 
         Bukkit.getServer().setIdleTimeout(timeout);
-        Bukkit.broadcastMessage("The idle timeout has been set to '" + timeout + "' minutes.");
+        sender.sendMessage("Successfully set the idle timeout to " + timeout + " minutes.");
 
         return true;
     }

--- a/src/main/java/net/glowstone/command/minecraft/SetIdleTimeoutCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/SetIdleTimeoutCommand.java
@@ -1,0 +1,52 @@
+package net.glowstone.command.minecraft;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.defaults.VanillaCommand;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SetIdleTimeoutCommand extends VanillaCommand {
+
+    public SetIdleTimeoutCommand() {
+        super("setidletimeout", "Sets the time before idle players are kicked from the server.", "/setidletimeout <Minutes until kick>", Collections.emptyList());
+        setPermission("minecraft.command.setidletimeout");
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String label, String[] args) {
+        if (!testPermission(sender)) return false;
+
+        if (args.length == 0) {
+            sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
+            return false;
+        }
+
+        final String stringTimeout = args[0];
+        int timeout;
+
+        try {
+            timeout = Integer.parseInt(stringTimeout);
+        } catch (NumberFormatException ex) {
+            sender.sendMessage(ChatColor.RED + "'" + stringTimeout + "' is not a valid number");
+            return false;
+        }
+
+        if (timeout <= 0) {
+            sender.sendMessage(ChatColor.RED + "Timeout has to be positive");
+            return false;
+        }
+
+        Bukkit.getServer().setIdleTimeout(timeout);
+        Bukkit.broadcastMessage("The idle timeout has been set to '" + timeout + "' minutes.");
+
+        return true;
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/net/glowstone/command/minecraft/SetWorldSpawnCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/SetWorldSpawnCommand.java
@@ -1,0 +1,79 @@
+package net.glowstone.command.minecraft;
+
+import net.glowstone.command.CommandUtils;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.command.BlockCommandSender;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.defaults.VanillaCommand;
+import org.bukkit.entity.Entity;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SetWorldSpawnCommand extends VanillaCommand {
+    public SetWorldSpawnCommand() {
+        super("setworldspawn", "Sets the world spawn.", "/setworldspawn OR /setworldspawn <x> <y> <z>", Collections.emptyList());
+        setPermission("minecraft.command.setworldspawn");
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String label, String[] args) {
+        if (!testPermission(sender)) return false;
+
+        Location spawnLocation;
+
+        final World world = CommandUtils.getWorld(sender);
+
+        if (world == null) {
+            return false;
+        }
+
+        if (args.length == 0) { // Get the player current location
+            if (CommandUtils.isPhysical(sender)) {
+                spawnLocation = sender instanceof Entity ? ((Entity) sender).getLocation() : ((BlockCommandSender) sender).getBlock().getLocation();
+            } else {
+                sender.sendMessage(ChatColor.RED + "Default coordinates can not be used without a physical user.");
+                return false;
+            }
+        } else if (args.length >= 3) { // manage arguments
+            final Location senderLocation;
+
+            // Get the sender coordinates if relative is used
+            if (args[0].startsWith("~") || args[1].startsWith("~") || args[2].startsWith("~")) {
+                if (!CommandUtils.isPhysical(sender)) {
+                    sender.sendMessage(ChatColor.RED + "Relative coordinates can not be used without a physical user.");
+                    return false;
+                } else {
+                    senderLocation = sender instanceof Entity ? ((Entity) sender).getLocation() : ((BlockCommandSender) sender).getBlock().getLocation();
+                }
+            } else { // Otherwise, the current location can be set to 0/0/0 (since it's absolute)
+                senderLocation = new Location(world, 0, 0, 0);
+            }
+
+            spawnLocation = CommandUtils.getLocation(senderLocation, args[0], args[1], args[2]);
+        } else {
+            sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
+            return false;
+        }
+
+        if (spawnLocation.getBlockY() < 0) {
+            sender.sendMessage(ChatColor.RED + "The y coordinate (" + spawnLocation.getBlockY() + ") is too small, it must be at least 0.");
+            return false;
+        } else if (!(spawnLocation.getBlockY() <= world.getMaxHeight())) {
+            sender.sendMessage(ChatColor.RED + "'" + spawnLocation.getBlockY() + "' is too high for the current world. Max value is '" + world.getMaxHeight() + "'.");
+            return false;
+        }
+
+        world.setSpawnLocation(spawnLocation.getBlockX(), spawnLocation.getBlockY(), spawnLocation.getBlockZ());
+        sender.sendMessage("Set world spawn point to " + spawnLocation.getBlockX() + ", " + spawnLocation.getBlockY() + ", " + spawnLocation.getBlockZ() + ".");
+
+        return true;
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/net/glowstone/command/minecraft/SetWorldSpawnCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/SetWorldSpawnCommand.java
@@ -61,7 +61,7 @@ public class SetWorldSpawnCommand extends VanillaCommand {
         if (spawnLocation.getBlockY() < 0) {
             sender.sendMessage(ChatColor.RED + "The y coordinate (" + spawnLocation.getBlockY() + ") is too small, it must be at least 0.");
             return false;
-        } else if (!(spawnLocation.getBlockY() <= world.getMaxHeight())) {
+        } else if (spawnLocation.getBlockY() > world.getMaxHeight()) {
             sender.sendMessage(ChatColor.RED + "'" + spawnLocation.getBlockY() + "' is too high for the current world. Max value is '" + world.getMaxHeight() + "'.");
             return false;
         }

--- a/src/main/java/net/glowstone/command/minecraft/SpawnPointCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/SpawnPointCommand.java
@@ -93,7 +93,7 @@ public class SpawnPointCommand extends VanillaCommand {
             if (spawnLocation.getY() < 0) {
                 sender.sendMessage(ChatColor.RED + "The y coordinate (" + spawnLocation.getY() + ") is too small, it must be at least 0.");
                 return false;
-            } else if (!(spawnLocation.getY() <= world.getMaxHeight())) {
+            } else if (spawnLocation.getBlockY() > world.getMaxHeight()) {
                 sender.sendMessage(ChatColor.RED + "'" + spawnLocation.getY() + "' is too high for the current world. Max value is '" + world.getMaxHeight() + "'.");
                 return false;
             }

--- a/src/main/java/net/glowstone/command/minecraft/SpawnPointCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/SpawnPointCommand.java
@@ -90,7 +90,10 @@ public class SpawnPointCommand extends VanillaCommand {
 
             spawnLocation = CommandUtils.getLocation(currentLocation, args[1], args[2], args[3]);
 
-            if (!(spawnLocation.getY() >= 0 && spawnLocation.getY() <= world.getMaxHeight())) {
+            if (spawnLocation.getY() < 0) {
+                sender.sendMessage(ChatColor.RED + "The y coordinate (" + spawnLocation.getY() + ") is too small, it must be at least 0.");
+                return false;
+            } else if (!(spawnLocation.getY() <= world.getMaxHeight())) {
                 sender.sendMessage(ChatColor.RED + "'" + spawnLocation.getY() + "' is too high for the current world. Max value is '" + world.getMaxHeight() + "'.");
                 return false;
             }

--- a/src/main/java/net/glowstone/command/minecraft/SpawnPointCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/SpawnPointCommand.java
@@ -35,14 +35,14 @@ public class SpawnPointCommand extends VanillaCommand {
 
         final String playerPattern = args.length >= 1 ? args[0] : null;
         List<Player> targets;
-        Location spawnLocation = null;
+        Location spawnLocation;
 
         // Manage player(s)
         if (playerPattern == null) { // Default player, set to current one (if a player)
             if (sender instanceof Player) {
                 targets = ImmutableList.of((Player) sender);
             } else {
-                sender.sendMessage(ChatColor.RED + "Current sender is not a player.");
+                sender.sendMessage(ChatColor.RED + "You must specify which player you wish to perform this action on.");
                 return false;
             }
         } else if (playerPattern.startsWith("@") && playerPattern.length() > 1 && CommandUtils.isPhysical(sender)) { // Manage selectors

--- a/src/main/java/net/glowstone/command/minecraft/SpawnPointCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/SpawnPointCommand.java
@@ -1,0 +1,119 @@
+package net.glowstone.command.minecraft;
+
+import com.google.common.collect.ImmutableList;
+import net.glowstone.command.CommandTarget;
+import net.glowstone.command.CommandUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.command.BlockCommandSender;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.defaults.VanillaCommand;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class SpawnPointCommand extends VanillaCommand {
+
+    public SpawnPointCommand() {
+        super("spawnpoint", "Sets the spawn point for a player.", "/spawnpoint OR /spawnpoint <player> OR /spawnpoint <player> <x> <y> <z>", Collections.emptyList());
+        setPermission("minecraft.command.spawnpoint");
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String label, String[] args) {
+        if (!testPermission(sender)) return false;
+
+        if (args.length != 0 && args.length != 1 && args.length < 4) {
+            sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
+            return false;
+        }
+
+        final String playerPattern = args.length >= 1 ? args[0] : null;
+        List<Player> targets;
+        Location spawnLocation = null;
+
+        // Manage player(s)
+        if (playerPattern == null) { // Default player, set to current one (if a player)
+            if (sender instanceof Player) {
+                targets = ImmutableList.of((Player) sender);
+            } else {
+                sender.sendMessage(ChatColor.RED + "Current sender is not a player.");
+                return false;
+            }
+        } else if (playerPattern.startsWith("@") && playerPattern.length() > 1 && CommandUtils.isPhysical(sender)) { // Manage selectors
+            final Location location = sender instanceof Entity ? ((Entity) sender).getLocation() : ((BlockCommandSender) sender).getBlock().getLocation();
+            final Entity[] entities = new CommandTarget(sender, args[0]).getMatched(location);
+            targets = new ArrayList<>();
+
+            for (final Entity entity : entities) {
+                if (entity instanceof Player) {
+                    targets.add((Player) entity);
+                }
+            }
+        } else { // One player given (with or without coordinates)
+            final Player player = Bukkit.getPlayerExact(playerPattern);
+
+            if (player == null) {
+                sender.sendMessage(ChatColor.RED + "Player '" + playerPattern + "' cannot be found");
+                return false;
+            } else {
+                targets = Collections.singletonList(player);
+            }
+        }
+
+        // Manage coordinates
+        if (args.length == 4) { // Coordinates are given
+            final Location currentLocation;
+
+            final World world = CommandUtils.getWorld(sender);
+
+            if (world == null) {
+                return false;
+            }
+
+            // If we are using relative coordinates, we need to get the sender location
+            if (args[1].startsWith("~") || args[2].startsWith("~") || args[3].startsWith("~")) {
+                if (!CommandUtils.isPhysical(sender)) {
+                    sender.sendMessage(ChatColor.RED + "Relative coordinates can not be used without a physical user.");
+                    return false;
+                } else {
+                    currentLocation = sender instanceof Entity ? ((Entity) sender).getLocation() : ((BlockCommandSender) sender).getBlock().getLocation();
+                }
+            } else { // Otherwise, the current location can be set to 0/0/0 (since it's absolute)
+                currentLocation = new Location(world, 0, 0, 0);
+            }
+
+            spawnLocation = CommandUtils.getLocation(currentLocation, args[1], args[2], args[3]);
+
+            if (!(spawnLocation.getY() >= 0 && spawnLocation.getY() <= world.getMaxHeight())) {
+                sender.sendMessage(ChatColor.RED + "'" + spawnLocation.getY() + "' is too high for the current world. Max value is '" + world.getMaxHeight() + "'.");
+                return false;
+            }
+        } else { // Use the sender coordinates
+            if (CommandUtils.isPhysical(sender)) {
+                spawnLocation = sender instanceof Entity ? ((Entity) sender).getLocation() : ((BlockCommandSender) sender).getBlock().getLocation();
+            } else {
+                sender.sendMessage(ChatColor.RED + "Default coordinates can not be used without a physical user.");
+                return false;
+            }
+        }
+
+        // Update spawn location
+        for (final Player target : targets) {
+            target.setBedSpawnLocation(spawnLocation, true);
+            sender.sendMessage("Set " + target.getName() + "'s spawn point to " + spawnLocation.getBlockX() + ", " + spawnLocation.getBlockY() + ", " + spawnLocation.getBlockZ() + ".");
+        }
+
+        return true;
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
+        return args.length == 1 ? super.tabComplete(sender, alias, args) : Collections.emptyList();
+    }
+}

--- a/src/main/java/net/glowstone/command/minecraft/ToggleDownfallCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/ToggleDownfallCommand.java
@@ -1,0 +1,42 @@
+package net.glowstone.command.minecraft;
+
+import net.glowstone.command.CommandUtils;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.defaults.VanillaCommand;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ToggleDownfallCommand extends VanillaCommand {
+    public ToggleDownfallCommand() {
+        super("toggledownfall", "Toggles the weather.", "/toggledownfall", Collections.emptyList());
+        setPermission("minecraft.command.toggledownfall");
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String label, String[] args) {
+        if (!testPermission(sender)) return false;
+
+        final World world = CommandUtils.getWorld(sender);
+
+        if (world == null) {
+            return false;
+        } else {
+            if (world.hasStorm()) {
+                world.setThundering(false);
+                world.setStorm(false);
+            } else {
+                world.setThundering(true);
+                world.setStorm(true);
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
+        return Collections.emptyList();
+    }
+}

--- a/src/main/java/net/glowstone/command/minecraft/ToggleDownfallCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/ToggleDownfallCommand.java
@@ -23,13 +23,8 @@ public class ToggleDownfallCommand extends VanillaCommand {
         if (world == null) {
             return false;
         } else {
-            if (world.hasStorm()) {
-                world.setThundering(false);
-                world.setStorm(false);
-            } else {
-                world.setThundering(true);
-                world.setStorm(true);
-            }
+            world.setThundering(!world.hasStorm());
+            world.setStorm(!world.hasStorm());
         }
 
         return true;

--- a/src/test/java/net/glowstone/command/minecraft/SetIdleTimeoutCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SetIdleTimeoutCommandTest.java
@@ -1,0 +1,111 @@
+package net.glowstone.command.minecraft;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Server;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Bukkit.class)
+public class SetIdleTimeoutCommandTest {
+
+    private CommandSender sender, opSender;
+
+    private Command command;
+
+    @Before
+    public void before() {
+        PowerMockito.mockStatic(Bukkit.class);
+
+        sender = PowerMockito.mock(CommandSender.class);
+        opSender = PowerMockito.mock(CommandSender.class);
+        command = new SetIdleTimeoutCommand();
+
+        Mockito.when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
+        Mockito.when(Bukkit.getServer()).thenReturn(PowerMockito.mock(Server.class));
+    }
+
+    @Test
+    public void testExecuteFailsWithoutPermission() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(sender, "label", new String[0]);
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(sender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error."));
+    }
+
+    @Test
+    public void testExecuteFailsWithoutParameters() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[0]);
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "Usage: /setidletimeout <Minutes until kick>"));
+    }
+
+    @Test
+    public void testExecuteFailsWithIncorrectNumber() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[]{"invalidNumber"});
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "'invalidNumber' is not a valid number"));
+    }
+
+    @Test
+    public void testExecuteFailsWithNegativeTimeout() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[]{"-42"});
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "Timeout has to be positive"));
+    }
+
+    @Test
+    public void testExecuteFailsWithNullTimeout() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[]{"0"});
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "Timeout has to be positive"));
+    }
+
+    @Test
+    public void testExecuteSucceeds() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[]{"50"});
+        PowerMockito.verifyStatic();
+        Bukkit.broadcastMessage(captor.capture());
+
+        assertThat(commandResult, is(true));
+        Mockito.verify(Bukkit.getServer()).setIdleTimeout(50);
+        assertThat(captor.getValue(), is("The idle timeout has been set to '50' minutes."));
+    }
+
+    @Test
+    public void testTabComplete() {
+        assertThat(command.tabComplete(null, null, null), is(Collections.emptyList()));
+        assertThat(command.tabComplete(sender, "", new String[0]), is(Collections.emptyList()));
+        assertThat(command.tabComplete(sender, "", new String[]{"12"}), is(Collections.emptyList()));
+        assertThat(command.tabComplete(sender, "", new String[]{"12", "test"}), is(Collections.emptyList()));
+    }
+}

--- a/src/test/java/net/glowstone/command/minecraft/SetIdleTimeoutCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SetIdleTimeoutCommandTest.java
@@ -76,7 +76,7 @@ public class SetIdleTimeoutCommandTest {
 
         assertThat(commandResult, is(false));
         Mockito.verify(opSender).sendMessage(captor.capture());
-        assertThat(captor.getValue(), is(ChatColor.RED + "Timeout has to be positive"));
+        assertThat(captor.getValue(), is(ChatColor.RED + "The number you have entered (-42) is too small, it must be at least 1"));
     }
 
     @Test
@@ -86,19 +86,18 @@ public class SetIdleTimeoutCommandTest {
 
         assertThat(commandResult, is(false));
         Mockito.verify(opSender).sendMessage(captor.capture());
-        assertThat(captor.getValue(), is(ChatColor.RED + "Timeout has to be positive"));
+        assertThat(captor.getValue(), is(ChatColor.RED + "The number you have entered (0) is too small, it must be at least 1"));
     }
 
     @Test
     public void testExecuteSucceeds() {
         final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         final boolean commandResult = command.execute(opSender, "label", new String[]{"50"});
-        PowerMockito.verifyStatic();
-        Bukkit.broadcastMessage(captor.capture());
 
         assertThat(commandResult, is(true));
+        Mockito.verify(opSender).sendMessage(captor.capture());
         Mockito.verify(Bukkit.getServer()).setIdleTimeout(50);
-        assertThat(captor.getValue(), is("The idle timeout has been set to '50' minutes."));
+        assertThat(captor.getValue(), is("Successfully set the idle timeout to 50 minutes."));
     }
 
     @Test

--- a/src/test/java/net/glowstone/command/minecraft/SetWorldSpawnCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SetWorldSpawnCommandTest.java
@@ -1,0 +1,164 @@
+package net.glowstone.command.minecraft;
+
+import net.glowstone.GlowServer;
+import net.glowstone.GlowWorld;
+import net.glowstone.command.CommandUtils;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CommandUtils.class, GlowServer.class, GlowWorld.class})
+public class SetWorldSpawnCommandTest {
+
+    private CommandSender sender, opSender, opPlayer;
+
+    private GlowWorld world;
+
+    private Command command;
+
+    @Before
+    public void before() {
+        sender = PowerMockito.mock(CommandSender.class);
+        opSender = PowerMockito.mock(CommandSender.class);
+        opPlayer = PowerMockito.mock(Player.class);
+        world = PowerMockito.mock(GlowWorld.class);
+        command = new SetWorldSpawnCommand();
+
+        Mockito.when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
+
+        Mockito.when(opPlayer.hasPermission(Mockito.anyString())).thenReturn(true);
+        Mockito.when(opPlayer.getName()).thenReturn("ChuckNorris");
+        Mockito.when(((Entity)opPlayer).getLocation()).thenReturn(new Location(world, 10.5, 20.5, 30.5));
+
+        Mockito.when(world.getMaxHeight()).thenReturn(50);
+
+        PowerMockito.stub(PowerMockito.method(CommandUtils.class, "getWorld", CommandSender.class)).toReturn(world);
+    }
+
+    @Test
+    public void testExecuteFailsWithoutPermission() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(sender, "label", new String[0]);
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(sender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error."));
+    }
+
+    @Test
+    public void testExecuteFailsWithoutWorld() {
+        PowerMockito.stub(PowerMockito.method(CommandUtils.class, "getWorld", CommandSender.class)).toReturn(null);
+        final boolean commandResult = command.execute(sender, "label", new String[0]);
+
+        assertThat(commandResult, is(false));
+    }
+
+    @Test
+    public void testExecuteFailsWithOneParameter() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[1]);
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "Usage: /setworldspawn OR /setworldspawn <x> <y> <z>"));
+    }
+
+    @Test
+    public void testExecuteFailsWithTwoParameters() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[2]);
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "Usage: /setworldspawn OR /setworldspawn <x> <y> <z>"));
+    }
+
+    @Test
+    public void testExecuteFailsWithDefaultLocation() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[0]);
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "Default coordinates can not be used without a physical user."));
+    }
+
+    @Test
+    public void testExecuteFailsWithRelativeLocation() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[]{"~2", "3", "4"});
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "Relative coordinates can not be used without a physical user."));
+    }
+
+    @Test
+    public void testExecuteFailsWithYCoordinatesTooHigh() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[]{"2", "10000", "4"});
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "'10000' is too high for the current world. Max value is '50'."));
+    }
+
+    @Test
+    public void testExecuteFailsWithYCoordinatesTooSmall() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[]{"2", "-10000", "4"});
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        // -10001 because of the floor, it's not supposed to be negative
+        assertThat(captor.getValue(), is(ChatColor.RED + "The y coordinate (-10001) is too small, it must be at least 0."));
+    }
+
+    @Test
+    public void testExecuteSucceedsWithCurrentLocation() {
+        final boolean commandResult = command.execute(opPlayer, "label", new String[0]);
+
+        assertThat(commandResult, is(true));
+        Mockito.verify(world).setSpawnLocation(10, 20, 30);
+    }
+
+    @Test
+    public void testExecuteSucceedsWithSpecificLocation() {
+        final boolean commandResult = command.execute(opPlayer, "label", new String[]{"30", "20", "10"});
+
+        assertThat(commandResult, is(true));
+        Mockito.verify(world).setSpawnLocation(30, 20, 10);
+    }
+
+    @Test
+    public void testExecuteSucceedsWithRelativeLocation() {
+        final boolean commandResult = command.execute(opPlayer, "label", new String[]{"30", "~20", "10"});
+
+        assertThat(commandResult, is(true));
+        Mockito.verify(world).setSpawnLocation(30, 41, 10);
+    }
+
+    @Test
+    public void testTabComplete() {
+        assertThat(command.tabComplete(opSender, "alias", new String[0]), is(Collections.emptyList()));
+        assertThat(command.tabComplete(opSender, "alias", new String[]{"test"}), is(Collections.emptyList()));
+        assertThat(command.tabComplete(opSender, "alias", new String[]{"test", "test"}), is(Collections.emptyList()));
+    }
+}

--- a/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
@@ -120,7 +120,7 @@ public class SpawnPointCommandTest {
 
         assertThat(commandResult, is(false));
         Mockito.verify(opSender).sendMessage(captor.capture());
-        assertThat(captor.getValue(), is(ChatColor.RED + "Current sender is not a player."));
+        assertThat(captor.getValue(), is(ChatColor.RED + "You must specify which player you wish to perform this action on."));
     }
 
     @Test

--- a/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
@@ -4,7 +4,9 @@ import com.google.common.collect.ImmutableList;
 import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
 import net.glowstone.command.CommandUtils;
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
@@ -161,6 +163,16 @@ public class SpawnPointCommandTest {
         assertThat(commandResult, is(false));
         Mockito.verify(opSender).sendMessage(captor.capture());
         assertThat(captor.getValue(), is(ChatColor.RED + "'10000.5' is too high for the current world. Max value is '50'."));
+    }
+
+    @Test
+    public void testExecuteFailsWithYCoordinatesTooSmall() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[]{"player1", "2", "-10000", "4"});
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "The y coordinate (-10000.5) is too small, it must be at least 0."));
     }
 
     @Test

--- a/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
@@ -1,0 +1,229 @@
+package net.glowstone.command.minecraft;
+
+import com.google.common.collect.ImmutableList;
+import net.glowstone.GlowServer;
+import net.glowstone.GlowWorld;
+import net.glowstone.command.CommandUtils;
+import org.bukkit.*;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Bukkit.class, CommandUtils.class, GlowServer.class, GlowWorld.class})
+public class SpawnPointCommandTest {
+
+    private CommandSender sender, opSender, opPlayer;
+
+    private Player fakePlayer1, fakePlayer2, fakePlayer3;
+
+    private Command command;
+
+    private GlowWorld world;
+
+    private GlowServer server;
+
+    @Before
+    public void before() {
+        server = PowerMockito.mock(GlowServer.class);
+
+        fakePlayer1 = PowerMockito.mock(Player.class);
+        fakePlayer2 = PowerMockito.mock(Player.class);
+        fakePlayer3 = PowerMockito.mock(Player.class);
+
+        sender = PowerMockito.mock(CommandSender.class);
+        opSender = PowerMockito.mock(CommandSender.class);
+        opPlayer = PowerMockito.mock(Player.class);
+        world = PowerMockito.mock(GlowWorld.class);
+        command = new SpawnPointCommand();
+
+        Mockito.when(fakePlayer1.getName()).thenReturn("player1");
+        Mockito.when(fakePlayer2.getName()).thenReturn("player2");
+        Mockito.when(fakePlayer3.getName()).thenReturn("thePlayer3");
+        Mockito.when(fakePlayer1.getLocation()).thenReturn(new Location(world, 10.5, 20.5, 30.5));
+        Mockito.when(fakePlayer2.getLocation()).thenReturn(new Location(world, 10.5, 20.5, 30.5));
+        Mockito.when(fakePlayer3.getLocation()).thenReturn(new Location(world, 10.5, 20.5, 30.5));
+        Mockito.when(fakePlayer1.getType()).thenReturn(EntityType.PLAYER);
+        Mockito.when(fakePlayer2.getType()).thenReturn(EntityType.PLAYER);
+        Mockito.when(fakePlayer3.getType()).thenReturn(EntityType.PLAYER);
+
+        Mockito.when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
+        Mockito.when(opSender.getServer()).thenReturn(server);
+
+        Mockito.when(opPlayer.hasPermission(Mockito.anyString())).thenReturn(true);
+        Mockito.when(opPlayer.getName()).thenReturn("ChuckNorris");
+        Mockito.when(((Entity)opPlayer).getLocation()).thenReturn(new Location(world, 10.5, 20.5, 30.5));
+
+        Mockito.doReturn(ImmutableList.of(fakePlayer1, fakePlayer2, fakePlayer3))
+                .when(server).getOnlinePlayers();
+
+        Mockito.when(world.getMaxHeight()).thenReturn(50);
+        Mockito.when(world.getEntities()).thenReturn(ImmutableList.of(fakePlayer1, fakePlayer2, fakePlayer3));
+
+        PowerMockito.mockStatic(Bukkit.class);
+        Mockito.when(Bukkit.getPlayerExact("player1")).thenReturn(fakePlayer1);
+        Mockito.when(Bukkit.getPlayerExact("player2")).thenReturn(fakePlayer2);
+        Mockito.when(Bukkit.getPlayerExact("thePlayer3")).thenReturn(fakePlayer3);
+
+        PowerMockito.stub(PowerMockito.method(CommandUtils.class, "getWorld", CommandSender.class)).toReturn(world);
+    }
+
+    @Test
+    public void testExecuteFailsWithoutPermission() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(sender, "label", new String[0]);
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(sender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error."));
+    }
+
+    @Test
+    public void testExecuteFailsWithTwoParameters() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[2]);
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "Usage: /spawnpoint OR /spawnpoint <player> OR /spawnpoint <player> <x> <y> <z>"));
+    }
+
+    @Test
+    public void testExecuteFailsWithThreeParameters() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[3]);
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "Usage: /spawnpoint OR /spawnpoint <player> OR /spawnpoint <player> <x> <y> <z>"));
+    }
+
+    @Test
+    public void testExecuteFailsWithSenderNotPlayer() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[0]);
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "Current sender is not a player."));
+    }
+
+    @Test
+    public void testExecuteFailsUnknownTarget() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[]{"player"});
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "Player 'player' cannot be found"));
+    }
+
+    @Test
+    public void testExecuteFailsWithDefaultLocation() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[]{"player1"});
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "Default coordinates can not be used without a physical user."));
+    }
+
+    @Test
+    public void testExecuteFailsWithRelativeLocation() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[]{"player1", "~2", "3", "4"});
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "Relative coordinates can not be used without a physical user."));
+    }
+
+    @Test
+    public void testExecuteFailsWithYCoordinatesTooHigh() {
+        final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[]{"player1", "2", "10000", "4"});
+
+        assertThat(commandResult, is(false));
+        Mockito.verify(opSender).sendMessage(captor.capture());
+        assertThat(captor.getValue(), is(ChatColor.RED + "'10000.5' is too high for the current world. Max value is '50'."));
+    }
+
+    @Test
+    public void testExecuteSucceedsWithCurrentLocation() {
+        final boolean commandResult = command.execute(opPlayer, "label", new String[0]);
+
+        assertThat(commandResult, is(true));
+        Mockito.verify((Player) opPlayer).setBedSpawnLocation(new Location(world, 10.5, 20.5, 30.5), true);
+    }
+
+    @Test
+    public void testExecuteSucceedsOnAnotherPlayerWithCurrentLocation() {
+        final boolean commandResult = command.execute(opPlayer, "label", new String[]{"player1"});
+
+        assertThat(commandResult, is(true));
+        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 10.5, 20.5, 30.5), true);
+    }
+
+    @Test
+    public void testExecuteSucceedsOnAnotherPlayerWithSpecificLocation() {
+        final boolean commandResult = command.execute(opPlayer, "label", new String[]{"player1", "30", "20", "10"});
+
+        assertThat(commandResult, is(true));
+        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 30.5, 20.5, 10.5), true);
+    }
+
+    @Test
+    public void testExecuteSucceedsAllPlayersWithCurrentLocation() {
+        final boolean commandResult = command.execute(opPlayer, "label", new String[]{"@a"});
+
+        assertThat(commandResult, is(true));
+        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 10.5, 20.5, 30.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("player2")).setBedSpawnLocation(new Location(world, 10.5, 20.5, 30.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("thePlayer3")).setBedSpawnLocation(new Location(world, 10.5, 20.5, 30.5), true);
+    }
+
+    @Test
+    public void testExecuteSucceedsAllPlayersWithSpecificLocation() {
+        final boolean commandResult = command.execute(opPlayer, "label", new String[]{"@a", "30", "20", "10"});
+
+        assertThat(commandResult, is(true));
+        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 30.5, 20.5, 10.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("player2")).setBedSpawnLocation(new Location(world, 30.5, 20.5, 10.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("thePlayer3")).setBedSpawnLocation(new Location(world, 30.5, 20.5, 10.5), true);
+    }
+
+    @Test
+    public void testExecuteSucceedsAllPlayersWithRelativeLocation() {
+        final boolean commandResult = command.execute(opPlayer, "label", new String[]{"@a", "30", "~20", "10"});
+
+        assertThat(commandResult, is(true));
+        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 30.5, 41, 10.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("player2")).setBedSpawnLocation(new Location(world, 30.5, 41, 10.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("thePlayer3")).setBedSpawnLocation(new Location(world, 30.5, 41, 10.5), true);
+    }
+
+    @Test
+    public void testTabComplete() {
+        assertThat(command.tabComplete(opSender, "alias", new String[0]), is(Collections.emptyList()));
+        assertThat(command.tabComplete(opSender, "alias", new String[]{""}), is(ImmutableList.of("player1", "player2", "thePlayer3")));
+        assertThat(command.tabComplete(opSender, "alias", new String[]{"player"}), is(ImmutableList.of("player1", "player2")));
+        assertThat(command.tabComplete(opSender, "alias", new String[]{"th"}), is(ImmutableList.of("thePlayer3")));
+        assertThat(command.tabComplete(opSender, "alias", new String[]{"12", "test"}), is(Collections.emptyList()));
+        assertThat(command.tabComplete(opSender, "alias", new String[]{"player", "test"}), is(Collections.emptyList()));
+    }
+}

--- a/src/test/java/net/glowstone/command/minecraft/ToggleDownfallCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/ToggleDownfallCommandTest.java
@@ -1,0 +1,85 @@
+package net.glowstone.command.minecraft;
+
+import net.glowstone.GlowWorld;
+import net.glowstone.command.CommandUtils;
+import org.bukkit.World;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({CommandUtils.class, GlowWorld.class})
+public class ToggleDownfallCommandTest {
+
+    private World world;
+
+    private Command command;
+
+    private CommandSender sender, opSender;
+
+    @Before
+    public void before() {
+        world = PowerMockito.mock(GlowWorld.class);
+        command = new ToggleDownfallCommand();
+        sender = PowerMockito.mock(CommandSender.class);
+        opSender = PowerMockito.mock(CommandSender.class);
+
+        Mockito.when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
+        PowerMockito.stub(PowerMockito.method(CommandUtils.class, "getWorld", CommandSender.class)).toReturn(world);
+    }
+
+    @Test
+    public void testExecuteFailsWithoutPermission() {
+        final boolean commandResult = command.execute(sender, "label", new String[0]);
+
+        assertThat(commandResult, is(false));
+    }
+
+    @Test
+    public void testExecuteSetRain() {
+        PowerMockito.when(world.hasStorm()).thenReturn(true);
+        final ArgumentCaptor<Boolean> stormCaptor = ArgumentCaptor.forClass(Boolean.class);
+        final ArgumentCaptor<Boolean> thunderingCaptor = ArgumentCaptor.forClass(Boolean.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[0]);
+
+        assertThat(commandResult, is(true));
+        Mockito.verify(world).setStorm(stormCaptor.capture());
+        Mockito.verify(world).setThundering(thunderingCaptor.capture());
+        assertThat(stormCaptor.getValue(), is(false));
+        assertThat(thunderingCaptor.getValue(), is(false));
+    }
+
+    @Test
+    public void testExecuteClearWeather() {
+        PowerMockito.when(world.hasStorm()).thenReturn(false);
+        final ArgumentCaptor<Boolean> stormCaptor = ArgumentCaptor.forClass(Boolean.class);
+        final ArgumentCaptor<Boolean> thunderingCaptor = ArgumentCaptor.forClass(Boolean.class);
+        final boolean commandResult = command.execute(opSender, "label", new String[0]);
+
+        assertThat(commandResult, is(true));
+        Mockito.verify(world).setStorm(stormCaptor.capture());
+        Mockito.verify(world).setThundering(thunderingCaptor.capture());
+        assertThat(stormCaptor.getValue(), is(true));
+        assertThat(thunderingCaptor.getValue(), is(true));
+    }
+
+    @Test
+    public void testTabComplete() {
+        assertThat(command.tabComplete(opSender, "alias", new String[0]), is(Collections.emptyList()));
+        assertThat(command.tabComplete(opSender, "alias", new String[]{""}), is(Collections.emptyList()));
+        assertThat(command.tabComplete(opSender, "alias", new String[]{"test"}), is(Collections.emptyList()));
+        assertThat(command.tabComplete(opSender, "alias", new String[]{"test", "test"}), is(Collections.emptyList()));
+    }
+}


### PR DESCRIPTION
Hi,

Another PR on the https://github.com/GlowstoneMC/Glowstone/issues/499 issue. This time, I added toggledownfall,  spawnpoint and setidletimeout.

I saw that no commands had unit tests so far. I implemented some on those three commands mainly using mockito. Tell me what you think of it, if it's really relevant or not.

Edit: I also added the /setworldspawn command.