### PR TITLE
#526 and #525 - Fix shift click when crafting and refresh the crafting result slot

### DIFF
--- a/src/main/java/net/glowstone/inventory/GlowCraftingInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowCraftingInventory.java
@@ -67,16 +67,15 @@ public class GlowCraftingInventory extends GlowInventory implements CraftingInve
             // Place the items in the player's inventory (right to left)
             player.getInventory().tryToFillSlots(clickedItem, 8, -1, 35, 8);
 
-            // Craft the items, removing the ingredients from the crafting matrix
-            for (int i = 0; i < recipeAmount; i++) {
-                craft();
-            }
+            // Avoid calling craft because we already know the player can craft 'recipeAmount' of this item
+            CraftingManager cm = ((GlowServer) Bukkit.getServer()).getCraftingManager();
+            // Removing all the items at once will avoid multiple useless calls to craft (and all of its sub methods like getRecipe)
+            cm.removeItems(getMatrix(), this, recipeAmount);
         } else {
             // Clicked in the crafting grid, no special handling required (just place them left to right)
             clickedItem = player.getInventory().tryToFillSlots(clickedItem, 9, 36, 0, 9);
             view.setItem(clickedSlot, clickedItem);
         }
-
     }
 
     @Override

--- a/src/main/java/net/glowstone/inventory/GlowCraftingInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowCraftingInventory.java
@@ -65,7 +65,7 @@ public class GlowCraftingInventory extends GlowInventory implements CraftingInve
             player.getInventory().tryToFillSlots(clickedItem, 8, -1, 35, 8);
 
             // Avoid calling craft because we already know the player can craft 'recipeAmount' of this item
