### PR TITLE
Fix food features and update food values

### DIFF
--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -276,7 +276,7 @@ public final class ItemTable {
         reg(Material.MELON_SEEDS, new ItemSeeds(Material.MELON_STEM, Material.SOIL));
         reg(Material.PUMPKIN_SEEDS, new ItemSeeds(Material.PUMPKIN_STEM, Material.SOIL));
         reg(Material.NETHER_STALK, new ItemSeeds(Material.NETHER_WARTS, Material.SOUL_SAND));
-        reg(Material.CARROT_ITEM, new ItemFoodSeeds(Material.CARROT, Material.SOIL, 3, 4.8f));
+        reg(Material.CARROT_ITEM, new ItemFoodSeeds(Material.CARROT, Material.SOIL, 3, 3.6f));
         reg(Material.POTATO_ITEM, new ItemFoodSeeds(Material.POTATO, Material.SOIL, 1, 0.6f));
         reg(Material.INK_SACK, new ItemDye());
         reg(Material.BANNER, new ItemBanner());
@@ -289,8 +289,8 @@ public final class ItemTable {
         reg(Material.DARK_OAK_DOOR_ITEM, new ItemPlaceAs(Material.DARK_OAK_DOOR));
         reg(Material.WRITTEN_BOOK, new ItemWrittenBook());
         reg(Material.ITEM_FRAME, new ItemItemFrame());
-        reg(Material.APPLE, new ItemFood(4, 12.4f));
-        reg(Material.BAKED_POTATO, new ItemFood(5, 7.2f));
+        reg(Material.APPLE, new ItemFood(4, 2.4f));
+        reg(Material.BAKED_POTATO, new ItemFood(5, 6f));
         reg(Material.BREAD, new ItemFood(5, 6f));
         reg(Material.COOKED_CHICKEN, new ItemFood(6, 7.2f));
         reg(Material.COOKED_FISH, new ItemFishCooked());
@@ -302,10 +302,12 @@ public final class ItemTable {
         reg(Material.GOLDEN_CARROT, new ItemFood(6, 14.4f));
         reg(Material.GRILLED_PORK, new ItemFood(8, 12.8f));
         reg(Material.MELON, new ItemFood(2, 1.2f));
-        reg(Material.MUSHROOM_SOUP, new ItemFood(6, 7.2f));
+        reg(Material.BEETROOT, new ItemFood(1, 1.2f));
+        reg(Material.BEETROOT_SOUP, new ItemSoup(6, 7.2f));
+        reg(Material.MUSHROOM_SOUP, new ItemSoup(6, 7.2f));
         reg(Material.POISONOUS_POTATO, new ItemPoisonousPotato());
         reg(Material.PUMPKIN_PIE, new ItemFood(8, 4.8f));
-        reg(Material.RABBIT_STEW, new ItemFood(10, 12f));
+        reg(Material.RABBIT_STEW, new ItemSoup(10, 12f));
         reg(Material.RAW_BEEF, new ItemFood(3, 1.8f));
         reg(Material.RAW_CHICKEN, new ItemRawChicken());
         reg(Material.RAW_FISH, new ItemFishRaw());
@@ -313,7 +315,8 @@ public final class ItemTable {
         reg(Material.PORK, new ItemFood(3, 1.8f));
         reg(Material.RABBIT, new ItemFood(3, 1.8f));
         reg(Material.ROTTEN_FLESH, new ItemRottenFlesh());
-        reg(Material.SPIDER_EYE, new ItemFood(2, 3.2f)); // todo: effect
+        reg(Material.SPIDER_EYE, new ItemSpiderEye());
+        reg(Material.CHORUS_FRUIT, new ItemFood(4, 2.4f)); //todo: chorus fruit teleportation
         reg(Material.ARMOR_STAND, new ItemArmorStand());
         reg(Material.MILK_BUCKET, new ItemMilk());
         reg(Material.MINECART, new ItemMinecart(GlowMinecart.MinecartType.RIDEABLE));

--- a/src/main/java/net/glowstone/block/itemtype/ItemFishCooked.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFishCooked.java
@@ -9,7 +9,7 @@ public class ItemFishCooked extends ItemFood {
         byte data = stack.getData().getData();
         switch (data) {
             case 0:
-                return 0.4f;
+                return 6f;
             case 1:
                 return 9.6f;
         }
@@ -21,7 +21,7 @@ public class ItemFishCooked extends ItemFood {
         byte data = stack.getData().getData();
         switch (data) {
             case 0:
-                return 2;
+                return 5;
             case 1:
                 return 6;
         }

--- a/src/main/java/net/glowstone/block/itemtype/ItemFishRaw.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFishRaw.java
@@ -2,6 +2,7 @@ package net.glowstone.block.itemtype;
 
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 public class ItemFishRaw extends ItemFood {
@@ -39,9 +40,9 @@ public class ItemFishRaw extends ItemFood {
         if (!super.eat(player, item)) return false;
 
         if (item.getData().getData() == 3) {
-            player.addPotionEffect(PotionEffectType.POISON.createEffect(60 * 20, 4), true);
-            player.addPotionEffect(PotionEffectType.HUNGER.createEffect(15 * 20, 3), true);
-            player.addPotionEffect(PotionEffectType.CONFUSION.createEffect(15 * 20, 2), true);
+            player.addPotionEffect(new PotionEffect(PotionEffectType.POISON, 60 * 20, 3), true);
+            player.addPotionEffect(new PotionEffect(PotionEffectType.HUNGER, 15 * 20, 2), true);
+            player.addPotionEffect(new PotionEffect(PotionEffectType.CONFUSION, 15 * 20, 1), true);
         }
         return true;
     }

--- a/src/main/java/net/glowstone/block/itemtype/ItemFood.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFood.java
@@ -35,8 +35,7 @@ public class ItemFood extends ItemTimedUsage {
         return saturation;
     }
 
-    public boolean eat(GlowPlayer player, ItemStack item) {
-
+    protected boolean handleEat(GlowPlayer player, ItemStack item) {
         PlayerItemConsumeEvent event1 = new PlayerItemConsumeEvent(player, item);
         EventFactory.callEvent(event1);
         if (event1.isCancelled()) return false;
@@ -50,6 +49,13 @@ public class ItemFood extends ItemTimedUsage {
 
         player.setUsageItem(null);
         player.setUsageTime(0);
+        return true;
+    }
+
+    public boolean eat(GlowPlayer player, ItemStack item) {
+        if (!handleEat(player, item)) {
+            return false;
+        }
         if (item.getAmount() > 1) {
             item.setAmount(item.getAmount() - 1);
         } else {

--- a/src/main/java/net/glowstone/block/itemtype/ItemGoldenApple.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemGoldenApple.java
@@ -2,6 +2,7 @@ package net.glowstone.block.itemtype;
 
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 public class ItemGoldenApple extends ItemFood {
@@ -14,15 +15,15 @@ public class ItemGoldenApple extends ItemFood {
     public boolean eat(GlowPlayer player, ItemStack item) {
         if (!super.eat(player, item)) return false;
 
-        player.addPotionEffect(PotionEffectType.ABSORPTION.createEffect(2 * 60 * 20, 1), true);
-
         byte data = item.getData().getData();
         if (data == 0) {
-            player.addPotionEffect(PotionEffectType.REGENERATION.createEffect(5 * 20, 2), true);
+            player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, 2 * 60 * 20, 0), true);
+            player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 5 * 20, 1), true);
         } else if (data == 1) {
-            player.addPotionEffect(PotionEffectType.REGENERATION.createEffect(30 * 20, 5), true);
-            player.addPotionEffect(PotionEffectType.DAMAGE_RESISTANCE.createEffect(5 * 60 * 20, 1), true);
-            player.addPotionEffect(PotionEffectType.FIRE_RESISTANCE.createEffect(5 * 60 * 20, 1), true);
+            player.addPotionEffect(new PotionEffect(PotionEffectType.ABSORPTION, 2 * 60 * 20, 3), true);
+            player.addPotionEffect(new PotionEffect(PotionEffectType.REGENERATION, 20 * 20, 1), true);
+            player.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 5 * 60 * 20, 0), true);
+            player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, 5 * 60 * 20, 0), true);
         }
 
         return true;

--- a/src/main/java/net/glowstone/block/itemtype/ItemPoisonousPotato.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemPoisonousPotato.java
@@ -2,12 +2,13 @@ package net.glowstone.block.itemtype;
 
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 public class ItemPoisonousPotato extends ItemFood {
 
     public ItemPoisonousPotato() {
-        super(1, 0.6f);
+        super(2, 1.2f);
     }
 
     @Override
@@ -15,7 +16,7 @@ public class ItemPoisonousPotato extends ItemFood {
         if (!super.eat(player, item)) return false;
 
         if (Math.random() < 0.6) {
-            player.addPotionEffect(PotionEffectType.POISON.createEffect(4 * 20, 1), true);
+            player.addPotionEffect(new PotionEffect(PotionEffectType.POISON, 5 * 20, 0), true);
         }
         return true;
     }

--- a/src/main/java/net/glowstone/block/itemtype/ItemRawChicken.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemRawChicken.java
@@ -2,6 +2,7 @@ package net.glowstone.block.itemtype;
 
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 public class ItemRawChicken extends ItemFood {
@@ -15,7 +16,7 @@ public class ItemRawChicken extends ItemFood {
         if (!super.eat(player, item)) return false;
 
         if (Math.random() < 0.3) {
-            player.addPotionEffect(PotionEffectType.HUNGER.createEffect(30 * 20, 1), true);
+            player.addPotionEffect(new PotionEffect(PotionEffectType.HUNGER, 30 * 20, 0), true);
         }
         return true;
     }

--- a/src/main/java/net/glowstone/block/itemtype/ItemRottenFlesh.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemRottenFlesh.java
@@ -2,6 +2,7 @@ package net.glowstone.block.itemtype;
 
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 public class ItemRottenFlesh extends ItemFood {
@@ -14,8 +15,8 @@ public class ItemRottenFlesh extends ItemFood {
     public boolean eat(GlowPlayer player, ItemStack item) {
         if (!super.eat(player, item)) return false;
 
-        if (Math.random() < 0.3) {
-            player.addPotionEffect(PotionEffectType.HUNGER.createEffect(30 * 20, 1), true);
+        if (Math.random() < 0.8) {
+            player.addPotionEffect(new PotionEffect(PotionEffectType.HUNGER, 30 * 20, 0), true);
         }
         return true;
     }

--- a/src/main/java/net/glowstone/block/itemtype/ItemSoup.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemSoup.java
@@ -1,0 +1,22 @@
+package net.glowstone.block.itemtype;
+
+import net.glowstone.entity.GlowPlayer;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class ItemSoup extends ItemFood {
+
+    public ItemSoup(int foodLevel, float saturation) {
+        super(foodLevel, saturation);
+    }
+
+    @Override
+    public boolean eat(GlowPlayer player, ItemStack item) {
+        if (!handleEat(player, item)) {
+            return false;
+        }
+
+        item.setType(Material.BOWL);
+        return true;
+    }
+}

--- a/src/main/java/net/glowstone/block/itemtype/ItemSpiderEye.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemSpiderEye.java
@@ -2,6 +2,7 @@ package net.glowstone.block.itemtype;
 
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 public class ItemSpiderEye extends ItemFood {
@@ -14,9 +15,7 @@ public class ItemSpiderEye extends ItemFood {
     public boolean eat(GlowPlayer player, ItemStack item) {
         if (!super.eat(player, item)) return false;
 
-        if (Math.random() < 0.3) {
-            player.addPotionEffect(PotionEffectType.POISON.createEffect(4 * 20, 1), true);
-        }
+        player.addPotionEffect(new PotionEffect(PotionEffectType.POISON, 5 * 20, 0), true);
         return true;
     }
 }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -601,7 +601,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         super.pulse();
 
         if (usageItem != null) {
-            if (usageItem == getItemInHand()) {
+            if (usageItem.equals(getItemInHand())) { //todo: implement offhand
                 if (--usageTime == 0) {
                     ItemType item = ItemTable.instance().getItem(usageItem.getType());
                     if (item instanceof ItemFood) {


### PR DESCRIPTION
This pull request fixes some food related features and updates the food values like restored hunger, saturation and the applied potion effects.

The following things are done by this PR:
- Update restored hunger and saturation according to the [Minecraft wiki](https://minecraft.gamepedia.com/Food)
- New ItemSoup class which returns an empty bowl to the player
- Added beetroot, beetroot soup and chorus fruit as food
- Update potion effect chances, durations and levels according to the Minecraft wiki and some additional investigation
- Changed the food potion effects to use `new PotionEffect(...)` because the old version uses the "duration modifiers" (I have no clue why these exist) which change the given duration depending on the potion effect resulting in wrong durations applied to the player
- Use an `equals` in the eating logic as `getItemInHand` returns a copy of the itemstack object