### PR TITLE
Memory usage optimization with chunks

### DIFF
--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -426,7 +426,7 @@ public final class GlowWorld implements World {
             for (int x = cx - radius; x <= cx + radius; x++) {
                 for (int z = cz - radius; z <= cz + radius; z++) {
                     if (isChunkLoaded(cx, cz)) {
-                        activeChunksSet.add(new Key(x, z));
+                        activeChunksSet.add(GlowChunk.ChunkKeyStore.get(x, z));
                     }
                 }
             }
@@ -827,7 +827,7 @@ public final class GlowWorld implements World {
                 } else {
                     loadChunk(x, z);
                 }
-                spawnChunkLock.acquire(new Key(x, z));
+                spawnChunkLock.acquire(GlowChunk.ChunkKeyStore.get(x, z));
                 if (System.currentTimeMillis() >= loadTime + 1000) {
                     int progress = 100 * current / total;
                     GlowServer.logger.info("Preparing spawn for " + name + ": " + progress + "%");
@@ -1271,7 +1271,7 @@ public final class GlowWorld implements World {
             return false;
         }
 
-        Key key = new Key(x, z);
+        Key key = GlowChunk.ChunkKeyStore.get(x, z);
         boolean result = false;
 
         for (GlowPlayer player : getRawPlayers()) {

--- a/src/main/java/net/glowstone/block/entity/BlockEntity.java
+++ b/src/main/java/net/glowstone/block/entity/BlockEntity.java
@@ -2,6 +2,7 @@ package net.glowstone.block.entity;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
+import net.glowstone.chunk.GlowChunk;
 import net.glowstone.chunk.GlowChunk.Key;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.util.nbt.CompoundTag;
@@ -41,7 +42,7 @@ public abstract class BlockEntity {
      * Update this BlockEntity's visible state to all players in range.
      */
     public final void updateInRange() {
-        Key key = new Key(block.getChunk().getX(), block.getChunk().getZ());
+        Key key = GlowChunk.ChunkKeyStore.get(block.getChunk().getX(), block.getChunk().getZ());
         block.getWorld().getRawPlayers().stream().filter(player -> player.canSeeChunk(key)).forEach(this::update);
     }
 

--- a/src/main/java/net/glowstone/block/itemtype/ItemPainting.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemPainting.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import net.glowstone.block.GlowBlock;
+import net.glowstone.chunk.GlowChunk;
 import net.glowstone.chunk.GlowChunk.Key;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.objects.GlowPainting;
@@ -37,7 +38,7 @@ public class ItemPainting extends ItemType {
             )
         ).arrayListValues().build();
 
-        Arrays.stream(Art.values()).forEach(art -> ART_BY_SIZE.put(new Key(art.getBlockHeight(), art.getBlockWidth()), art));
+        Arrays.stream(Art.values()).forEach(art -> ART_BY_SIZE.put(GlowChunk.ChunkKeyStore.get(art.getBlockHeight(), art.getBlockWidth()), art));
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/state/GlowNoteBlock.java
+++ b/src/main/java/net/glowstone/block/state/GlowNoteBlock.java
@@ -4,6 +4,7 @@ import net.glowstone.EventFactory;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.NoteblockEntity;
+import net.glowstone.chunk.GlowChunk;
 import net.glowstone.chunk.GlowChunk.Key;
 import org.bukkit.Instrument;
 import org.bukkit.Location;
@@ -196,7 +197,7 @@ public class GlowNoteBlock extends GlowBlockState implements NoteBlock {
 
         Location location = getBlock().getLocation();
 
-        Key key = new Key(getX() >> 4, getZ() >> 4);
+        Key key = GlowChunk.ChunkKeyStore.get(getX() >> 4, getZ() >> 4);
         getWorld().getRawPlayers().stream().filter(player -> player.canSeeChunk(key)).forEach(player -> player.playNote(location, instrument, note));
 
         return true;

--- a/src/main/java/net/glowstone/chunk/ChunkManager.java
+++ b/src/main/java/net/glowstone/chunk/ChunkManager.java
@@ -96,7 +96,7 @@ public final class ChunkManager {
      * @return The chunk.
      */
     public GlowChunk getChunk(int x, int z) {
-        Key key = new Key(x, z);
+        Key key = GlowChunk.ChunkKeyStore.get(x, z);
         if (chunks.containsKey(key)) {
             return chunks.get(key);
         } else {
@@ -115,7 +115,7 @@ public final class ChunkManager {
      * @return true if the chunk is loaded, otherwise false.
      */
     public boolean isChunkLoaded(int x, int z) {
-        Key key = new Key(x, z);
+        Key key = GlowChunk.ChunkKeyStore.get(x, z);
         return chunks.containsKey(key) && chunks.get(key).isLoaded();
     }
 
@@ -127,7 +127,7 @@ public final class ChunkManager {
      * @return Whether the chunk is in use.
      */
     public boolean isChunkInUse(int x, int z) {
-        Key key = new Key(x, z);
+        Key key = GlowChunk.ChunkKeyStore.get(x, z);
         Set<ChunkLock> lockSet = locks.get(key);
         return lockSet != null && !lockSet.isEmpty();
     }

--- a/src/main/java/net/glowstone/chunk/GlowChunk.java
+++ b/src/main/java/net/glowstone/chunk/GlowChunk.java
@@ -282,7 +282,7 @@ public final class GlowChunk implements Chunk {
      * @param cy   the Y coordinate of the BlockEntity
      * @param cz   the Z coordinate of the BlockEntity
      * @param type the type of BlockEntity
-     * @return     The BlockEntity that was created.
+     * @return The BlockEntity that was created.
      */
     public BlockEntity createEntity(int cx, int cy, int cz, int type) {
         Material material = Material.getMaterial(type);
@@ -694,7 +694,7 @@ public final class GlowChunk implements Chunk {
      * Creates a new {@link ChunkDataMessage} which can be sent to a client to stream
      * parts of this chunk to them.
      *
-     * @param skylight Whether to include skylight data.
+     * @param skylight    Whether to include skylight data.
      * @param entireChunk Whether to send all chunk sections.
      * @return The {@link ChunkDataMessage}.
      */
@@ -755,7 +755,30 @@ public final class GlowChunk implements Chunk {
         /**
          * The coordinates.
          */
-        private final int x, z;
+        private final int x, z, hashCode;
+
+        private Key(int x, int z) {
+            this.x = x;
+            this.z = z;
+            this.hashCode = x * 31 + z;
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
     }
 
+    public static final class ChunkKeyStore {
+        private static final ConcurrentHashMap<Integer, Key> keys = new ConcurrentHashMap<>();
+
+        public static Key get(int x, int z) {
+            int id = x * 31 + z;
+            Key key = keys.get(id);
+            if (key != null) return key;
+            key = new Key(x, z);
+            keys.put(id, key);
+            return key;
+        }
+    }
 }

--- a/src/main/java/net/glowstone/chunk/GlowChunk.java
+++ b/src/main/java/net/glowstone/chunk/GlowChunk.java
@@ -760,12 +760,16 @@ public final class GlowChunk implements Chunk {
         private Key(int x, int z) {
             this.x = x;
             this.z = z;
-            this.hashCode = x * 31 + z;
+            this.hashCode = hashCode(x, z);
         }
 
         @Override
         public int hashCode() {
             return hashCode;
+        }
+
+        private static int hashCode(int x, int z) {
+            return x * 31 + z;
         }
     }
 
@@ -773,7 +777,7 @@ public final class GlowChunk implements Chunk {
         private static final ConcurrentHashMap<Integer, Key> keys = new ConcurrentHashMap<>();
 
         public static Key get(int x, int z) {
-            int id = x * 31 + z;
+            int id = Key.hashCode(x, z);
             Key key = keys.get(id);
             if (key != null) return key;
             key = new Key(x, z);

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -734,7 +734,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             Map<Key, Map<BlockVector, BlockChangeMessage>> chunks = new HashMap<>();
             for (BlockChangeMessage message : messages) {
                 if (message != null) {
-                    Key key = new Key(message.getX() >> 4, message.getZ() >> 4);
+                    Key key = GlowChunk.ChunkKeyStore.get(message.getX() >> 4, message.getZ() >> 4);
                     if (canSeeChunk(key)) {
                         Map<BlockVector, BlockChangeMessage> map = chunks.computeIfAbsent(key, k -> new HashMap<>());
                         map.put(new BlockVector(message.getX(), message.getY(), message.getZ()), message);
@@ -772,7 +772,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         int radius = Math.min(server.getViewDistance(), 1 + settings.getViewDistance());
         for (int x = centralX - radius; x <= centralX + radius; x++) {
             for (int z = centralZ - radius; z <= centralZ + radius; z++) {
-                Key key = new Key(x, z);
+                Key key = GlowChunk.ChunkKeyStore.get(x, z);
                 if (knownChunks.contains(key)) {
                     previousChunks.remove(key);
                 } else {
@@ -2188,7 +2188,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
     public void sendBlockChange(BlockChangeMessage message) {
         // only send message if the chunk is within visible range
-        Key key = new Key(message.getX() >> 4, message.getZ() >> 4);
+        Key key = GlowChunk.ChunkKeyStore.get(message.getX() >> 4, message.getZ() >> 4);
         if (canSeeChunk(key)) {
             blockChanges.add(message);
         }
@@ -2953,7 +2953,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
     }
 
     private void broadcastBlockBreakAnimation(GlowBlock block, int destroyStage) {
-        GlowChunk.Key key = new GlowChunk.Key(block.getChunk().getX(), block.getChunk().getZ());
+        GlowChunk.Key key = GlowChunk.ChunkKeyStore.get(block.getChunk().getX(), block.getChunk().getZ());
         block.getWorld().getRawPlayers().stream()
                 .filter(player -> player.canSeeChunk(key) && player != this)
                 .forEach(player -> player.sendBlockBreakAnimation(block.getLocation(), destroyStage));

--- a/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
@@ -2,6 +2,7 @@ package net.glowstone.entity.objects;
 
 import com.flowpowered.network.Message;
 import net.glowstone.EventFactory;
+import net.glowstone.chunk.GlowChunk;
 import net.glowstone.chunk.GlowChunk.Key;
 import net.glowstone.entity.GlowHangingEntity;
 import net.glowstone.entity.GlowPlayer;
@@ -147,7 +148,7 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
                 break;
         }
 
-        Key key = new Key(location.getChunk().getX(), location.getChunk().getZ());
+        Key key = GlowChunk.ChunkKeyStore.get(location.getChunk().getX(), location.getChunk().getZ());
         for (GlowPlayer player : getWorld().getRawPlayers()) {
             if (player.canSeeChunk(key)) {
                 double x = location.getX();

--- a/src/main/java/net/glowstone/generator/populators/StructurePopulator.java
+++ b/src/main/java/net/glowstone/generator/populators/StructurePopulator.java
@@ -2,7 +2,7 @@ package net.glowstone.generator.populators;
 
 import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
-import net.glowstone.chunk.GlowChunk.Key;
+import net.glowstone.chunk.GlowChunk;
 import net.glowstone.generator.structures.GlowStructure;
 import net.glowstone.io.structure.StructureStorage;
 import net.glowstone.io.structure.StructureStore;
@@ -36,7 +36,7 @@ public class StructurePopulator extends BlockPopulator {
                     if (world.getChunkAt(x, z).isLoaded() || world.getChunkAt(x, z).load(true)) {
                         random.setSeed(x * xRand + z * zRand ^ world.getSeed());
                         Map<Integer, GlowStructure> structures = ((GlowWorld) world).getStructures();
-                        int key = new Key(x, z).hashCode();
+                        int key = GlowChunk.ChunkKeyStore.get(x, z).hashCode();
                         if (!structures.containsKey(key)) {
                             for (StructureStore<?> store : StructureStorage.getStructureStores()) {
                                 GlowStructure structure = store.createNewStructure((GlowWorld) world, random, x, z);

--- a/src/main/java/net/glowstone/io/nbt/NbtStructureDataService.java
+++ b/src/main/java/net/glowstone/io/nbt/NbtStructureDataService.java
@@ -2,7 +2,7 @@ package net.glowstone.io.nbt;
 
 import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
-import net.glowstone.chunk.GlowChunk.Key;
+import net.glowstone.chunk.GlowChunk;
 import net.glowstone.generator.structures.GlowStructure;
 import net.glowstone.io.StructureDataService;
 import net.glowstone.io.structure.StructureStorage;
@@ -51,7 +51,7 @@ public class NbtStructureDataService implements StructureDataService {
                             CompoundTag features = data.getCompound("Features");
                             features.getValue().keySet().stream().filter(features::isCompound).forEach(key -> {
                                 GlowStructure structure = StructureStorage.loadStructure(world, features.getCompound(key));
-                                structures.put(new Key(structure.getChunkX(), structure.getChunkZ()).hashCode(), structure);
+                                structures.put(GlowChunk.ChunkKeyStore.get(structure.getChunkX(), structure.getChunkZ()).hashCode(), structure);
                             });
                         }
                     } else {


### PR DESCRIPTION
The goal of this PR is to lower the usage of memory by certain objects. Using a profiler, I noticed that over 75% of the memory usage was made of `GlowChunk$Key` objects, which are used to index chunks by their coordinates in multiple places in the code.

Since objects take more place than primitive types like ints, I tried caching these keys by having a simple permanent hash attributed to them (`x * 31 + z`) and storing them in a concurrent map. I noticed that not only the amount of `GlowChunk$Key` objects was reduced considerably (from 5 million to 1600 in a fresh world), but the RAM usage in bytes was lowered because most of these objects were replaced with single integers.

I have also noticed that there are many `GlowBlock` objects being created and deleted constantly, probably because this type is never cached. I didn't try much in that area yet, but there might be some more stuff to fix as well.

I am no optimization expert, so I am just analyzing graphs over time here. Please feel free to suggest anything or review my attempts if they feel inappropriate.

PS: I didn't really take the time to properly format/beautify my code, sorry in advance :)