### PR TITLE
Implement critical hit + damage enchantment amplification

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -15,10 +15,7 @@ import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.objects.GlowExperienceOrb;
 import net.glowstone.inventory.EquipmentMonitor;
 import net.glowstone.net.GlowSession;
-import net.glowstone.net.message.play.entity.EntityEffectMessage;
-import net.glowstone.net.message.play.entity.EntityEquipmentMessage;
-import net.glowstone.net.message.play.entity.EntityHeadRotationMessage;
-import net.glowstone.net.message.play.entity.EntityRemoveEffectMessage;
+import net.glowstone.net.message.play.entity.*;
 import net.glowstone.net.message.play.player.InteractEntityMessage;
 import net.glowstone.net.message.play.player.InteractEntityMessage.Action;
 import net.glowstone.util.*;
@@ -1000,6 +997,14 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     @Override
     public void setArrowsStuck(int arrowsStuck) {
         // todo: 1.11
+    }
+
+    @Override
+    public void playAnimation(EntityAnimation animation) {
+        AnimateEntityMessage message = new AnimateEntityMessage(getEntityId(), animation.ordinal());
+        getWorld().getRawPlayers().stream()
+                .filter(observer -> observer != this && observer.canSeeEntity(this))
+                .forEach(observer -> observer.getSession().send(message));
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -550,6 +550,24 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         return true;
     }
 
+    /**
+     * Get whether of not this entity is an arthropod.
+     *
+     * @return true if this entity is an arthropod, false otherwise
+     */
+    public boolean isArthropod() {
+        return false;
+    }
+
+    /**
+     * Get whether or not this entity is undead.
+     *
+     * @return true if this entity is undead, false otherwise
+     */
+    public boolean isUndead() {
+        return false;
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Line of Sight
 

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -1729,9 +1729,8 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         // Call event
         EventFactory.callEvent(new PlayerBedLeaveEvent(this, head));
 
-        getSession().send(new AnimateEntityMessage(SELF_ID, AnimateEntityMessage.LEAVE_BED));
-        AnimateEntityMessage msg = new AnimateEntityMessage(getEntityId(), AnimateEntityMessage.LEAVE_BED);
-        world.getRawPlayers().stream().filter(p -> p != this && p.canSeeEntity(this)).forEach(p -> p.getSession().send(msg));
+        playAnimationToSelf(EntityAnimation.LEAVE_BED);
+        playAnimation(EntityAnimation.LEAVE_BED);
     }
 
     @Override
@@ -2990,5 +2989,11 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
     public boolean isInWater() {
         Material mat = getLocation().getBlock().getType();
         return mat == Material.WATER || mat == Material.STATIONARY_WATER;
+    }
+
+    @Override
+    public void playAnimationToSelf(EntityAnimation animation) {
+        AnimateEntityMessage message = new AnimateEntityMessage(SELF_ID, animation.ordinal());
+        getSession().send(message);
     }
 }

--- a/src/main/java/net/glowstone/entity/monster/GlowCaveSpider.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowCaveSpider.java
@@ -25,4 +25,9 @@ public class GlowCaveSpider extends GlowMonster implements CaveSpider {
     protected Sound getAmbientSound() {
         return Sound.ENTITY_SPIDER_AMBIENT;
     }
+
+    @Override
+    public boolean isArthropod() {
+        return true;
+    }
 }

--- a/src/main/java/net/glowstone/entity/monster/GlowEndermite.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowEndermite.java
@@ -36,4 +36,9 @@ public class GlowEndermite extends GlowMonster implements Endermite {
     protected Sound getAmbientSound() {
         return Sound.ENTITY_ENDERMITE_AMBIENT;
     }
+
+    @Override
+    public boolean isArthropod() {
+        return true;
+    }
 }

--- a/src/main/java/net/glowstone/entity/monster/GlowSilverfish.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowSilverfish.java
@@ -25,4 +25,9 @@ public class GlowSilverfish extends GlowMonster implements Silverfish {
     protected Sound getAmbientSound() {
         return Sound.ENTITY_SILVERFISH_AMBIENT;
     }
+
+    @Override
+    public boolean isArthropod() {
+        return true;
+    }
 }

