### PR TITLE
Cleanup itemframes

### DIFF
--- a/src/main/java/net/glowstone/block/itemtype/ItemItemFrame.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemItemFrame.java
@@ -2,10 +2,12 @@ package net.glowstone.block.itemtype;
 
 
 import com.flowpowered.network.Message;
+import net.glowstone.EventFactory;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.objects.GlowItemFrame;
 import org.bukkit.block.BlockFace;
+import org.bukkit.event.hanging.HangingPlaceEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
@@ -16,7 +18,12 @@ public class ItemItemFrame extends ItemType {
 
     @Override
     public void rightClickBlock(GlowPlayer player, GlowBlock target, BlockFace face, ItemStack holding, Vector clickedLoc, EquipmentSlot hand) {
-        GlowItemFrame entity = new GlowItemFrame(player, target.getLocation().getBlock().getRelative(face).getLocation(), face);
+        GlowItemFrame entity = new GlowItemFrame(player, target.getRelative(face).getLocation(), face);
+
+        if (EventFactory.callEvent(new HangingPlaceEvent(entity, player, target, face)).isCancelled()) {
+            return;
+        }
+
         List<Message> spawnMessage = entity.createSpawnMessage();
         entity.getWorld().getRawPlayers().stream().filter(p -> p.canSeeEntity(entity)).forEach(p -> p.getSession().sendAll(spawnMessage.toArray(new Message[spawnMessage.size()])));
     }

--- a/src/main/java/net/glowstone/entity/GlowHangingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowHangingEntity.java
@@ -35,8 +35,7 @@ public abstract class GlowHangingEntity extends GlowEntity implements Hanging {
         EAST(BlockFace.EAST);
 
         private BlockFace blockFace;
-
-        private static Map<BlockFace, HangingFace> byBlockFace = new HashMap<>();
+        private static final Map<BlockFace, HangingFace> byBlockFace = new HashMap<>();
 
         static {
             for (HangingFace hangingFace : values()) {

--- a/src/main/java/net/glowstone/entity/GlowHangingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowHangingEntity.java
@@ -1,0 +1,51 @@
+package net.glowstone.entity;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.bukkit.Location;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Hanging;
+
+public abstract class GlowHangingEntity extends GlowEntity implements Hanging {
+    protected HangingFace facing = HangingFace.SOUTH;
+
+    public GlowHangingEntity(Location location, BlockFace clickedface) {
+        super(location);
+        facing = HangingFace.getByBlockFace(clickedface);
+    }
+
+    @Override
+    public BlockFace getAttachedFace() {
+        return facing.getBlockFace().getOppositeFace();
+    }
+
+    @Override
+    public BlockFace getFacing() {
+        return facing.getBlockFace();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public enum HangingFace {
+        SOUTH(BlockFace.SOUTH),
+        WEST(BlockFace.WEST),
+        NORTH(BlockFace.NORTH),
+        EAST(BlockFace.EAST);
+
+        private BlockFace blockFace;
+
+        private static Map<BlockFace, HangingFace> byBlockFace = new HashMap<>();
+
+        static {
+            for (HangingFace hangingFace : values()) {
+                byBlockFace.put(hangingFace.blockFace, hangingFace);
+            }
+        }
+
+        public static HangingFace getByBlockFace(BlockFace by) {
+            return byBlockFace.getOrDefault(by, SOUTH);
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
@@ -80,6 +80,7 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
                 }
                 remove();
             } else {
+                world.dropItemNaturally(location, getItem().clone());
                 setItem(new ItemStack(Material.AIR));
                 setRotation(Rotation.NONE);
             }
@@ -94,6 +95,9 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
         if (ticksLived % 11 == 0) {
 
             if (location.getBlock().getRelative(getAttachedFace()).getType() == Material.AIR) {
+                if (EventFactory.callEvent(new HangingBreakEvent(this, RemoveCause.PHYSICS)).isCancelled()) {
+                    return;
+                }
                 world.dropItemNaturally(location, new ItemStack(Material.ITEM_FRAME));
                 if (!isEmpty()) {
                     world.dropItemNaturally(location, getItem().clone());
@@ -196,10 +200,10 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
 
     @Override
     public void setItem(ItemStack is) {
-        if (is == null) {
-            is = new ItemStack(Material.AIR, 1);
-        }
+        is = InventoryUtil.itemOrEmpty(is);
+        is = is.clone();
         is.setAmount(1);
+
         metadata.set(MetadataIndex.ITEM_FRAME_ITEM, is);
         setRotation(Rotation.NONE);
     }

--- a/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
@@ -1,8 +1,9 @@
 package net.glowstone.entity.objects;
 
 import com.flowpowered.network.Message;
+import net.glowstone.EventFactory;
 import net.glowstone.chunk.GlowChunk.Key;
-import net.glowstone.entity.GlowEntity;
+import net.glowstone.entity.GlowHangingEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
@@ -10,6 +11,7 @@ import net.glowstone.net.message.play.entity.EntityTeleportMessage;
 import net.glowstone.net.message.play.entity.SpawnObjectMessage;
 import net.glowstone.net.message.play.player.InteractEntityMessage;
 import net.glowstone.net.message.play.player.InteractEntityMessage.Action;
+import net.glowstone.util.InventoryUtil;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -17,22 +19,19 @@ import org.bukkit.Rotation;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemFrame;
+import org.bukkit.event.hanging.HangingBreakEvent;
+import org.bukkit.event.hanging.HangingBreakEvent.RemoveCause;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Arrays;
 import java.util.List;
 
 
-public class GlowItemFrame extends GlowEntity implements ItemFrame {
+public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
 
-    private BlockFace face;
-    private Material itemInFrame;
-    private int rot;
+    public GlowItemFrame(GlowPlayer player, Location location, BlockFace facing) {
 
-    public GlowItemFrame(GlowPlayer player, Location location, BlockFace clickedface) {
-
-        super(location);
-        face = clickedface;
+        super(location, facing);
         if (player != null) { // could be Anvil loading....
             if (player.getGameMode() != GameMode.CREATIVE) {
                 ItemStack is = player.getItemInHand();
@@ -44,81 +43,21 @@ public class GlowItemFrame extends GlowEntity implements ItemFrame {
                 player.setItemInHand(is);
             }
         }
-        metadata.set(MetadataIndex.ITEM_FRAME_ROTATION, 0);
-        metadata.set(MetadataIndex.ITEM_FRAME_ITEM, new ItemStack(Material.AIR));
 
-        itemInFrame = Material.AIR;
-    }
-
-    private static byte getFacingNumber(BlockFace face) {
-        switch (face) {
-            case SOUTH:
-                return 0;
-            case WEST:
-                return 1;
-            case NORTH:
-                return 2;
-            case EAST:
-                return 3;
-            default:
-                return 0;
-        }
-    }
-
-    private static BlockFace getFace(int face) {
-        switch (face) {
-            case 0:
-                return BlockFace.SOUTH;
-            case 1:
-                return BlockFace.WEST;
-            case 2:
-                return BlockFace.NORTH;
-            case 3:
-                return BlockFace.EAST;
-            default:
-                return BlockFace.SOUTH;
-        }
+        setRotation(Rotation.NONE);
+        setItem(new ItemStack(Material.AIR));
     }
 
     // //////////////////////////////////////////////////////////////////////////
     // Overrides
 
-    private static BlockFace inverseGetFace(int face) {
-        switch (face) {
-            case 0:
-                return BlockFace.NORTH;
-            case 1:
-                return BlockFace.EAST;
-            case 2:
-                return BlockFace.SOUTH;
-            case 3:
-                return BlockFace.WEST;
-            default:
-                return BlockFace.NORTH;
-        }
-    }
-
-    public void setItemInFrame(ItemStack is) {
-        if (is == null) {
-            is = new ItemStack(Material.AIR, 1);
-        }
-        is.setAmount(1);
-        itemInFrame = is.getType();
-        metadata.set(MetadataIndex.ITEM_FRAME_ITEM, is);
-        metadata.set(MetadataIndex.ITEM_FRAME_ROTATION, 0);
-    }
-
-    public void setItemFrameRotation(int rotation) {
-        metadata.set(MetadataIndex.ITEM_FRAME_ROTATION, rotation);
-    }
-
     @Override
     public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
         if (message.getAction() == Action.INTERACT.ordinal()) {
-            if (itemInFrame == Material.AIR) {
+            if (InventoryUtil.isEmpty(getItem())) {
                 ItemStack isInHand = player.getItemInHand();
                 if (isInHand != null) {
-                    setItemInFrame(isInHand);
+                    setItem(isInHand);
                     if (player.getGameMode() != GameMode.CREATIVE) {
                         int amount = player.getItemInHand().getAmount();
                         isInHand.setAmount(amount - 1);
@@ -129,19 +68,20 @@ public class GlowItemFrame extends GlowEntity implements ItemFrame {
                     }
                 }
             } else {
-                rot++;
-                if (rot > 7) {
-                    rot = 0;
-                }
-                setItemFrameRotation(rot);
+                int rot = (getRotation().ordinal() + 1) % 8;
+                setRotation(Rotation.values()[rot]);
             }
         }
         if (message.getAction() == Action.ATTACK.ordinal()) {
             if (isEmpty()) {
+                // TODO: use correct RemoveCause
+                if (EventFactory.callEvent(new HangingBreakEvent(this, RemoveCause.DEFAULT)).isCancelled()) {
+                    return false;
+                }
                 remove();
             } else {
-                setItemInFrame(new ItemStack(Material.AIR));
-                rot = 0;
+                setItem(new ItemStack(Material.AIR));
+                setRotation(Rotation.NONE);
             }
         }
         return true;
@@ -153,10 +93,10 @@ public class GlowItemFrame extends GlowEntity implements ItemFrame {
 
         if (ticksLived % 11 == 0) {
 
-            if (location.getBlock().getRelative(face.getOppositeFace()).getType() == Material.AIR) {
+            if (location.getBlock().getRelative(getAttachedFace()).getType() == Material.AIR) {
                 world.dropItemNaturally(location, new ItemStack(Material.ITEM_FRAME));
                 if (!isEmpty()) {
-                    world.dropItemNaturally(location, new ItemStack(itemInFrame));
+                    world.dropItemNaturally(location, getItem().clone());
                 }
                 remove();
             }
@@ -170,53 +110,39 @@ public class GlowItemFrame extends GlowEntity implements ItemFrame {
 
     @Override
     public List<Message> createSpawnMessage() {
-        int yaw = 0;
-        switch (getFacingNumber(face)) {
-            case 1:
-                yaw = 64;
-                break;
-            case 2:
-                yaw = -128;
-                break;
-            case 3:
-                yaw = -64;
-                break;
-            case 0:
-                yaw = 0;
-                break;
-        }
-        return Arrays.asList(new SpawnObjectMessage(id, getUniqueId(), 71, location.getBlockX(), location.getBlockY(), location.getBlockZ(), 0, yaw, getFacingNumber(face), 0, 0, 0), new EntityMetadataMessage(id, metadata.getEntryList()));
+        int yaw = getYaw(getFacing());
+
+        return Arrays.asList(
+            new SpawnObjectMessage(id, getUniqueId(), SpawnObjectMessage.ITEM_FRAME, location.getBlockX(), location.getBlockY(), location.getBlockZ(), 0, yaw, HangingFace.getByBlockFace(getFacing()).ordinal()),
+            new EntityMetadataMessage(id, metadata.getEntryList())
+        );
     }
 
     @Override
     public boolean isEmpty() {
-        return itemInFrame == null || itemInFrame == Material.AIR;
+        return InventoryUtil.isEmpty(getItem());
     }
 
-    void generateTeleportMessage(BlockFace face) {
+    private void createTeleportMessage(BlockFace face) {
         int xoffset = 0;
         int zoffset = 0;
-        int yaw = 0;
-        switch (getFacingNumber(face)) {
-            case 1:
+        int yaw = getYaw(face);
+        switch (face) {
+            case WEST:
                 xoffset = -32;
-                yaw = 64;
                 break;
-            case 2:
+            case NORTH:
                 zoffset = -32;
-                yaw = -128;
                 break;
-            case 3:
+            case EAST:
                 xoffset = 32;
-                yaw = -64;
                 break;
-            case 0:
+            case SOUTH:
                 zoffset = 32;
-                yaw = 0;
                 break;
         }
-        Location itemframelocation = location;
-        Key key = new Key(itemframelocation.getBlockX() >> 4, itemframelocation.getBlockZ() >> 4);
+
+        Key key = new Key(location.getChunk().getX(), location.getChunk().getZ());
         for (GlowPlayer player : getWorld().getRawPlayers()) {
             if (player.canSeeChunk(key)) {
                 double x = location.getX();
@@ -227,15 +153,17 @@ public class GlowItemFrame extends GlowEntity implements ItemFrame {
         }
     }
 
-    @Override
-    public boolean setFacingDirection(BlockFace blockface, boolean force) {
-        generateTeleportMessage(blockface);
-        return true;
-    }
-
-    @Override
-    public void setFacingDirection(BlockFace blockface) {
-        generateTeleportMessage(blockface);
+    private int getYaw(BlockFace face) {
+        switch (getFacing()) {
+            case WEST:
+                return 64;
+            case NORTH:
+                return -128;
+            case EAST:
+                return -64;
+            default:
+                return 0;
+        }
     }
 
     @Override
@@ -249,52 +177,39 @@ public class GlowItemFrame extends GlowEntity implements ItemFrame {
     }
 
     @Override
-    public BlockFace getAttachedFace() {
-        return inverseGetFace(getFacingNumber());
-    }
-
-    @Override
-    public BlockFace getFacing() {
-        return face;
-    }
-
-    public int getFacingNumber() {
-        return getFacingNumber(face);
-    }
-
-    public void setFacingDirectionNumber(int direction) {
-        face = getFace(direction);
-    }
-
-    @Override
     public ItemStack getItem() {
-        return new ItemStack(itemInFrame, 1);
+        return metadata.getItem(MetadataIndex.ITEM_FRAME_ITEM);
+    }
+
+    @Override
+    public boolean setFacingDirection(BlockFace blockface, boolean force) {
+        facing = HangingFace.getByBlockFace(blockface);
+        createTeleportMessage(blockface);
+        return true;
+    }
+
+    @Override
+    public void setFacingDirection(BlockFace blockface) {
+        facing = HangingFace.getByBlockFace(blockface);
+        createTeleportMessage(blockface);
     }
 
     @Override
     public void setItem(ItemStack is) {
-        setItemInFrame(is);
+        if (is == null) {
+            is = new ItemStack(Material.AIR, 1);
+        }
+        is.setAmount(1);
+        metadata.set(MetadataIndex.ITEM_FRAME_ITEM, is);
+        setRotation(Rotation.NONE);
     }
 
     @Override
     public Rotation getRotation() {
-        switch (rot) {
-            case 0:
-                return Rotation.NONE;
-            case 1:
-                return Rotation.CLOCKWISE_45;
-            case 2:
-                return Rotation.CLOCKWISE;
-            case 3:
-                return Rotation.CLOCKWISE_135;
-            case 4:
-                return Rotation.FLIPPED;
-            case 5:
-                return Rotation.FLIPPED_45;
-            case 6:
-                return Rotation.COUNTER_CLOCKWISE;
-            case 7:
-                return Rotation.COUNTER_CLOCKWISE_45;
+        int rot = metadata.getInt(MetadataIndex.ITEM_FRAME_ROTATION);
+
+        if (rot < Rotation.values().length) {
+            return Rotation.values()[rot];
         }
 
         return Rotation.NONE;
@@ -302,7 +217,6 @@ public class GlowItemFrame extends GlowEntity implements ItemFrame {
 
     @Override
     public void setRotation(Rotation rotation) {
-        rot = rotation.ordinal();
-        setItemFrameRotation(rot);
+        metadata.set(MetadataIndex.ITEM_FRAME_ROTATION, rotation.ordinal());
     }
 }

--- a/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
@@ -200,8 +200,7 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
 
     @Override
     public void setItem(ItemStack is) {
-        is = InventoryUtil.itemOrEmpty(is);
-        is = is.clone();
+        is = InventoryUtil.itemOrEmpty(is).clone();
         is.setAmount(1);
 
         metadata.set(MetadataIndex.ITEM_FRAME_ITEM, is);

--- a/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
@@ -21,6 +21,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.hanging.HangingBreakEvent.RemoveCause;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Arrays;
@@ -45,7 +46,7 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
         }
 
         setRotation(Rotation.NONE);
-        setItem(new ItemStack(Material.AIR));
+        setItem(InventoryUtil.createEmptyStack());
     }
 
     // //////////////////////////////////////////////////////////////////////////
@@ -53,7 +54,7 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
 
     @Override
     public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
-        if (message.getAction() == Action.INTERACT.ordinal()) {
+        if (message.getAction() == Action.INTERACT.ordinal() && message.getHandSlot() == EquipmentSlot.HAND) {
             if (InventoryUtil.isEmpty(getItem())) {
                 ItemStack isInHand = player.getItemInHand();
                 if (isInHand != null) {
@@ -81,7 +82,7 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
                 remove();
             } else {
                 world.dropItemNaturally(location, getItem().clone());
-                setItem(new ItemStack(Material.AIR));
+                setItem(InventoryUtil.createEmptyStack());
                 setRotation(Rotation.NONE);
             }
         }

--- a/src/main/java/net/glowstone/io/entity/HangingStore.java
+++ b/src/main/java/net/glowstone/io/entity/HangingStore.java
@@ -1,0 +1,28 @@
+package net.glowstone.io.entity;
+
+import net.glowstone.entity.GlowHangingEntity;
+import net.glowstone.entity.GlowHangingEntity.HangingFace;
+import net.glowstone.util.nbt.CompoundTag;
+import org.bukkit.entity.EntityType;
+
+public abstract class HangingStore<T extends GlowHangingEntity> extends EntityStore<T> {
+
+    public HangingStore(Class<? extends T> clazz, EntityType type) {
+        super(clazz, type);
+    }
+
+    @Override
+    public void load(T entity, CompoundTag tag) {
+        super.load(entity, tag);
+
+        if (tag.isByte("Facing")) {
+            entity.setFacingDirection(HangingFace.values()[tag.getByte("Facing")].getBlockFace());
+        }
+    }
+
+    @Override
+    public void save(T entity, CompoundTag tag) {
+        super.save(entity, tag);
+        tag.putByte("Facing", HangingFace.getByBlockFace(entity.getFacing()).ordinal());
+    }
+}

--- a/src/main/java/net/glowstone/io/entity/ItemFrameStore.java
+++ b/src/main/java/net/glowstone/io/entity/ItemFrameStore.java
@@ -1,5 +1,6 @@
 package net.glowstone.io.entity;
 
+import net.glowstone.entity.GlowHangingEntity.HangingFace;
 import net.glowstone.entity.objects.GlowItemFrame;
 import net.glowstone.io.nbt.NbtSerialization;
 import net.glowstone.util.nbt.CompoundTag;
@@ -7,7 +8,7 @@ import org.bukkit.Location;
 import org.bukkit.Rotation;
 import org.bukkit.entity.EntityType;
 
-class ItemFrameStore extends EntityStore<GlowItemFrame> {
+class ItemFrameStore extends HangingStore<GlowItemFrame> {
 
     public ItemFrameStore() {
         super(GlowItemFrame.class, EntityType.ITEM_FRAME);
@@ -15,9 +16,8 @@ class ItemFrameStore extends EntityStore<GlowItemFrame> {
 
     public GlowItemFrame createEntity(Location location, CompoundTag compound) {
         // item frame will be set by loading code below
-        int facing = compound.getByte("Facing");
         GlowItemFrame itemFrame = new GlowItemFrame(null, location, null);
-        itemFrame.setFacingDirectionNumber(facing);
+
         return itemFrame;
     }
 
@@ -25,11 +25,8 @@ class ItemFrameStore extends EntityStore<GlowItemFrame> {
     public void load(GlowItemFrame entity, CompoundTag tag) {
         super.load(entity, tag);
 
-        if (tag.isByte("Facing")) {
-            entity.setFacingDirectionNumber(tag.getByte("Facing"));
-        }
         if (tag.isCompound("Item")) {
-            entity.setItemInFrame(NbtSerialization.readItem(tag.getCompound("Item")));
+            entity.setItem(NbtSerialization.readItem(tag.getCompound("Item")));
         }
 
         if (tag.isInt("Rotation")) {
@@ -40,7 +37,7 @@ class ItemFrameStore extends EntityStore<GlowItemFrame> {
     @Override
     public void save(GlowItemFrame entity, CompoundTag tag) {
         super.save(entity, tag);
-        tag.putByte("Facing", entity.getFacingNumber());
+        tag.putByte("Facing", HangingFace.getByBlockFace(entity.getFacing()).ordinal());
         tag.putCompound("Item", NbtSerialization.writeItem(entity.getItem(), -1));
         tag.putInt("Rotation", entity.getRotation().ordinal());
     }

--- a/src/main/java/net/glowstone/net/message/play/entity/SpawnObjectMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/entity/SpawnObjectMessage.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 public final class SpawnObjectMessage implements Message {
 
     public static final int ITEM = 2;
+    public static final int ITEM_FRAME = 71;
 
     private final int id;
     private final UUID uuid; //TODO: Handle UUID


### PR DESCRIPTION
Moved facing attribute into new GlowHangingEntity super class.
Remove all methods used to set or get by a "facingNumber", and use the new enum HangingFace instead.
Pull save and load of "Facing" attribute up into new super class "HangingStore".
call some more of the hanging* events, but there are for sure some instances missing where more events should be called.

related to #504, since this is the groundwork for paintings