-            CraftingManager cm = ((GlowServer) Bukkit.getServer()).getCraftingManager();
+            CraftingManager cm = player.getServer().getCraftingManager();
             // Removing all the items at once will avoid multiple useless calls to craft (and all of its sub methods like getRecipe)
             cm.removeItems(matrix, this, recipeAmount);
         } else {

--- a/src/main/java/net/glowstone/inventory/crafting/CraftingManager.java
+++ b/src/main/java/net/glowstone/inventory/crafting/CraftingManager.java
@@ -93,11 +93,24 @@ public final class CraftingManager implements Iterable<Recipe> {
      * @param inv   The inventory to remove the items from.
      */
     public void removeItems(ItemStack[] items, GlowCraftingInventory inv) {
+        this.removeItems(items, inv, 1);
+    }
+
+    /**
+     * Remove a specific amount of layers from the crafting matrix and recipe result.
+     *
+     * @param items The items to remove the ingredients from.
+     * @param inv   The inventory to remove the items from.
+     * @param amount The amount of items you want to remove.
+     */
+    public void removeItems(final ItemStack[] items, final GlowCraftingInventory inv, final int amount) {
+        if (amount < 0) throw new IllegalArgumentException("Can not remove negative amount of layers.");
+
         for (int i = 0; i < items.length; i++) {
             if (!InventoryUtil.isEmpty(items[i])) {
-                int amount = items[i].getAmount();
-                if (amount > 1) {
-                    items[i].setAmount(amount - 1);
+                int itemAmount = items[i].getAmount();
+                if (itemAmount > amount) {
+                    items[i].setAmount(itemAmount - amount);
                 } else {
                     inv.setItem(i + 1, InventoryUtil.createEmptyStack());
                 }
@@ -115,7 +128,7 @@ public final class CraftingManager implements Iterable<Recipe> {
     public static int getLayers(ItemStack... items) {
         int layers = 0;
         for (ItemStack item : items) {
-            if (item != null && (item.getAmount() < layers || layers == 0)) {
+            if (item != null && item.getAmount() != 0 && (item.getAmount() < layers || layers == 0)) {
                 layers = item.getAmount();
             }
         }

--- a/src/main/java/net/glowstone/inventory/crafting/CraftingManager.java
+++ b/src/main/java/net/glowstone/inventory/crafting/CraftingManager.java
@@ -129,7 +129,7 @@ public final class CraftingManager implements Iterable<Recipe> {
     public static int getLayers(ItemStack... items) {
         int layers = 0;
         for (ItemStack item : items) {
-            if (item != null && item.getAmount() != 0 && (item.getAmount() < layers || layers == 0)) {
+            if (!InventoryUtil.isEmpty(item) && (item.getAmount() < layers || layers == 0)) {
                 layers = item.getAmount();
             }
         }

--- a/src/main/java/net/glowstone/inventory/crafting/CraftingManager.java
+++ b/src/main/java/net/glowstone/inventory/crafting/CraftingManager.java
@@ -111,6 +111,7 @@ public final class CraftingManager implements Iterable<Recipe> {
                 int itemAmount = items[i].getAmount();
                 if (itemAmount > amount) {
                     items[i].setAmount(itemAmount - amount);
+                    inv.updateResultSlot();
                 } else {
                     inv.setItem(i + 1, InventoryUtil.createEmptyStack());
                 }

--- a/src/main/java/net/glowstone/net/handler/play/inv/WindowClickHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/WindowClickHandler.java
@@ -402,13 +402,8 @@ public final class WindowClickHandler implements MessageHandler<GlowSession, Win
             // If we are crafting (but not using shift click because no more items can be crafted for the given pattern. If a new item can be crafted with another pattern, a new click is required).
             final GlowCraftingInventory glowCraftingInventory = (GlowCraftingInventory) top;
             glowCraftingInventory.craft();
-            // Refresh the result slot with the next item (if any)
-            Recipe nextItem = glowCraftingInventory.getRecipe();
-
-            if (nextItem != null) {
-                glowCraftingInventory.setResult(nextItem.getResult());
-                player.sendItemChange(viewSlot, nextItem.getResult());
-            }
+            // Notify the player the result slot changed
+            player.sendItemChange(viewSlot, glowCraftingInventory.getResult());
         }
 
         if (!handled) {

--- a/src/main/java/net/glowstone/net/handler/play/inv/WindowClickHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/WindowClickHandler.java
@@ -397,7 +397,15 @@ public final class WindowClickHandler implements MessageHandler<GlowSession, Win
         }
 
         if (handled && top == inv && top instanceof GlowCraftingInventory && top.getSlotType(invSlot) == SlotType.RESULT) {
-            ((GlowCraftingInventory) top).craft();
+            final GlowCraftingInventory glowCraftingInventory = (GlowCraftingInventory) top;
+            glowCraftingInventory.craft();
+            // Refresh the result slot with the next item (if any)
+            Recipe nextItem = glowCraftingInventory.getRecipe();
+
+            if (nextItem != null) {
+                glowCraftingInventory.setResult(nextItem.getResult());
+                player.sendItemChange(viewSlot, nextItem.getResult());
+            }
         }
 
         if (!handled) {

--- a/src/main/java/net/glowstone/net/handler/play/inv/WindowClickHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/WindowClickHandler.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 
+import static org.bukkit.event.inventory.InventoryAction.MOVE_TO_OTHER_INVENTORY;
+
 public final class WindowClickHandler implements MessageHandler<GlowSession, WindowClickMessage> {
     @Override
     public void handle(GlowSession session, WindowClickMessage message) {
@@ -396,7 +398,8 @@ public final class WindowClickHandler implements MessageHandler<GlowSession, Win
                 break;
         }
 
-        if (handled && top == inv && top instanceof GlowCraftingInventory && top.getSlotType(invSlot) == SlotType.RESULT) {
+        if (handled && top == inv && top instanceof GlowCraftingInventory && top.getSlotType(invSlot) == SlotType.RESULT && action != MOVE_TO_OTHER_INVENTORY) {
+            // If we are crafting (but not using shift click because no more items can be crafted for the given pattern. If a new item can be crafted with another pattern, a new click is required).
             final GlowCraftingInventory glowCraftingInventory = (GlowCraftingInventory) top;
             glowCraftingInventory.craft();
             // Refresh the result slot with the next item (if any)


### PR DESCRIPTION
Hi,

This PR relates to the following issues :

- https://github.com/GlowstoneMC/Glowstone/issues/525
- https://github.com/GlowstoneMC/Glowstone/issues/526

The crafting result slot is now updated if a new item can be crafted. Also, I fixed the shift click on crafting as well. 

There is still one little thing I need to fix : when shift clicking, the amount of layers is first reduced by 1 and right after completely reset. The result is correct, all the items are crafted and the required items removed, but the layers are supposed to be removed all at once.