### PR TITLE
Fix Enderman carried item metadata not being set properly

### DIFF
--- a/src/main/java/net/glowstone/entity/monster/GlowEnderman.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowEnderman.java
@@ -25,7 +25,13 @@ public class GlowEnderman extends GlowMonster implements Enderman {
     @Override
     public void setCarriedMaterial(MaterialData type) {
         carriedMaterial = type;
-        metadata.set(MetadataIndex.ENDERMAN_BLOCK, new Integer(type.getItemTypeId()).shortValue());
+        if (type == null) {
+            metadata.set(MetadataIndex.ENDERMAN_BLOCK, 0);
+        } else {
+            // TODO: store block data. This code appears to be broken (although documented in the protocol):
+            // int blockId = type.getItemTypeId() << 4 | type.getData();
+            metadata.set(MetadataIndex.ENDERMAN_BLOCK, type.getItemTypeId());
+        }
     }
 
     public boolean isScreaming() {


### PR DESCRIPTION
This fixes an issue where the Enderman carried-data would be saved as a short instead of a `BlockID` (Integer) in the metadata entry.

However, it should be noted that storing the block data should be possible as well, but is not working for some reason. The protocol documentation states that the metadata entry should be stored as `id << 4 | data`. From my testing though, the client appears to just read the full int as the block ID, thus shifting the bits would show different blocks instead. 

For now, I have decided to let it at that (only storing the ID) until I can investigate more on that issue.