--- a/src/main/java/net/glowstone/entity/monster/GlowSkeleton.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowSkeleton.java
@@ -41,4 +41,9 @@ public class GlowSkeleton extends GlowMonster implements Skeleton {
     protected Sound getAmbientSound() {
         return Sound.ENTITY_SKELETON_AMBIENT;
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/net/glowstone/entity/monster/GlowSpider.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowSpider.java
@@ -35,4 +35,9 @@ public class GlowSpider extends GlowMonster implements Spider {
     protected Sound getAmbientSound() {
         return Sound.ENTITY_SPIDER_AMBIENT;
     }
+
+    @Override
+    public boolean isArthropod() {
+        return true;
+    }
 }

--- a/src/main/java/net/glowstone/entity/monster/GlowWither.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowWither.java
@@ -101,4 +101,9 @@ public class GlowWither extends GlowMonster implements Wither {
     protected Sound getAmbientSound() {
         return Sound.ENTITY_WITHER_AMBIENT;
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/net/glowstone/entity/monster/GlowZombie.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowZombie.java
@@ -101,4 +101,9 @@ public class GlowZombie extends GlowMonster implements Zombie {
     protected Sound getAmbientSound() {
         return Sound.ENTITY_ZOMBIE_AMBIENT;
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/net/glowstone/entity/passive/GlowUndeadHorse.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowUndeadHorse.java
@@ -14,4 +14,9 @@ public class GlowUndeadHorse extends GlowAbstractHorse implements AbstractHorse 
     public Inventory getInventory() {
         return null;
     }
+
+    @Override
+    public boolean isUndead() {
+        return true;
+    }
 }

--- a/src/main/java/net/glowstone/entity/passive/GlowVillager.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowVillager.java
@@ -104,6 +104,11 @@ public class GlowVillager extends GlowAgeable implements Villager {
     }
 
     @Override
+    public boolean isUndead() {
+        return profession != null && profession.isZombie();
+    }
+
+    @Override
     public void damage(double amount, Entity source, DamageCause cause) {
         if (!DamageCause.LIGHTNING.equals(cause)) {
             super.damage(amount, source, cause);

--- a/src/main/java/net/glowstone/entity/passive/GlowVillager.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowVillager.java
@@ -39,6 +39,16 @@ public class GlowVillager extends GlowAgeable implements Villager {
     }
 
     @Override
+    public Career getCareer() {
+        return null;
+    }
+
+    @Override
+    public void setCareer(Career career) {
+
+    }
+
+    @Override
     public List<MerchantRecipe> getRecipes() {
         return null;
     }

--- a/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
@@ -54,7 +54,7 @@ public final class InteractEntityHandler implements MessageHandler<GlowSession, 
                 ItemStack itemInHand = InventoryUtil.itemOrEmpty(player.getInventory().getItem(hand));
                 Material type = itemInHand.getType();
 
-                boolean critical = player.getFallDistance() > 0.0F;
+                boolean critical = player.getFallDistance() > 0.0F && !player.isOnGround() && !player.isInWater() && !player.isInsideVehicle() && !player.isSprinting();
                 float damage = AttackDamage.getMeleeDamage(type, critical);
                 if (critical) {
                     // Critical-hit effect

--- a/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
@@ -12,9 +12,9 @@ import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.InteractEntityMessage;
 import net.glowstone.net.message.play.player.InteractEntityMessage.Action;
 import net.glowstone.util.InventoryUtil;
+import org.bukkit.EntityAnimation;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
-import org.bukkit.Particle;
 import org.bukkit.Statistic;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.EntityType;
@@ -58,7 +58,7 @@ public final class InteractEntityHandler implements MessageHandler<GlowSession, 
                 float damage = AttackDamage.getMeleeDamage(type, critical);
                 if (critical) {
                     // Critical-hit effect
-                    player.getWorld().spawnParticle(Particle.CRIT, target.getEyeLocation().add(0, 0.5, 0), 10);
+                    target.playAnimation(EntityAnimation.CRITICAL_HIT);
                 }
 
                 // Set entity on fire if the item has Fire Aspect
@@ -101,7 +101,7 @@ public final class InteractEntityHandler implements MessageHandler<GlowSession, 
                     }
                 }
                 if (showMagicCrit) {
-                    player.getWorld().spawnParticle(Particle.CRIT_MAGIC, target.getEyeLocation().add(0, 0.5, 0), 10);
+                    target.playAnimation(EntityAnimation.MAGIC_CRITICAL_HIT);
                 }
 
                 // Apply damage. Calls the EntityDamageByEntityEvent

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
@@ -1,12 +1,11 @@
 package net.glowstone.net.handler.play.player;
 
-import com.flowpowered.network.Message;
 import com.flowpowered.network.MessageHandler;
 import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
-import net.glowstone.net.message.play.entity.AnimateEntityMessage;
 import net.glowstone.net.message.play.player.PlayerSwingArmMessage;
+import org.bukkit.EntityAnimation;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.Event.Result;
@@ -36,8 +35,7 @@ public final class PlayerSwingArmHandler implements MessageHandler<GlowSession, 
 
         if (!EventFactory.callEvent(new PlayerAnimationEvent(player)).isCancelled()) {
             // play the animation to others
-            Message toSend = new AnimateEntityMessage(player.getEntityId(), message.getHand() == 1 ? AnimateEntityMessage.SWING_OFF_HAND : AnimateEntityMessage.SWING_MAIN_HAND);
-            player.getWorld().getRawPlayers().stream().filter(observer -> observer != player && observer.canSeeEntity(player)).forEach(observer -> observer.getSession().send(toSend));
+            player.playAnimation(message.getHand() == 1 ? EntityAnimation.SWING_OFF_HAND : EntityAnimation.SWING_MAIN_HAND);
         }
     }
 }

--- a/src/main/java/net/glowstone/net/message/play/entity/AnimateEntityMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/entity/AnimateEntityMessage.java
@@ -6,13 +6,6 @@ import lombok.Data;
 @Data
 public final class AnimateEntityMessage implements Message {
 
-    public static final int SWING_MAIN_HAND = 0;
-    public static final int TAKE_DAMAGE = 1;
-    public static final int LEAVE_BED = 2;
-    public static final int SWING_OFF_HAND = 3;
-    public static final int CRIT = 4;
-    public static final int MAGIC_CRIT = 5;
-
     private final int id, animation;
 
 }


### PR DESCRIPTION
**Note**: https://github.com/GlowstoneMC/Glowkit/pull/14 and https://github.com/GlowstoneMC/Glowstone/pull/563 have to be merged first.

Implements [critical hits](https://minecraft.gamepedia.com/Damage#Critical_Hits), as well as some enchantments:

- Sharpness
- Smite
- Bane of Arthropods

It also implements the new Entity Animation API (https://github.com/GlowstoneMC/Glowkit/pull/14)

*Note*: I tested this