### PR TITLE
Fix random target selector - Fixes #574

### DIFF
--- a/src/main/java/net/glowstone/command/CommandTarget.java
+++ b/src/main/java/net/glowstone/command/CommandTarget.java
@@ -234,10 +234,14 @@ public class CommandTarget {
             count = entities.size();
         List<Entity> matched = new ArrayList<>();
         List<Integer> used = new ArrayList<>();
+        Random rand = null;
         for (int i = 0; i < count; i++) {
             if (selector == SelectorType.RANDOM) {
+                if (rand == null) {
+                    rand = new Random();
+                }
                 while (true) {
-                    int random = new Random().nextInt(count + 1);
+                    int random = rand.nextInt(entities.size());
                     if (!used.contains(random)) {
                         matched.add(entities.get(random));
                         used.add(random);


### PR DESCRIPTION
This PR fixes the IndexOutOfBoundsException when using the `@r` selector on a single player as stated in #574.

The commit also reuses the random object for performance reasons.
