### PR TITLE
Fix NPE when running from an IDE

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1278,7 +1278,7 @@ public final class GlowServer implements Server {
 
     @Override
     public String getName() {
-        return getClass().getPackage().getImplementationTitle();
+        return GlowServer.class.getPackage().getImplementationTitle();
     }
 
     @Override


### PR DESCRIPTION
This tiny change fixes an NPE that I ran into when running Glowstone from IntelliJ.
```
22:00:36 [SEVERE] Error while executing GlowTask{id=0, plugin=null, sync=true: net.glowstone.net.handler.login.EncryptionKeyResponseHandler$ClientAuthCallback$$Lambda$62/1879985001@45b53b1b}
java.lang.NullPointerException
	at net.glowstone.net.message.play.game.PluginMessage.fromString(PluginMessage.java:20)
	at net.glowstone.entity.GlowPlayer.join(GlowPlayer.java:411)
	at net.glowstone.net.GlowSession.setPlayer(GlowSession.java:357)
	at net.glowstone.net.handler.login.EncryptionKeyResponseHandler$ClientAuthCallback.lambda$done$0(EncryptionKeyResponseHandler.java:167)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at net.glowstone.scheduler.GlowTask.run(GlowTask.java:167)
	at net.glowstone.scheduler.GlowScheduler.pulse(GlowScheduler.java:152)
	at net.glowstone.scheduler.GlowScheduler.lambda$start$0(GlowScheduler.java:83)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
22:00:38 [WARNING] Z750 moved too quickly!
```
This makes getName behave the same as getVersion and getBukkitVersion.