### PR TITLE
Support multiple passengers

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -899,9 +899,6 @@ public abstract class GlowEntity implements Entity {
             setRawLocation(location.clone().add(velocity));
         }
 
-        // apply location changes to all passengers
-
-
         // apply friction and gravity
         if (location.getBlock().getType() == Material.WATER) {
             velocity.multiply(liquidDrag);
@@ -1177,11 +1174,11 @@ public abstract class GlowEntity implements Entity {
 
     @Override
     public boolean setPassenger(Entity bPassenger) {
-        Preconditions.checkArgument(bPassenger != this, "Entity cannot ride itself.");
+        Preconditions.checkArgument(!this.equals(bPassenger), "Entity cannot ride itself.");
 
         boolean result = false;
         for (Entity passenger : Lists.newArrayList(passengers)) {
-            if (passenger != bPassenger) {
+            if (!Objects.equals(passenger, bPassenger)) {
                 result = !removePassenger(passenger);
             }
         }

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -999,6 +999,7 @@ public abstract class GlowEntity implements Entity {
         boundingBox = null;
         world.getEntityManager().unregister(this);
         server.getEntityIdManager().deallocate(this);
+        this.setPassenger(null);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -1122,7 +1123,7 @@ public abstract class GlowEntity implements Entity {
 
     @Override
     public boolean removePassenger(Entity passenger) {
-        Preconditions.checkArgument(passenger != this, "Entity cannot ride itself.");
+        Preconditions.checkArgument(!this.equals(passenger), "Entity cannot ride itself.");
 
         if (passenger == null || !passengers.contains(passenger)) return false; // nothing changed
 
@@ -1139,12 +1140,14 @@ public abstract class GlowEntity implements Entity {
         passengerChanged = true;
         glowPassenger.vehicle = null;
 
+        glowPassenger.teleport(getDismountLocation());
+
         return passengers.remove(passenger);
     }
 
     @Override
     public boolean addPassenger(Entity passenger) {
-        Preconditions.checkArgument(passenger != this, "Entity cannot ride itself.");
+        Preconditions.checkArgument(!this.equals(passenger), "Entity cannot ride itself.");
 
         if (passenger == null || passengers.contains(passenger)) return false; // nothing changed
 
@@ -1164,14 +1167,12 @@ public abstract class GlowEntity implements Entity {
             return false;
         }
 
-        this.passengers.add(passenger);
+        passengerChanged = true;
         glowPassenger.vehicle = this;
-        this.passengerChanged = true;
 
-        Location onTopOfVehicle = this.location.clone().add(0, this.getHeight(), 0);
-        glowPassenger.teleport(onTopOfVehicle);
+        glowPassenger.teleport(getMountLocation());
 
-        return true;
+        return this.passengers.add(passenger);
     }
 
     @Override
@@ -1190,6 +1191,14 @@ public abstract class GlowEntity implements Entity {
         }
 
         return !result;
+    }
+
+    protected Location getMountLocation() {
+        return this.location.clone().add(0, this.getHeight(), 0);
+    }
+
+    protected Location getDismountLocation() {
+        return this.location;
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -135,7 +135,7 @@ public abstract class GlowEntity implements Entity {
     /**
      * Passenger
      */
-    private List<Entity> passengers = new ArrayList<>();
+    private final List<Entity> passengers = new ArrayList<>();
     protected boolean passengerChanged;
     /**
      * Whether gravity applies to the entity.

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -1169,7 +1169,7 @@ public abstract class GlowEntity implements Entity {
         this.passengerChanged = true;
 
         Location onTopOfVehicle = this.location.clone().add(0, this.getHeight(), 0);
-        glowPassenger.setRawLocation(onTopOfVehicle, false);
+        glowPassenger.teleport(onTopOfVehicle);
 
         return true;
     }

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -2,6 +2,7 @@ package net.glowstone.entity;
 
 import com.flowpowered.network.Message;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import lombok.Getter;
 import net.glowstone.EventFactory;
 import net.glowstone.GlowServer;
@@ -134,7 +135,7 @@ public abstract class GlowEntity implements Entity {
     /**
      * Passenger
      */
-    private GlowEntity passenger;
+    private List<Entity> passengers = new ArrayList<>();
     protected boolean passengerChanged;
     /**
      * Whether gravity applies to the entity.
@@ -465,7 +466,6 @@ public abstract class GlowEntity implements Entity {
         metadata.resetChanges();
         teleported = false;
         velocityChanged = false;
-        passengerChanged = false;
     }
 
     /**
@@ -581,6 +581,7 @@ public abstract class GlowEntity implements Entity {
         if (passengerChanged) {
             //this method will not call for this player, we don't need check SELF_ID
             result.add(new SetPassengerMessage(getEntityId(), getPassengers().stream().mapToInt(Entity::getEntityId).toArray()));
+            passengerChanged = false;
         }
 
         return result;
@@ -898,6 +899,9 @@ public abstract class GlowEntity implements Entity {
             setRawLocation(location.clone().add(velocity));
         }
 
+        // apply location changes to all passengers
+
+
         // apply friction and gravity
         if (location.getBlock().getType() == Material.WATER) {
             velocity.multiply(liquidDrag);
@@ -1040,7 +1044,7 @@ public abstract class GlowEntity implements Entity {
 
     @Override
     public boolean leaveVehicle() {
-        return isInsideVehicle() && vehicle.setPassenger(null); // TODO: multiple passengers
+        return isInsideVehicle() && vehicle.removePassenger(this);
     }
 
     @Override
@@ -1105,73 +1109,92 @@ public abstract class GlowEntity implements Entity {
 
     @Override
     public Entity getPassenger() {
-        return passenger;
+        if (passengers.size() > 0) {
+            return passengers.get(0);
+        }
+        return null;
     }
 
     @Override
     public List<Entity> getPassengers() {
-        return Arrays.asList(new Entity[]{passenger}); // TODO: multiple passengers
+        return Collections.unmodifiableList(passengers);
     }
 
     @Override
     public boolean removePassenger(Entity passenger) {
-        return passenger.leaveVehicle();
+        Preconditions.checkArgument(passenger != this, "Entity cannot ride itself.");
+
+        if (passenger == null || !passengers.contains(passenger)) return false; // nothing changed
+
+        if (EventFactory.callEvent(new EntityDismountEvent(passenger, this)).isCancelled()) {
+            return false;
+        }
+
+        if (!(passenger instanceof GlowEntity)) {
+            return false;
+        }
+
+        GlowEntity glowPassenger = (GlowEntity) passenger;
+
+        passengerChanged = true;
+        glowPassenger.vehicle = null;
+
+        return passengers.remove(passenger);
     }
 
     @Override
     public boolean addPassenger(Entity passenger) {
-        return setPassenger(passenger); // TODO: multiple passengers
+        Preconditions.checkArgument(passenger != this, "Entity cannot ride itself.");
+
+        if (passenger == null || passengers.contains(passenger)) return false; // nothing changed
+
+        if (!(passenger instanceof GlowEntity)) {
+            return false;
+        }
+
+        GlowEntity glowPassenger = (GlowEntity) passenger;
+
+        if (glowPassenger.vehicle != null) {
+            glowPassenger.vehicle.removePassenger(passenger);
+        }
+
+        EntityMountEvent event = new EntityMountEvent(passenger, this);
+        EventFactory.callEvent(event);
+        if (event.isCancelled()) {
+            return false;
+        }
+
+        this.passengers.add(passenger);
+        glowPassenger.vehicle = this;
+        this.passengerChanged = true;
+
+        Location onTopOfVehicle = this.location.clone().add(0, this.getHeight(), 0);
+        glowPassenger.setRawLocation(onTopOfVehicle, false);
+
+        return true;
     }
 
     @Override
     public boolean setPassenger(Entity bPassenger) {
         Preconditions.checkArgument(bPassenger != this, "Entity cannot ride itself.");
 
-        if (passenger == bPassenger) return false; // nothing changed
-
-        if (bPassenger == null) {
-
-            EventFactory.callEvent(new EntityDismountEvent(passenger, this));
-
-            passengerChanged = true;
-            passenger.vehicle = null;
-            passenger = null;
-        } else {
-
-            if (!(bPassenger instanceof GlowEntity)) {
-                return false;
+        boolean result = false;
+        for (Entity passenger : Lists.newArrayList(passengers)) {
+            if (passenger != bPassenger) {
+                result = !removePassenger(passenger);
             }
-
-            GlowEntity passenger = (GlowEntity) bPassenger;
-
-            if (passenger.vehicle != null) {
-                EventFactory.callEvent(new EntityDismountEvent(passenger, passenger.vehicle));
-                passenger.vehicle.passenger = null;
-                passenger.vehicle = null;
-            }
-
-            EntityMountEvent event = new EntityMountEvent(passenger, this);
-            EventFactory.callEvent(event);
-            if (event.isCancelled()) {
-                return false;
-            }
-
-            if (this.passenger != null) {
-                EventFactory.callEvent(new EntityDismountEvent(this.passenger, this));
-                this.passengerChanged = true;
-                this.passenger.vehicle = null;
-            }
-
-            this.passenger = passenger;
-            this.passenger.vehicle = this;
-            this.passengerChanged = true;
         }
-        return true;
+
+        if (bPassenger != null && passengers.size() == 0) {
+            result = !addPassenger(bPassenger);
+        }
+
+        return !result;
     }
 
     @Override
     public boolean isEmpty() {
-        return getPassenger() == null;
+        return getPassengers().isEmpty();
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
@@ -82,6 +82,7 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
 
         System.arraycopy(defaultPose, 0, pose, 0, 6);
         this.getEquipmentMonitor().resetChanges();
+        setSize(false);
     }
 
     @Override
@@ -530,6 +531,15 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
     public void setSmall(boolean small) {
         isSmall = small;
         metadata.setBit(MetadataIndex.ARMORSTAND_FLAGS, ArmorStandFlags.IS_SMALL, small);
+        setSize(small);
+    }
+
+    private void setSize(boolean small) {
+        if (small) {
+            setSize(0.25f, 0.9875f);
+        } else {
+            setSize(0.5f, 1.975f);
+        }
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
@@ -28,6 +28,7 @@ public abstract class GlowMinecart extends GlowEntity implements Minecart {
 
     public GlowMinecart(Location location, MinecartType type) {
         super(location);
+        setSize(0.98f, 0.7f);
         this.type = type;
     }
 

--- a/src/main/java/net/glowstone/entity/passive/GlowAbstractHorse.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowAbstractHorse.java
@@ -22,6 +22,7 @@ public abstract class GlowAbstractHorse extends GlowTameable implements Abstract
 
     public GlowAbstractHorse(Location location, EntityType type, double maxHealth) {
         super(location, type, maxHealth);
+        setSize(1.3964f, 1.6f);
     }
 
     @Override

--- a/src/main/java/net/glowstone/io/anvil/AnvilChunkIoService.java
+++ b/src/main/java/net/glowstone/io/anvil/AnvilChunkIoService.java
@@ -218,6 +218,10 @@ public final class AnvilChunkIoService implements ChunkIoService {
             if (!entity.shouldSave()) {
                 continue;
             }
+            // passengers will be saved as part of the vehicle
+            if (entity.isInsideVehicle()) {
+                continue;
+            }
             try {
                 CompoundTag tag = new CompoundTag();
                 EntityStorage.save(entity, tag);

--- a/src/main/java/net/glowstone/io/entity/EntityStore.java
+++ b/src/main/java/net/glowstone/io/entity/EntityStore.java
@@ -133,7 +133,7 @@ public abstract class EntityStore<T extends GlowEntity> {
             if (e.getMessage() != null && e.getMessage().startsWith("Unknown entity type to load:")) {
                 GlowServer.logger.warning("Skipping Entity with id " + id);
             } else {
-                GlowServer.logger.log(Level.WARNING, "Error loading entity "+id, e);
+                GlowServer.logger.log(Level.WARNING, "Error loading entity " + id, e);
             }
         }
         return null;

--- a/src/main/java/net/glowstone/io/entity/EntityStore.java
+++ b/src/main/java/net/glowstone/io/entity/EntityStore.java
@@ -130,7 +130,11 @@ public abstract class EntityStore<T extends GlowEntity> {
             return EntityStorage.loadEntity(vehicle.getWorld(), compoundTag);
         } catch (Exception e) {
             String id = compoundTag.isString("id") ? compoundTag.getString("id") : "<missing>";
-            GlowServer.logger.warning("Skipping Entity with id " + id);
+            if (e.getMessage() != null && e.getMessage().startsWith("Unknown entity type to load:")) {
+                GlowServer.logger.warning("Skipping Entity with id " + id);
+            } else {
+                GlowServer.logger.log(Level.WARNING, "Error loading entity "+id, e);
+            }
         }
         return null;
     }


### PR DESCRIPTION
This PR attempts to implement multiple passengers per vehicle.

Save and load Passengers. When an entity is a passenger, it will only be saved as child of its vehicle, and never alone.
Adjust api implementation to be (hopefully) in line with papers.
Also set the size for armorstands and horses.

closes #522
related to #504