### PR TITLE
Add prevent authentication proxy option

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -2091,4 +2091,8 @@ public final class GlowServer implements Server {
     public boolean doesUseGPGPU() {
         return isCLApplicable && config.getBoolean(Key.GPGPU);
     }
+
+    public boolean shouldPreventProxy() {
+        return config.getBoolean(Key.PREVENT_PROXY);
+    }
 }

--- a/src/main/java/net/glowstone/net/handler/login/EncryptionKeyResponseHandler.java
+++ b/src/main/java/net/glowstone/net/handler/login/EncryptionKeyResponseHandler.java
@@ -102,13 +102,15 @@ public final class EncryptionKeyResponseHandler implements MessageHandler<GlowSe
         }
 
         String url = BASE_URL + "?username=" + session.getVerifyUsername() + "&serverId=" + hash;
-        try {
-            //in case we are dealing with an IPv6 address rather than an IPv4 we have to encode it properly
-            url += "&ip=" + URLEncoder.encode(session.getAddress().getAddress().getHostAddress(), "UTF-8");
-        } catch (UnsupportedEncodingException encodingEx) {
-            //unlikely to happen, because UTF-8 is part of the StandardCharset in Java
-            //but if it happens, the client will still able to login, because we won't add the IP parameter
-            GlowServer.logger.log(Level.WARNING, "Cannot encode ip address for proxy check", encodingEx);
+        if (session.getServer().shouldPreventProxy()) {
+            try {
+                //in case we are dealing with an IPv6 address rather than an IPv4 we have to encode it properly
+                url += "&ip=" + URLEncoder.encode(session.getAddress().getAddress().getHostAddress(), "UTF-8");
+            } catch (UnsupportedEncodingException encodingEx) {
+                //unlikely to happen, because UTF-8 is part of the StandardCharset in Java
+                //but if it happens, the client will still able to login, because we won't add the IP parameter
+                GlowServer.logger.log(Level.WARNING, "Cannot encode ip address for proxy check", encodingEx);
+            }
         }
 
         HttpClient.connect(url, session.getChannel().eventLoop(), new ClientAuthCallback(session));

--- a/src/main/java/net/glowstone/net/handler/login/EncryptionKeyResponseHandler.java
+++ b/src/main/java/net/glowstone/net/handler/login/EncryptionKeyResponseHandler.java
@@ -21,7 +21,10 @@ import org.json.simple.parser.ParseException;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+
+import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
+import java.net.URLEncoder;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -99,6 +102,15 @@ public final class EncryptionKeyResponseHandler implements MessageHandler<GlowSe
         }
 
         String url = BASE_URL + "?username=" + session.getVerifyUsername() + "&serverId=" + hash;
+        try {
+            //in case we are dealing with an IPv6 address rather than an IPv4 we have to encode it properly
+            url += "&ip=" + URLEncoder.encode(session.getAddress().getAddress().getHostAddress(), "UTF-8");
+        } catch (UnsupportedEncodingException encodingEx) {
+            //unlikely to happen, because UTF-8 is part of the StandardCharset in Java
+            //but if it happens, the client will still able to login, because we won't add the IP parameter
+            GlowServer.logger.log(Level.WARNING, "Cannot encode ip address for proxy check", encodingEx);
+        }
+
         HttpClient.connect(url, session.getChannel().eventLoop(), new ClientAuthCallback(session));
     }
 

--- a/src/main/java/net/glowstone/util/config/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/config/ServerConfig.java
@@ -356,6 +356,7 @@ public final class ServerConfig {
         RESOURCE_PACK("game.resource-pack", "", Migrate.PROPS, "resource-pack"),
         RESOURCE_PACK_HASH("game.resource-pack-hash", "", Migrate.PROPS, "resource-pack-hash"),
         SNOOPER_ENABLED("server.snooper-enabled", false, Migrate.PROPS, "snooper-enabled"),
+        PREVENT_PROXY("server.prevent-proxy-connections", true, Migrate.PROPS, "prevent-proxy-connections"),
 
         // critters
         SPAWN_MONSTERS("creatures.enable.monsters", true, Migrate.PROPS, "spawn-monsters"),


### PR DESCRIPTION
A couple of months ago, Mojang introduced a new parameter to the hasJoined url ([wiki.vg](http://wiki.vg/Protocol_Encryption#Server)). The vanilla Minecraft server and [BungeeCord](https://github.com/SpigotMC/BungeeCord/commit/806a6dfacaadb7538860889f8a50612bb496a2d3) has this implemented, so it's time that Glowstone implements this too.

This doesn't prevent proxy connections in general, but it verifies that the same IP that is used for connecting to the Minecraft server is also used for authenticating against the Mojang servers.