### PR TITLE
Implement Firework Entity

### DIFF
--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -329,6 +329,7 @@ public final class ItemTable {
         reg(Material.BOAT_ACACIA, new ItemBoat(TreeSpecies.ACACIA));
         reg(Material.BOAT_DARK_OAK, new ItemBoat(TreeSpecies.DARK_OAK));
         reg(Material.PAINTING, new ItemPainting());
+        reg(Material.FIREWORK, new ItemFirework());
     }
 
     private void reg(Material material, ItemType type) {

--- a/src/main/java/net/glowstone/block/itemtype/ItemBoat.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemBoat.java
@@ -37,7 +37,7 @@ public class ItemBoat extends ItemType {
     }
 
     @Override
-    public boolean canOnlyUseSelf() {
-        return true;
+    public Context getContext() {
+        return Context.AIR;
     }
 }

--- a/src/main/java/net/glowstone/block/itemtype/ItemBucket.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemBucket.java
@@ -23,8 +23,8 @@ public class ItemBucket extends ItemType {
     }
 
     @Override
-    public boolean canOnlyUseSelf() {
-        return true;
+    public Context getContext() {
+        return Context.AIR;
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/itemtype/ItemFirework.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFirework.java
@@ -1,0 +1,49 @@
+package net.glowstone.block.itemtype;
+
+import java.util.UUID;
+import net.glowstone.block.GlowBlock;
+import net.glowstone.entity.GlowPlayer;
+import net.glowstone.entity.passive.GlowFirework;
+import net.glowstone.util.InventoryUtil;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.FireworkMeta;
+import org.bukkit.util.Vector;
+
+public class ItemFirework extends ItemType {
+
+    @Override
+    public void rightClickBlock(GlowPlayer player, GlowBlock target, BlockFace face, ItemStack holding, Vector clickedLoc, EquipmentSlot hand) {
+        spawnFirework(player, holding, target.getLocation().add(clickedLoc), player.getUniqueId(), null);
+    }
+
+    @Override
+    public void rightClickAir(GlowPlayer player, ItemStack holding) {
+        if (InventoryUtil.isEmpty(player.getEquipment().getChestplate()) || player.getEquipment().getChestplate().getType() != Material.ELYTRA || !player.isGliding()) {
+            return;
+        }
+
+        spawnFirework(player, holding, player.getLocation(), player.getUniqueId(), player);
+    }
+
+    private void spawnFirework(GlowPlayer player, ItemStack item, Location location, UUID spawner, LivingEntity boostedEntity) {
+        if (item.getType() != Material.FIREWORK || !(item.getItemMeta() instanceof FireworkMeta)) {
+            return;
+        }
+        new GlowFirework(location, spawner, boostedEntity, item);
+
+        if (player.getGameMode() != GameMode.CREATIVE) {
+            item.setAmount(item.getAmount() - 1);
+        }
+    }
+
+    @Override
+    public Context getContext() {
+        return Context.AIR_BLOCK;
+    }
+}

--- a/src/main/java/net/glowstone/block/itemtype/ItemFirework.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFirework.java
@@ -44,6 +44,6 @@ public class ItemFirework extends ItemType {
 
     @Override
     public Context getContext() {
-        return Context.AIR_BLOCK;
+        return Context.ANY;
     }
 }

--- a/src/main/java/net/glowstone/block/itemtype/ItemFood.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFood.java
@@ -23,8 +23,8 @@ public class ItemFood extends ItemTimedUsage {
     }
 
     @Override
-    public boolean canOnlyUseSelf() {
-        return true;
+    public Context getContext() {
+        return Context.AIR;
     }
 
     protected int getFoodLevel(ItemStack stack) {

--- a/src/main/java/net/glowstone/block/itemtype/ItemType.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemType.java
@@ -168,16 +168,16 @@ public class ItemType {
      */
     public enum Context {
         /**
-         * The Item can only be used in Air
+         * The item can only be used when clicking in the air
          */
         AIR,
         /**
-         * The Item can only be used in conjunction with a block
+         * The item can only be used when clicking against a block
          */
         BLOCK,
         /**
-         * The Item can be used in Air and in conjunction with a block
+         * The item can be used on any click
          */
-        AIR_BLOCK
+        ANY
     }
 }

--- a/src/main/java/net/glowstone/block/itemtype/ItemType.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemType.java
@@ -133,11 +133,11 @@ public class ItemType {
     }
 
     /**
-     * If this item can only be used without any context (essentially used in air)
-     * @return If this item can only be used without any context
+     * Get the context this item can be used in
+     * @return context of the item, default is {{@link Context#BLOCK}}
      */
-    public boolean canOnlyUseSelf() {
-        return false;
+    public Context getContext() {
+        return Context.BLOCK;
     }
 
     /**
@@ -161,5 +161,23 @@ public class ItemType {
     @Override
     public final String toString() {
         return getClass().getSimpleName() + "{" + getId() + " -> " + getMaterial() + "}";
+    }
+
+    /**
+     * Context of the Items interaction
+     */
+    public enum Context {
+        /**
+         * The Item can only be used in Air
+         */
+        AIR,
+        /**
+         * The Item can only be used in conjunction with a block
+         */
+        BLOCK,
+        /**
+         * The Item can be used in Air and in conjunction with a block
+         */
+        AIR_BLOCK
     }
 }

--- a/src/main/java/net/glowstone/block/itemtype/ItemWrittenBook.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemWrittenBook.java
@@ -9,8 +9,8 @@ public class ItemWrittenBook extends ItemType {
     private static final byte[] EMPTY = new byte[0];
 
     @Override
-    public boolean canOnlyUseSelf() {
-        return true;
+    public Context getContext() {
+        return Context.AIR;
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/EntityRegistry.java
+++ b/src/main/java/net/glowstone/entity/EntityRegistry.java
@@ -41,7 +41,7 @@ public class EntityRegistry {
                     .put(EvokerFangs.class, GlowEvokerFangs.class)
                     .put(FallingBlock.class, GlowFallingBlock.class)
                     //TODO: Fireball
-                    //TODO: Firework
+                    .put(Firework.class, GlowFirework.class)
                     //TODO: Fishing hook
                     .put(Ghast.class, GlowGhast.class)
                     .put(Giant.class, GlowGiant.class)

--- a/src/main/java/net/glowstone/entity/passive/GlowFirework.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowFirework.java
@@ -1,0 +1,204 @@
+package net.glowstone.entity.passive;
+
+import com.flowpowered.network.Message;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.Getter;
+import lombok.Setter;
+import net.glowstone.EventFactory;
+import net.glowstone.entity.GlowEntity;
+import net.glowstone.entity.meta.MetadataIndex;
+import net.glowstone.net.message.play.entity.EntityMetadataMessage;
+import net.glowstone.net.message.play.entity.SpawnObjectMessage;
+import net.glowstone.util.InventoryUtil;
+import org.bukkit.EntityEffect;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.SoundCategory;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Firework;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.event.entity.FireworkExplodeEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.FireworkMeta;
+import org.bukkit.util.Vector;
+
+public class GlowFirework extends GlowEntity implements Firework {
+
+    @Getter
+    @Setter
+    private ItemStack item;
+    @Getter
+    @Setter
+    private UUID spawningEntity;
+    @Getter
+    private LivingEntity boostedEntity;
+    /**
+     * The number of ticks before this fireworks rocket explodes.
+     */
+    @Getter
+    @Setter
+    private int lifeTime;
+
+    public GlowFirework(Location location) {
+        super(location);
+        setSize(0.25f, 0.25f);
+    }
+
+    public GlowFirework(Location location, UUID spawningEntity, LivingEntity boostedEntity, ItemStack item) {
+        super(location);
+        this.spawningEntity = spawningEntity;
+        setBoostedEntity(boostedEntity);
+        setSize(0.25f, 0.25f);
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        setVelocity(new Vector(random.nextGaussian() * 0.001, 0.05, random.nextGaussian() * 0.001));
+
+        this.item = InventoryUtil.itemOrEmpty(item).clone();
+        int power = 0;
+        if (!InventoryUtil.isEmpty(item) && item.getItemMeta() instanceof FireworkMeta) {
+            this.metadata.set(MetadataIndex.FIREWORK_INFO, item.clone());
+            power = ((FireworkMeta) item.getItemMeta()).getPower();
+        }
+        lifeTime = calculateLifeTime(power);
+    }
+
+    @Override
+    public EntityType getType() {
+        return EntityType.FIREWORK;
+    }
+
+    @Override
+    public List<Message> createSpawnMessage() {
+        double x = location.getX();
+        double y = location.getY();
+        double z = location.getZ();
+
+        return Arrays.asList(
+            new SpawnObjectMessage(id, UUID.randomUUID(), SpawnObjectMessage.FIREWORK, x, y, z, 0, 0),
+            new EntityMetadataMessage(id, metadata.getEntryList())
+        );
+    }
+
+    @Override
+    public FireworkMeta getFireworkMeta() {
+        return ((FireworkMeta) item.getItemMeta()).clone();
+    }
+
+    @Override
+    public void setFireworkMeta(FireworkMeta fireworkMeta) {
+        if (fireworkMeta == null) {
+            return;
+        }
+
+        if (InventoryUtil.isEmpty(item) || !Material.FIREWORK.equals(item.getType())) {
+            item = new ItemStack(Material.FIREWORK);
+        }
+
+        this.item.setItemMeta(fireworkMeta.clone());
+        this.metadata.set(MetadataIndex.FIREWORK_INFO, item.clone());
+        this.lifeTime = calculateLifeTime(fireworkMeta.getPower());
+    }
+
+    private int calculateLifeTime(int power) {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        return ((power + 1) * 10 + random.nextInt(0, 6) + random.nextInt(0, 7));
+    }
+
+    @Override
+    public void detonate() {
+        if (this.isDead()) {
+            return;
+        }
+        setTicksLived(lifeTime);
+    }
+
+    @Override
+    public void pulse() {
+        super.pulse();
+
+        if (ticksLived == 1) {
+            world.playSound(this.location, Sound.ENTITY_FIREWORK_LAUNCH, SoundCategory.AMBIENT, 3, 1);
+        }
+
+        if (ticksLived > lifeTime) {
+            explode();
+        }
+    }
+
+    private void explode() {
+        if (!EventFactory.callEvent(new FireworkExplodeEvent(this)).isCancelled()) {
+            this.playEffect(EntityEffect.FIREWORK_EXPLODE);
+
+            int effectsSize = item != null && item.getItemMeta() instanceof FireworkMeta ? ((FireworkMeta) item.getItemMeta()).getEffectsSize() : 0;
+            if (effectsSize > 0) {
+                if (boostedEntity != null) {
+                    boostedEntity.damage((5 + effectsSize * 2), DamageCause.ENTITY_EXPLOSION);
+                }
+
+                List<Entity> nearbyEntities = this.getNearbyEntities(2.5, 2.5, 2.5);
+                for (Entity nearbyEntity : nearbyEntities) {
+                    if (!(nearbyEntity instanceof LivingEntity)) {
+                        continue;
+                    }
+                    if (this.getLocation().distanceSquared(nearbyEntity.getLocation()) > 25) {
+                        continue;
+                    }
+
+                    // "The explosion of firework rockets deals 2.5 hearts of damage, per firework star."
+                    ((LivingEntity) nearbyEntity).damage((effectsSize * 5), DamageCause.ENTITY_EXPLOSION);
+                }
+            }
+        }
+        remove();
+    }
+
+    @Override
+    protected void pulsePhysics() {
+        // TODO: proper physics
+        if (this.boostedEntity == null) {
+            // Fireworks velocity is not affected by airdrag or gravity
+            // These values are static
+            velocity.setX(velocity.getX() * 1.15);
+            velocity.setY(velocity.getY() + 0.04);
+            velocity.setZ(velocity.getZ() * 1.15);
+            setVelocity(velocity);
+        } else {
+            Vector direction = boostedEntity.getLocation().getDirection();
+            Vector velocity = boostedEntity.getVelocity();
+
+            // close enough approximation of vanillas velocity for boosted entity
+            double dx = direction.getX() * 0.1 + (direction.getX() * 1.5 - velocity.getX()) * 0.5;
+            double dy = direction.getY() * 0.1 + (direction.getY() * 1.5 - velocity.getY()) * 0.5;
+            double dz = direction.getZ() * 0.1 + (direction.getZ() * 1.5 - velocity.getZ()) * 0.5;
+
+            velocity.setX(velocity.getX() + dx);
+            velocity.setY(velocity.getY() + dy);
+            velocity.setZ(velocity.getZ() + dz);
+
+            boostedEntity.setVelocity(velocity);
+            this.setVelocity(velocity);
+
+            Location location = boostedEntity.getLocation().add(velocity);
+            if (boostedEntity instanceof GlowEntity) {
+                ((GlowEntity) boostedEntity).setRawLocation(location, false);
+            } else {
+                boostedEntity.teleport(location);
+            }
+        }
+
+        setRawLocation(this.location.add(velocity), false);
+    }
+
+    private void setBoostedEntity(LivingEntity boostedEntity) {
+        this.boostedEntity = boostedEntity;
+        if (boostedEntity != null) {
+            metadata.set(MetadataIndex.FIREWORK_ENTITY, boostedEntity.getEntityId());
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/passive/GlowFirework.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowFirework.java
@@ -41,7 +41,7 @@ public class GlowFirework extends GlowEntity implements Firework {
     @Getter
     @Setter
     private int lifeTime;
-    public static final ItemStack DEFAULT_FIREWORK_ITEM = new ItemStack(Material.FIREWORK);
+    private static final ItemStack DEFAULT_FIREWORK_ITEM = new ItemStack(Material.FIREWORK);
 
     public GlowFirework(Location location) {
         super(location);
@@ -97,8 +97,9 @@ public class GlowFirework extends GlowEntity implements Firework {
     }
 
     /**
-     * Get
-     * @return
+     * Get the underlying firework item.
+     *
+     * @return The Firework ItemStack of this Firework entity, or a new Firework ItemStack
      */
     public ItemStack getFireworkItem() {
         ItemStack item = this.metadata.getItem(MetadataIndex.FIREWORK_INFO);
@@ -110,7 +111,8 @@ public class GlowFirework extends GlowEntity implements Firework {
 
     /**
      * Set the firework item of this firework entity.
-     * If an empty ItemStack, or one not of the type {{@link Material#FIREWORK}} was given, an new Firework ItemStack will be created.
+     * If an empty ItemStack, or none of the type {{@link Material#FIREWORK}} was given, a new Firework ItemStack will be created.
+     *
      * @param item FireWork Item this entity should use
      */
     public void setFireworkItem(ItemStack item) {

--- a/src/main/java/net/glowstone/inventory/crafting/GlowChargeFadeMatcher.java
+++ b/src/main/java/net/glowstone/inventory/crafting/GlowChargeFadeMatcher.java
@@ -37,6 +37,10 @@ public class GlowChargeFadeMatcher extends ItemMatcher {
         FireworkEffectMeta meta = (FireworkEffectMeta) charge.getItemMeta();
         FireworkEffect old = meta.getEffect();
 
+        if (old == null) {
+            return null;
+        }
+
         FireworkEffect newEffect = FireworkEffect.builder()
                 .with(old.getType())
                 .withColor(old.getColors())

--- a/src/main/java/net/glowstone/inventory/crafting/GlowFireworkMatcher.java
+++ b/src/main/java/net/glowstone/inventory/crafting/GlowFireworkMatcher.java
@@ -38,7 +38,7 @@ public class GlowFireworkMatcher extends ItemMatcher {
         if (gunpowder < 1 || gunpowder > 3) return null; // Must have 1-3 gunpowder
         if (!hasPaper) return null; // Paper needed
 
-        ItemStack ret = new ItemStack(Material.FIREWORK, 1);
+        ItemStack ret = new ItemStack(Material.FIREWORK, 3);
 
         if (charges.isEmpty()) { // This makes no sense Mojang, but whatever
             return ret;

--- a/src/main/java/net/glowstone/io/entity/EntityStorage.java
+++ b/src/main/java/net/glowstone/io/entity/EntityStorage.java
@@ -100,6 +100,7 @@ public final class EntityStorage {
         }
         bind(new PaintingStore());
         bind(new ExperienceOrbStore());
+        bind(new FireworkStore());
     }
 
     private EntityStorage() {

--- a/src/main/java/net/glowstone/io/entity/FireworkStore.java
+++ b/src/main/java/net/glowstone/io/entity/FireworkStore.java
@@ -29,7 +29,7 @@ public class FireworkStore extends EntityStore<GlowFirework> {
             entity.setLifeTime(tag.getInt("LifeTime"));
         }
         if (tag.isCompound("FireworksItem")) {
-            entity.setItem(NbtSerialization.readItem(tag.getCompound("FireworksItem")));
+            entity.setFireworkItem(NbtSerialization.readItem(tag.getCompound("FireworksItem")));
         }
         if (tag.isLong("SpawningEntityMost") && tag.isLong("SpawningEntityLeast")) {
             UUID uuid = new UUID(tag.getLong("SpawningEntityMost"), tag.getLong("SpawningEntityLeast"));
@@ -43,7 +43,7 @@ public class FireworkStore extends EntityStore<GlowFirework> {
 
         tag.putInt("Life", entity.getTicksLived());
         tag.putInt("LifeTime", entity.getLifeTime());
-        CompoundTag fireworkItem = NbtSerialization.writeItem(entity.getItem(), -1);
+        CompoundTag fireworkItem = NbtSerialization.writeItem(entity.getFireworkItem(), -1);
         tag.putCompound("FireworksItem", fireworkItem);
 
         tag.putLong("SpawningEntityMost", entity.getSpawningEntity().getMostSignificantBits());

--- a/src/main/java/net/glowstone/io/entity/FireworkStore.java
+++ b/src/main/java/net/glowstone/io/entity/FireworkStore.java
@@ -1,0 +1,52 @@
+package net.glowstone.io.entity;
+
+import java.util.UUID;
+import net.glowstone.entity.passive.GlowFirework;
+import net.glowstone.io.nbt.NbtSerialization;
+import net.glowstone.util.nbt.CompoundTag;
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+
+public class FireworkStore extends EntityStore<GlowFirework> {
+
+    public FireworkStore() {
+        super(GlowFirework.class, EntityType.FIREWORK);
+    }
+
+    @Override
+    public GlowFirework createEntity(Location location, CompoundTag compound) {
+        return new GlowFirework(location, null, null, null);
+    }
+
+    @Override
+    public void load(GlowFirework entity, CompoundTag tag) {
+        super.load(entity, tag);
+
+        if (tag.isInt("Life")) {
+            entity.setTicksLived(tag.getInt("Life"));
+        }
+        if (tag.isInt("LifeTime")) {
+            entity.setLifeTime(tag.getInt("LifeTime"));
+        }
+        if (tag.isCompound("FireworksItem")) {
+            entity.setItem(NbtSerialization.readItem(tag.getCompound("FireworksItem")));
+        }
+        if (tag.isLong("SpawningEntityMost") && tag.isLong("SpawningEntityLeast")) {
+            UUID uuid = new UUID(tag.getLong("SpawningEntityMost"), tag.getLong("SpawningEntityLeast"));
+            entity.setSpawningEntity(uuid);
+        }
+    }
+
+    @Override
+    public void save(GlowFirework entity, CompoundTag tag) {
+        super.save(entity, tag);
+
+        tag.putInt("Life", entity.getTicksLived());
+        tag.putInt("LifeTime", entity.getLifeTime());
+        CompoundTag fireworkItem = NbtSerialization.writeItem(entity.getItem(), -1);
+        tag.putCompound("FireworksItem", fireworkItem);
+
+        tag.putLong("SpawningEntityMost", entity.getSpawningEntity().getMostSignificantBits());
+        tag.putLong("SpawningEntityLeast", entity.getSpawningEntity().getLeastSignificantBits());
+    }
+}

--- a/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
@@ -137,7 +137,7 @@ public final class BlockPlacementHandler implements MessageHandler<GlowSession, 
         // follows ALLOW/DENY: default to if no block was interacted with
         if (selectResult(event.useItemInHand(), !useInteractedBlock) && holding != null) {
             ItemType type = ItemTable.instance().getItem(holding.getType());
-            if (!rightClickedAir && holding.getType() != Material.AIR && (type.getContext() == Context.BLOCK || type.getContext() == Context.AIR_BLOCK)) {
+            if (!rightClickedAir && holding.getType() != Material.AIR && (type.getContext() == Context.BLOCK || type.getContext() == Context.ANY)) {
                 type.rightClickBlock(player, clicked, face, holding, clickedLoc, message.getHandSlot());
             }
         }

--- a/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
@@ -8,6 +8,7 @@ import net.glowstone.block.ItemTable;
 import net.glowstone.block.blocktype.BlockType;
 import net.glowstone.block.entity.BlockEntity;
 import net.glowstone.block.itemtype.ItemType;
+import net.glowstone.block.itemtype.ItemType.Context;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.BlockPlacementMessage;
@@ -136,7 +137,7 @@ public final class BlockPlacementHandler implements MessageHandler<GlowSession, 
         // follows ALLOW/DENY: default to if no block was interacted with
         if (selectResult(event.useItemInHand(), !useInteractedBlock) && holding != null) {
             ItemType type = ItemTable.instance().getItem(holding.getType());
-            if (!rightClickedAir && holding.getType() != Material.AIR && !type.canOnlyUseSelf()) {
+            if (!rightClickedAir && holding.getType() != Material.AIR && (type.getContext() == Context.BLOCK || type.getContext() == Context.AIR_BLOCK)) {
                 type.rightClickBlock(player, clicked, face, holding, clickedLoc, message.getHandSlot());
             }
         }

--- a/src/main/java/net/glowstone/net/handler/play/player/UseItemHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/UseItemHandler.java
@@ -3,9 +3,11 @@ package net.glowstone.net.handler.play.player;
 import com.flowpowered.network.MessageHandler;
 import net.glowstone.block.ItemTable;
 import net.glowstone.block.itemtype.ItemType;
+import net.glowstone.block.itemtype.ItemType.Context;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.UseItemMessage;
+import net.glowstone.util.InventoryUtil;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -15,10 +17,10 @@ public class UseItemHandler implements MessageHandler<GlowSession, UseItemMessag
         GlowPlayer player = session.getPlayer();
         ItemStack holding = player.getItemInHand();
 
-        if (holding != null) {
+        if (!InventoryUtil.isEmpty(holding)) {
             ItemType type = ItemTable.instance().getItem(holding.getType());
             if (type != null) {
-                if (type.canOnlyUseSelf()) {
+                if (type.getContext() == Context.AIR || type.getContext() == Context.AIR_BLOCK) {
                     type.rightClickAir(player, holding);
                 } else {
                     if (holding.getType() == Material.WATER_BUCKET || holding.getType() == Material.LAVA_BUCKET) {
@@ -26,6 +28,11 @@ public class UseItemHandler implements MessageHandler<GlowSession, UseItemMessag
                     }
                 }
             }
+
+            if (!InventoryUtil.isEmpty(holding) && holding.getAmount() <= 0) {
+                holding = InventoryUtil.createEmptyStack();
+            }
+            player.setItemInHand(holding);
         }
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/UseItemHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/UseItemHandler.java
@@ -15,12 +15,12 @@ public class UseItemHandler implements MessageHandler<GlowSession, UseItemMessag
     @Override
     public void handle(GlowSession session, UseItemMessage message) {
         GlowPlayer player = session.getPlayer();
-        ItemStack holding = player.getItemInHand();
+        ItemStack holding = player.getInventory().getItem(message.getEquipmentSlot());
 
         if (!InventoryUtil.isEmpty(holding)) {
             ItemType type = ItemTable.instance().getItem(holding.getType());
             if (type != null) {
-                if (type.getContext() == Context.AIR || type.getContext() == Context.AIR_BLOCK) {
+                if (type.getContext() == Context.AIR || type.getContext() == Context.ANY) {
                     type.rightClickAir(player, holding);
                 } else {
                     if (holding.getType() == Material.WATER_BUCKET || holding.getType() == Material.LAVA_BUCKET) {
@@ -29,10 +29,10 @@ public class UseItemHandler implements MessageHandler<GlowSession, UseItemMessag
                 }
             }
 
-            if (!InventoryUtil.isEmpty(holding) && holding.getAmount() <= 0) {
+            if (holding.getAmount() <= 0) {
                 holding = InventoryUtil.createEmptyStack();
             }
-            player.setItemInHand(holding);
+            player.getInventory().setItem(message.getEquipmentSlot(), holding);
         }
     }
 }

--- a/src/main/java/net/glowstone/net/message/play/entity/SpawnObjectMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/entity/SpawnObjectMessage.java
@@ -14,6 +14,7 @@ public final class SpawnObjectMessage implements Message {
     public static final int ITEM = 2;
     public static final int ENDER_CRYSTAL = 51;
     public static final int ITEM_FRAME = 71;
+    public static final int FIREWORK = 76;
 
     private final int id;
     private final UUID uuid; //TODO: Handle UUID

--- a/src/main/java/net/glowstone/net/message/play/player/UseItemMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/player/UseItemMessage.java
@@ -2,9 +2,14 @@ package net.glowstone.net.message.play.player;
 
 import com.flowpowered.network.Message;
 import lombok.Data;
+import org.bukkit.inventory.EquipmentSlot;
 
 @Data
 public class UseItemMessage implements Message {
 
     private final int hand;
+
+    public EquipmentSlot getEquipmentSlot() {
+        return EquipmentSlot.values()[hand];
+    }
 }

--- a/src/main/java/net/glowstone/net/message/play/player/UseItemMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/player/UseItemMessage.java
@@ -10,6 +10,6 @@ public class UseItemMessage implements Message {
     private final int hand;
 
     public EquipmentSlot getEquipmentSlot() {
-        return EquipmentSlot.values()[hand];
+        return hand == 1 ? EquipmentSlot.OFF_HAND : EquipmentSlot.HAND;
     }
 }


### PR DESCRIPTION
Hello,

This PR implements the firework_rocket entity, excluding proper physics.

Firework items can be used in the air (for boosting a player), as well as on blocks. Only one of this interactions was possible before. I changed this using the `Context` (and its value AIR_BLOCK) so that both interactions are possible. This replaces the old `canOnlyUseSelf` of ItemType.
Since 16w20a, the firework recipe produces 3 rockets.

### Physics during normal flight
The initial velocity is random for vx and vz, and static for vy. This matches the output that I got from paper (see sources), the values are most likely a bit imprecise though.

**During flight**, vx and vz are each multiplied by 1.15. This was calculated using 
* -0.001125*x^30=-0.086 =>  x = 1.5552
*  -0.0405*x^10=-0.164125 => x = 1.1502  

Vy is only increased by 0.04 each tick during flight, which appears to be a static value.

### Physics of boosting an entity
These are just assumptions.
When you are only boosted by one firework rocket, vx, vy, and vz never go above 1.5.
When you are boosted by multiple firework rockets, your velocity goes slightly above 1.5.

I played around till I found a way to replicate vanilla, but its off by like 1.1. Most likely air drag or gravity which needs to be applied.

related to #504

### Sources:
https://minecraft.gamepedia.com/Firework_Rocket
https://gist.github.com/Postremus/7223c6a153c3b9042bb63ed510c052ea
https://gist.github.com/Postremus/bef66401490048a5a1d42fcae8f55e75