### PR TITLE
Fix library management

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -312,7 +312,6 @@ public final class GlowServer implements Server {
      */
     public static void main(String... args) {
         try {
-            Thread.currentThread().setContextClassLoader(LibraryManager.getLibraryClassLoader());
             GlowServer server = createFromArguments(args);
 
             // we don't want to run a server when called with --version

--- a/src/main/java/net/glowstone/util/LibraryManager.java
+++ b/src/main/java/net/glowstone/util/LibraryManager.java
@@ -6,17 +6,12 @@ import javax.net.ssl.HttpsURLConnection;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -39,37 +34,10 @@ public final class LibraryManager {
 
     private final ExecutorService downloaderService = Executors.newCachedThreadPool();
 
-    private static final LibraryClassLoader loader = new LibraryClassLoader();
-
     public LibraryManager() {
         // todo: allow configuration of repository, libraries, and directory
         repository = "https://repo.glowstone.net/service/local/repositories/central/content/";
         directory = new File("lib");
-    }
-
-    public static void addToClasspath(String... paths) {
-        try {
-            for (String path : Objects.requireNonNull(paths)) {
-                String trimmedPath;
-                if (path != null && !(trimmedPath = path.trim()).isEmpty()) {
-                    loader.addURL(Paths.get(trimmedPath).toUri().toURL());
-                }
-            }
-        } catch (IllegalArgumentException | MalformedURLException e) {
-            RuntimeException re = new RuntimeException(e);
-            re.setStackTrace(e.getStackTrace());
-            throw re;
-        }
-    }
-
-    public static ClassLoader getLibraryClassLoader() {
-        return loader;
-    }
-
-    public static void addToLibraryPath(String... paths) {
-        for (String path : Objects.requireNonNull(paths)) {
-            loader.addLibPath(path);
-        }
     }
 
     public void run() {
@@ -79,6 +47,8 @@ public final class LibraryManager {
 
         downloaderService.execute(new LibraryDownloader("org.xerial", "sqlite-jdbc", "3.16.1", ""));
         downloaderService.execute(new LibraryDownloader("mysql", "mysql-connector-java", "5.1.42", ""));
+        downloaderService.execute(new LibraryDownloader("org.apache.logging.log4j", "log4j-api", "2.8.1", ""));
+        downloaderService.execute(new LibraryDownloader("org.apache.logging.log4j", "log4j-core", "2.8.1", ""));
         downloaderService.shutdown();
         try {
             downloaderService.awaitTermination(5, TimeUnit.SECONDS);
@@ -124,40 +94,20 @@ public final class LibraryManager {
                 }
             }
 
-            addToClasspath(file.getAbsolutePath());
+            // hack it onto the classpath
+            URLClassLoader sysLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
+            try {
+                Method method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
+                method.setAccessible(true);
+                method.invoke(sysLoader, file.toURI().toURL());
+            } catch (ReflectiveOperationException | MalformedURLException e) {
+                GlowServer.logger.log(Level.WARNING, "Failed to add to classpath: " + library + " " + version, e);
+            }
         }
 
         public boolean checksum(File file, String checksum) {
             // TODO: actually check checksum
             return true;
-        }
-    }
-
-    private static class LibraryClassLoader extends URLClassLoader {
-
-        static {
-            ClassLoader.registerAsParallelCapable();
-        }
-
-        private final Set<Path> libPaths = new CopyOnWriteArraySet<>();
-
-        private LibraryClassLoader() {
-            super(new URL[0]);
-        }
-
-        @Override
-        protected void addURL(URL url) {
-            super.addURL(url);
-        }
-
-        protected void addLibPath(String path) {
-            libPaths.add(Paths.get(path).toAbsolutePath());
-        }
-
-        @Override
-        protected String findLibrary(String libname) {
-            String nativeName = System.mapLibraryName(libname);
-            return libPaths.stream().map(path -> path.resolve(nativeName)).filter(Files::exists).map(Path::toString).findFirst().orElse(super.findLibrary(libname));
         }
     }
 }


### PR DESCRIPTION
Revert back to the old Java 8 classpath behavior because of Java 9 release delays (fixes libraries not being added to classpath properly in some cases)

Add new libraries for increased compatibility (we didn't add the new logging library Mojang uses)

This fixes #500 