### PR TITLE
Implement block states for commands and /testforblock command

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -11,7 +11,7 @@ import net.glowstone.advancement.GlowAdvancement;
 import net.glowstone.advancement.GlowAdvancementDisplay;
 import net.glowstone.block.BuiltinMaterialValueManager;
 import net.glowstone.block.MaterialValueManager;
-import net.glowstone.block.state.GlowDispenser;
+import net.glowstone.block.entity.state.GlowDispenser;
 import net.glowstone.boss.BossBarManager;
 import net.glowstone.boss.GlowBossBar;
 import net.glowstone.client.GlowClient;

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -861,6 +861,7 @@ public final class GlowServer implements Server {
         commandMap.register("minecraft", new EffectCommand());
         commandMap.register("minecraft", new EnchantCommand());
         commandMap.register("minecraft", new TestForCommand());
+        commandMap.register("minecraft", new TestForBlockCommand());
 
         File folder = new File(config.getString(Key.PLUGIN_FOLDER));
         if (!folder.isDirectory() && !folder.mkdirs()) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockBanner.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockBanner.java
@@ -4,7 +4,7 @@ import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.BlockEntity;
 import net.glowstone.block.entity.BannerEntity;
-import net.glowstone.block.state.GlowBanner;
+import net.glowstone.block.entity.state.GlowBanner;
 import net.glowstone.chunk.GlowChunk;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.util.nbt.CompoundTag;

--- a/src/main/java/net/glowstone/block/blocktype/BlockBed.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockBed.java
@@ -5,7 +5,7 @@ import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.BedEntity;
 import net.glowstone.block.entity.BlockEntity;
-import net.glowstone.block.state.GlowBed;
+import net.glowstone.block.entity.state.GlowBed;
 import net.glowstone.chunk.GlowChunk;
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.DyeColor;

--- a/src/main/java/net/glowstone/block/blocktype/BlockDispenser.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockDispenser.java
@@ -4,7 +4,7 @@ import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.BlockEntity;
 import net.glowstone.block.entity.DispenserEntity;
-import net.glowstone.block.state.GlowDispenser;
+import net.glowstone.block.entity.state.GlowDispenser;
 import net.glowstone.chunk.GlowChunk;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.inventory.MaterialMatcher;

--- a/src/main/java/net/glowstone/block/blocktype/BlockFlowerPot.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockFlowerPot.java
@@ -4,7 +4,7 @@ import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.BlockEntity;
 import net.glowstone.block.entity.FlowerPotEntity;
-import net.glowstone.block.state.GlowFlowerPot;
+import net.glowstone.block.entity.state.GlowFlowerPot;
 import net.glowstone.chunk.GlowChunk;
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.GrassSpecies;

--- a/src/main/java/net/glowstone/block/blocktype/BlockHopper.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockHopper.java
@@ -5,7 +5,7 @@ import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.BlockEntity;
 import net.glowstone.block.entity.ContainerEntity;
 import net.glowstone.block.entity.HopperEntity;
-import net.glowstone.block.state.GlowHopper;
+import net.glowstone.block.entity.state.GlowHopper;
 import net.glowstone.chunk.GlowChunk;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.objects.GlowItem;

--- a/src/main/java/net/glowstone/block/blocktype/BlockJukebox.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockJukebox.java
@@ -3,7 +3,7 @@ package net.glowstone.block.blocktype;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.entity.BlockEntity;
 import net.glowstone.block.entity.JukeboxEntity;
-import net.glowstone.block.state.GlowJukebox;
+import net.glowstone.block.entity.state.GlowJukebox;
 import net.glowstone.chunk.GlowChunk;
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.GameMode;

--- a/src/main/java/net/glowstone/block/blocktype/BlockSkull.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSkull.java
@@ -4,7 +4,7 @@ import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.SkullEntity;
 import net.glowstone.block.entity.BlockEntity;
-import net.glowstone.block.state.GlowSkull;
+import net.glowstone.block.entity.state.GlowSkull;
 import net.glowstone.chunk.GlowChunk;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.util.pattern.BlockPattern;

--- a/src/main/java/net/glowstone/block/entity/BannerEntity.java
+++ b/src/main/java/net/glowstone/block/entity/BannerEntity.java
@@ -3,7 +3,7 @@ package net.glowstone.block.entity;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.blocktype.BlockBanner;
-import net.glowstone.block.state.GlowBanner;
+import net.glowstone.block.entity.state.GlowBanner;
 import net.glowstone.constants.GlowBlockEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.util.nbt.CompoundTag;

--- a/src/main/java/net/glowstone/block/entity/BedEntity.java
+++ b/src/main/java/net/glowstone/block/entity/BedEntity.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
-import net.glowstone.block.state.GlowBed;
+import net.glowstone.block.entity.state.GlowBed;
 import net.glowstone.constants.GlowBlockEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.util.nbt.CompoundTag;

--- a/src/main/java/net/glowstone/block/entity/BrewingStandEntity.java
+++ b/src/main/java/net/glowstone/block/entity/BrewingStandEntity.java
@@ -2,7 +2,7 @@ package net.glowstone.block.entity;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
-import net.glowstone.block.state.GlowBrewingStand;
+import net.glowstone.block.entity.state.GlowBrewingStand;
 import net.glowstone.inventory.GlowBrewerInventory;
 import net.glowstone.util.nbt.CompoundTag;
 

--- a/src/main/java/net/glowstone/block/entity/ChestEntity.java
+++ b/src/main/java/net/glowstone/block/entity/ChestEntity.java
@@ -2,7 +2,7 @@ package net.glowstone.block.entity;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
-import net.glowstone.block.state.GlowChest;
+import net.glowstone.block.entity.state.GlowChest;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.inventory.GlowChestInventory;
 import net.glowstone.net.message.play.game.BlockActionMessage;

--- a/src/main/java/net/glowstone/block/entity/DispenserEntity.java
+++ b/src/main/java/net/glowstone/block/entity/DispenserEntity.java
@@ -2,7 +2,7 @@ package net.glowstone.block.entity;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
-import net.glowstone.block.state.GlowDispenser;
+import net.glowstone.block.entity.state.GlowDispenser;
 import net.glowstone.inventory.GlowInventory;
 import org.bukkit.event.inventory.InventoryType;
 

--- a/src/main/java/net/glowstone/block/entity/DropperEntity.java
+++ b/src/main/java/net/glowstone/block/entity/DropperEntity.java
@@ -2,7 +2,7 @@ package net.glowstone.block.entity;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
-import net.glowstone.block.state.GlowDropper;
+import net.glowstone.block.entity.state.GlowDropper;
 
 public class DropperEntity extends DispenserEntity {
 

--- a/src/main/java/net/glowstone/block/entity/FlowerPotEntity.java
+++ b/src/main/java/net/glowstone/block/entity/FlowerPotEntity.java
@@ -2,7 +2,7 @@ package net.glowstone.block.entity;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
-import net.glowstone.block.state.GlowFlowerPot;
+import net.glowstone.block.entity.state.GlowFlowerPot;
 import net.glowstone.constants.GlowBlockEntity;
 import net.glowstone.constants.ItemIds;
 import net.glowstone.entity.GlowPlayer;

--- a/src/main/java/net/glowstone/block/entity/FurnaceEntity.java
+++ b/src/main/java/net/glowstone/block/entity/FurnaceEntity.java
@@ -4,7 +4,7 @@ import net.glowstone.EventFactory;
 import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
-import net.glowstone.block.state.GlowFurnace;
+import net.glowstone.block.entity.state.GlowFurnace;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.inventory.GlowFurnaceInventory;
 import net.glowstone.inventory.crafting.CraftingManager;

--- a/src/main/java/net/glowstone/block/entity/HopperEntity.java
+++ b/src/main/java/net/glowstone/block/entity/HopperEntity.java
@@ -2,7 +2,7 @@ package net.glowstone.block.entity;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
-import net.glowstone.block.state.GlowHopper;
+import net.glowstone.block.entity.state.GlowHopper;
 import net.glowstone.inventory.GlowInventory;
 import org.bukkit.event.inventory.InventoryType;
 

--- a/src/main/java/net/glowstone/block/entity/JukeboxEntity.java
+++ b/src/main/java/net/glowstone/block/entity/JukeboxEntity.java
@@ -2,7 +2,7 @@ package net.glowstone.block.entity;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
-import net.glowstone.block.state.GlowJukebox;
+import net.glowstone.block.entity.state.GlowJukebox;
 import net.glowstone.io.nbt.NbtSerialization;
 import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.inventory.ItemStack;

--- a/src/main/java/net/glowstone/block/entity/MobSpawnerEntity.java
+++ b/src/main/java/net/glowstone/block/entity/MobSpawnerEntity.java
@@ -2,7 +2,7 @@ package net.glowstone.block.entity;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
-import net.glowstone.block.state.GlowCreatureSpawner;
+import net.glowstone.block.entity.state.GlowCreatureSpawner;
 import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.entity.EntityType;
 

--- a/src/main/java/net/glowstone/block/entity/NoteblockEntity.java
+++ b/src/main/java/net/glowstone/block/entity/NoteblockEntity.java
@@ -2,7 +2,7 @@ package net.glowstone.block.entity;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
-import net.glowstone.block.state.GlowNoteBlock;
+import net.glowstone.block.entity.state.GlowNoteBlock;
 import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.Note;
 

--- a/src/main/java/net/glowstone/block/entity/SignEntity.java
+++ b/src/main/java/net/glowstone/block/entity/SignEntity.java
@@ -2,7 +2,7 @@ package net.glowstone.block.entity;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
-import net.glowstone.block.state.GlowSign;
+import net.glowstone.block.entity.state.GlowSign;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.util.TextMessage;
 import net.glowstone.util.nbt.CompoundTag;

--- a/src/main/java/net/glowstone/block/entity/SkullEntity.java
+++ b/src/main/java/net/glowstone/block/entity/SkullEntity.java
@@ -3,7 +3,7 @@ package net.glowstone.block.entity;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.blocktype.BlockSkull;
-import net.glowstone.block.state.GlowSkull;
+import net.glowstone.block.entity.state.GlowSkull;
 import net.glowstone.constants.GlowBlockEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.meta.profile.PlayerProfile;

--- a/src/main/java/net/glowstone/block/entity/state/GlowBanner.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowBanner.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;

--- a/src/main/java/net/glowstone/block/entity/state/GlowBeacon.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowBeacon.java
@@ -1,5 +1,5 @@
 
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.entity.BeaconEntity;

--- a/src/main/java/net/glowstone/block/entity/state/GlowBed.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowBed.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;

--- a/src/main/java/net/glowstone/block/entity/state/GlowBrewingStand.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowBrewingStand.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.entity.BrewingStandEntity;

--- a/src/main/java/net/glowstone/block/entity/state/GlowChest.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowChest.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;

--- a/src/main/java/net/glowstone/block/entity/state/GlowContainer.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowContainer.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import com.destroystokyo.paper.loottable.LootableBlockInventory;
 import net.glowstone.block.GlowBlock;

--- a/src/main/java/net/glowstone/block/entity/state/GlowCreatureSpawner.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowCreatureSpawner.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;

--- a/src/main/java/net/glowstone/block/entity/state/GlowDispenser.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowDispenser.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.entity.DispenserEntity;

--- a/src/main/java/net/glowstone/block/entity/state/GlowDropper.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowDropper.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.block.GlowBlock;
 import org.bukkit.block.Dropper;

--- a/src/main/java/net/glowstone/block/entity/state/GlowFlowerPot.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowFlowerPot.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;

--- a/src/main/java/net/glowstone/block/entity/state/GlowFurnace.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowFurnace.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.entity.FurnaceEntity;

--- a/src/main/java/net/glowstone/block/entity/state/GlowHopper.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowHopper.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.entity.HopperEntity;

--- a/src/main/java/net/glowstone/block/entity/state/GlowJukebox.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowJukebox.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;

--- a/src/main/java/net/glowstone/block/entity/state/GlowNoteBlock.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowNoteBlock.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.EventFactory;
 import net.glowstone.block.GlowBlock;

--- a/src/main/java/net/glowstone/block/entity/state/GlowSign.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowSign.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;

--- a/src/main/java/net/glowstone/block/entity/state/GlowSkull.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowSkull.java
@@ -1,4 +1,4 @@
-package net.glowstone.block.state;
+package net.glowstone.block.entity.state;
 
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;

--- a/src/main/java/net/glowstone/block/state/BlockStateData.java
+++ b/src/main/java/net/glowstone/block/state/BlockStateData.java
@@ -1,12 +1,53 @@
 package net.glowstone.block.state;
 
-import java.util.HashMap;
+import com.google.common.collect.Maps;
 
-public class BlockStateData extends HashMap<String, String> {
+import java.util.Map;
+
+public class BlockStateData {
+
+    private final Map<String, String> map = Maps.newHashMap();
+    private final int numericValue;
+
+    public BlockStateData(int numericValue) {
+        this.numericValue = numericValue;
+    }
+
+    public BlockStateData() {
+        this.numericValue = -1;
+    }
+
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    public void put(String key, String value) {
+        map.put(key, value);
+    }
+
+    public boolean contains(String key) {
+        return map.containsKey(key);
+    }
+
+    public String get(String key) {
+        return map.get(key);
+    }
+
+    public boolean isNumeric() {
+        return numericValue != -1;
+    }
+
+    public int getNumericValue() {
+        return numericValue;
+    }
+
     @Override
     public String toString() {
+        if (isNumeric()) {
+            return String.valueOf(numericValue);
+        }
         StringBuilder builder = new StringBuilder();
-        for (Entry<String, String> entry : entrySet()) {
+        for (Map.Entry<String, String> entry : map.entrySet()) {
             builder.append(",").append(entry.getKey()).append("=").append(entry.getValue());
         }
         return builder.length() == 0 ? builder.toString() : builder.substring(1);

--- a/src/main/java/net/glowstone/block/state/BlockStateData.java
+++ b/src/main/java/net/glowstone/block/state/BlockStateData.java
@@ -1,0 +1,14 @@
+package net.glowstone.block.state;
+
+import java.util.HashMap;
+
+public class BlockStateData extends HashMap<String, String> {
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        for (Entry<String, String> entry : entrySet()) {
+            builder.append(",").append(entry.getKey()).append("=").append(entry.getValue());
+        }
+        return builder.length() == 0 ? builder.toString() : builder.substring(1);
+    }
+}

--- a/src/main/java/net/glowstone/block/state/BlockStateReader.java
+++ b/src/main/java/net/glowstone/block/state/BlockStateReader.java
@@ -3,7 +3,11 @@ package net.glowstone.block.state;
 import org.bukkit.Material;
 import org.bukkit.material.MaterialData;
 
+import java.util.Set;
+
 public abstract class BlockStateReader<T extends MaterialData> {
+
+    public abstract Set<String> getValidStates();
 
     public abstract T read(Material material, BlockStateData data) throws InvalidBlockStateException;
 

--- a/src/main/java/net/glowstone/block/state/BlockStateReader.java
+++ b/src/main/java/net/glowstone/block/state/BlockStateReader.java
@@ -1,0 +1,11 @@
+package net.glowstone.block.state;
+
+import org.bukkit.Material;
+import org.bukkit.material.MaterialData;
+
+public abstract class BlockStateReader<T extends MaterialData> {
+
+    public abstract T read(Material material, BlockStateData data) throws InvalidBlockStateException;
+
+    public abstract boolean matches(BlockStateData state, T data) throws InvalidBlockStateException;
+}

--- a/src/main/java/net/glowstone/block/state/InvalidBlockStateException.java
+++ b/src/main/java/net/glowstone/block/state/InvalidBlockStateException.java
@@ -1,0 +1,14 @@
+package net.glowstone.block.state;
+
+import net.glowstone.constants.ItemIds;
+import org.bukkit.Material;
+
+public class InvalidBlockStateException extends Exception {
+    public InvalidBlockStateException(Material material, String state) {
+        super("'" + state + "' is not a state for block " + ItemIds.getName(material));
+    }
+
+    public InvalidBlockStateException(Material material, BlockStateData state) {
+        super("'" + state.toString() + "' is not a state for block " + ItemIds.getName(material));
+    }
+}

--- a/src/main/java/net/glowstone/block/state/StateSerialization.java
+++ b/src/main/java/net/glowstone/block/state/StateSerialization.java
@@ -55,7 +55,7 @@ public class StateSerialization {
     }
 
     public static BlockStateReader getReader(Material material) {
-        if (!READERS.containsKey(material)) {
+        if (material == null) {
             return null;
         }
         return READERS.get(material);

--- a/src/main/java/net/glowstone/block/state/StateSerialization.java
+++ b/src/main/java/net/glowstone/block/state/StateSerialization.java
@@ -1,0 +1,78 @@
+package net.glowstone.block.state;
+
+import net.glowstone.block.state.impl.WoolStateDataReader;
+import org.bukkit.DyeColor;
+import org.bukkit.Material;
+import org.bukkit.material.MaterialData;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class StateSerialization {
+
+    private static final Map<Material, BlockStateReader> READERS = new HashMap<>();
+
+    public static BlockStateData parse(Material material, String state) throws InvalidBlockStateException {
+        if (state == null || state.trim().isEmpty()) {
+            return new BlockStateData();
+        }
+        if (material == null || getReader(material) == null) {
+            throw new InvalidBlockStateException(material, state);
+        }
+        BlockStateData data = new BlockStateData();
+        String[] split = state.trim().split(",");
+        for (String section : split) {
+            if (!section.contains("=") || section.indexOf('=') != section.lastIndexOf('=')) {
+                throw new InvalidBlockStateException(material, state);
+            }
+            String[] keyVal = section.split("=");
+            keyVal[0] = keyVal[0].trim().toLowerCase();
+            keyVal[1] = keyVal[1].trim().toLowerCase();
+            if (keyVal[0].isEmpty() || keyVal[1].isEmpty()) {
+                throw new InvalidBlockStateException(material, state);
+            }
+            data.put(keyVal[0], keyVal[1]);
+        }
+        return data;
+    }
+
+    public static boolean matches(Material type, MaterialData data, BlockStateData state) throws InvalidBlockStateException {
+        if (state == null || data == null || data.getItemType() != type) {
+            return false;
+        }
+        BlockStateReader reader = getReader(type);
+        if (reader == null) return false;
+        return reader.matches(state, data);
+    }
+
+    public static MaterialData parseData(Material type, BlockStateData state) throws InvalidBlockStateException {
+        if (type == null || state == null) {
+            return null;
+        }
+        BlockStateReader reader = getReader(type);
+        if (reader == null) throw new InvalidBlockStateException(type, state);
+        return reader.read(type, state);
+    }
+
+    public static BlockStateReader getReader(Material material) {
+        if (!READERS.containsKey(material)) {
+            return null;
+        }
+        return READERS.get(material);
+    }
+
+    public static DyeColor getColor(String color) {
+        if (color == null) {
+            return null;
+        }
+        try {
+            return DyeColor.valueOf(color.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    static {
+        READERS.put(Material.WOOL, new WoolStateDataReader());
+    }
+}

--- a/src/main/java/net/glowstone/block/state/StateSerialization.java
+++ b/src/main/java/net/glowstone/block/state/StateSerialization.java
@@ -13,7 +13,7 @@ public class StateSerialization {
     private static final Map<Material, BlockStateReader> READERS = new HashMap<>();
 
     public static BlockStateData parse(Material material, String state) throws InvalidBlockStateException {
-        if (state == null || state.trim().isEmpty()) {
+        if (state == null || state.trim().isEmpty() || state.trim().equals("*")) {
             return new BlockStateData();
         }
         if (material == null || getReader(material) == null) {

--- a/src/main/java/net/glowstone/block/state/StateSerialization.java
+++ b/src/main/java/net/glowstone/block/state/StateSerialization.java
@@ -27,6 +27,9 @@ public class StateSerialization {
                 throw new InvalidBlockStateException(material, state);
             }
             String[] keyVal = section.split("=");
+            if (keyVal.length < 2) {
+                throw new InvalidBlockStateException(material, state);
+            }
             keyVal[0] = keyVal[0].trim().toLowerCase();
             keyVal[1] = keyVal[1].trim().toLowerCase();
             if (keyVal[0].isEmpty() || keyVal[1].isEmpty()) {

--- a/src/main/java/net/glowstone/block/state/StateSerialization.java
+++ b/src/main/java/net/glowstone/block/state/StateSerialization.java
@@ -16,7 +16,8 @@ public class StateSerialization {
         if (state == null || state.trim().isEmpty() || state.trim().equals("*")) {
             return new BlockStateData();
         }
-        if (material == null || getReader(material) == null) {
+        BlockStateReader reader = getReader(material);
+        if (material == null || reader == null) {
             throw new InvalidBlockStateException(material, state);
         }
         BlockStateData data = new BlockStateData();
@@ -29,6 +30,9 @@ public class StateSerialization {
             keyVal[0] = keyVal[0].trim().toLowerCase();
             keyVal[1] = keyVal[1].trim().toLowerCase();
             if (keyVal[0].isEmpty() || keyVal[1].isEmpty()) {
+                throw new InvalidBlockStateException(material, state);
+            }
+            if (!reader.getValidStates().contains(keyVal[0])) {
                 throw new InvalidBlockStateException(material, state);
             }
             data.put(keyVal[0], keyVal[1]);

--- a/src/main/java/net/glowstone/block/state/StateSerialization.java
+++ b/src/main/java/net/glowstone/block/state/StateSerialization.java
@@ -40,6 +40,9 @@ public class StateSerialization {
         if (state == null || data == null || data.getItemType() != type) {
             return false;
         }
+        if (state.isEmpty()) {
+            return true;
+        }
         BlockStateReader reader = getReader(type);
         if (reader == null) return false;
         return reader.matches(state, data);

--- a/src/main/java/net/glowstone/block/state/impl/WoolStateDataReader.java
+++ b/src/main/java/net/glowstone/block/state/impl/WoolStateDataReader.java
@@ -1,5 +1,6 @@
 package net.glowstone.block.state.impl;
 
+import com.google.common.collect.Sets;
 import net.glowstone.block.state.BlockStateData;
 import net.glowstone.block.state.BlockStateReader;
 import net.glowstone.block.state.InvalidBlockStateException;
@@ -8,7 +9,16 @@ import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.material.Wool;
 
+import java.util.Set;
+
 public class WoolStateDataReader extends BlockStateReader<Wool> {
+
+    private static final Set<String> VALID_STATES = Sets.newHashSet("color");
+
+    @Override
+    public Set<String> getValidStates() {
+        return VALID_STATES;
+    }
 
     @Override
     public Wool read(Material material, BlockStateData data) throws InvalidBlockStateException {

--- a/src/main/java/net/glowstone/block/state/impl/WoolStateDataReader.java
+++ b/src/main/java/net/glowstone/block/state/impl/WoolStateDataReader.java
@@ -1,0 +1,37 @@
+package net.glowstone.block.state.impl;
+
+import net.glowstone.block.state.BlockStateData;
+import net.glowstone.block.state.BlockStateReader;
+import net.glowstone.block.state.InvalidBlockStateException;
+import net.glowstone.block.state.StateSerialization;
+import org.bukkit.DyeColor;
+import org.bukkit.Material;
+import org.bukkit.material.Wool;
+
+public class WoolStateDataReader extends BlockStateReader<Wool> {
+
+    @Override
+    public Wool read(Material material, BlockStateData data) throws InvalidBlockStateException {
+        Wool wool = new Wool();
+        if (data.containsKey("color")) {
+            DyeColor color = StateSerialization.getColor(data.get("wool"));
+            if (color == null) {
+                return null;
+            }
+            wool.setColor(color);
+        }
+        return wool;
+    }
+
+    @Override
+    public boolean matches(BlockStateData state, Wool data) throws InvalidBlockStateException {
+        if (state.containsKey("color")) {
+            DyeColor color = StateSerialization.getColor(state.get("wool"));
+            if (color == null) {
+                throw new InvalidBlockStateException(data.getItemType(), state);
+            }
+            return data.getColor() == color;
+        }
+        return true;
+    }
+}

--- a/src/main/java/net/glowstone/block/state/impl/WoolStateDataReader.java
+++ b/src/main/java/net/glowstone/block/state/impl/WoolStateDataReader.java
@@ -16,9 +16,11 @@ public class WoolStateDataReader extends BlockStateReader<Wool> {
         if (data.containsKey("color")) {
             DyeColor color = StateSerialization.getColor(data.get("color"));
             if (color == null) {
-                return null;
+                throw new InvalidBlockStateException(material, data);
             }
             wool.setColor(color);
+        } else {
+            wool.setColor(DyeColor.WHITE);
         }
         return wool;
     }

--- a/src/main/java/net/glowstone/block/state/impl/WoolStateDataReader.java
+++ b/src/main/java/net/glowstone/block/state/impl/WoolStateDataReader.java
@@ -14,7 +14,7 @@ public class WoolStateDataReader extends BlockStateReader<Wool> {
     public Wool read(Material material, BlockStateData data) throws InvalidBlockStateException {
         Wool wool = new Wool();
         if (data.containsKey("color")) {
-            DyeColor color = StateSerialization.getColor(data.get("wool"));
+            DyeColor color = StateSerialization.getColor(data.get("color"));
             if (color == null) {
                 return null;
             }
@@ -26,7 +26,7 @@ public class WoolStateDataReader extends BlockStateReader<Wool> {
     @Override
     public boolean matches(BlockStateData state, Wool data) throws InvalidBlockStateException {
         if (state.containsKey("color")) {
-            DyeColor color = StateSerialization.getColor(state.get("wool"));
+            DyeColor color = StateSerialization.getColor(state.get("color"));
             if (color == null) {
                 throw new InvalidBlockStateException(data.getItemType(), state);
             }

--- a/src/main/java/net/glowstone/block/state/impl/WoolStateDataReader.java
+++ b/src/main/java/net/glowstone/block/state/impl/WoolStateDataReader.java
@@ -23,7 +23,7 @@ public class WoolStateDataReader extends BlockStateReader<Wool> {
     @Override
     public Wool read(Material material, BlockStateData data) throws InvalidBlockStateException {
         Wool wool = new Wool();
-        if (data.containsKey("color")) {
+        if (data.contains("color")) {
             DyeColor color = StateSerialization.getColor(data.get("color"));
             if (color == null) {
                 throw new InvalidBlockStateException(material, data);
@@ -37,7 +37,7 @@ public class WoolStateDataReader extends BlockStateReader<Wool> {
 
     @Override
     public boolean matches(BlockStateData state, Wool data) throws InvalidBlockStateException {
-        if (state.containsKey("color")) {
+        if (state.contains("color")) {
             DyeColor color = StateSerialization.getColor(state.get("color"));
             if (color == null) {
                 throw new InvalidBlockStateException(data.getItemType(), state);

--- a/src/main/java/net/glowstone/command/CommandUtils.java
+++ b/src/main/java/net/glowstone/command/CommandUtils.java
@@ -31,26 +31,26 @@ public class CommandUtils {
         if (xRelative.startsWith("~")) {
             double diff = 0;
             if (xRelative.length() > 1)
-                diff = getDouble(xRelative.substring(1));
+                diff = getDouble(xRelative.substring(1), true);
             x = location.getX() + diff;
         } else {
-            x = getDouble(xRelative);
+            x = getDouble(xRelative, true);
         }
         if (yRelative.startsWith("~")) {
             double diff = 0;
             if (yRelative.length() > 1)
-                diff = getDouble(yRelative.substring(1));
+                diff = getDouble(yRelative.substring(1), false);
             y = location.getY() + diff;
         } else {
-            y = getDouble(yRelative);
+            y = getDouble(yRelative, false);
         }
         if (zRelative.startsWith("~")) {
             double diff = 0;
             if (zRelative.length() > 1)
-                diff = getDouble(zRelative.substring(1));
+                diff = getDouble(zRelative.substring(1), true);
             z = location.getZ() + diff;
         } else {
-            z = getDouble(zRelative);
+            z = getDouble(zRelative, true);
         }
         return new Location(location.getWorld(), x, y, z);
     }
@@ -85,9 +85,9 @@ public class CommandUtils {
         return new Location(location.getWorld(), location.getX(), location.getY(), location.getZ(), yaw, pitch);
     }
 
-    private static double getDouble(String d) {
+    private static double getDouble(String d, boolean shift) {
         boolean literal = d.split("\\.").length != 1;
-        if (!literal)
+        if (shift && !literal)
             d += ".5";
         return Double.valueOf(d);
     }

--- a/src/main/java/net/glowstone/command/CommandUtils.java
+++ b/src/main/java/net/glowstone/command/CommandUtils.java
@@ -1,7 +1,13 @@
 package net.glowstone.command;
 
 import net.glowstone.GlowWorld;
+import net.glowstone.block.GlowBlock;
+import net.glowstone.block.state.BlockStateData;
+import net.glowstone.block.state.InvalidBlockStateException;
+import net.glowstone.block.state.StateSerialization;
+import org.apache.commons.lang.math.NumberUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.BlockCommandSender;
 import org.bukkit.command.CommandSender;
@@ -90,6 +96,22 @@ public class CommandUtils {
         if (shift && !literal)
             d += ".5";
         return Double.valueOf(d);
+    }
+
+    public static BlockStateData readState(CommandSender sender, GlowBlock block, String state) {
+        if (isNumeric(state)) {
+            return new BlockStateData(Integer.parseInt(state));
+        }
+        try {
+            return StateSerialization.parse(block.getType(), state);
+        } catch (InvalidBlockStateException e) {
+            sender.sendMessage(ChatColor.RED + e.getMessage());
+            return null;
+        }
+    }
+
+    public static boolean isNumeric(String argument) {
+        return NumberUtils.isNumber(argument);
     }
 
     public static String prettyPrint(Entity[] entities) {

--- a/src/main/java/net/glowstone/command/minecraft/TestForBlockCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/TestForBlockCommand.java
@@ -1,0 +1,82 @@
+package net.glowstone.command.minecraft;
+
+import net.glowstone.block.state.BlockStateData;
+import net.glowstone.block.state.InvalidBlockStateException;
+import net.glowstone.block.state.StateSerialization;
+import net.glowstone.command.CommandUtils;
+import net.glowstone.constants.ItemIds;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.defaults.VanillaCommand;
+
+import java.util.Collections;
+
+public class TestForBlockCommand extends VanillaCommand {
+    public TestForBlockCommand() {
+        super("testforblock",
+                "Tests for a certain block at a given location",
+                "/testforblock <x> <y> <z> <block> [dataValue|state] [dataTag]",
+                Collections.emptyList());
+        setPermission("minecraft.command.testforblock");
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String label, String[] args) {
+        if (!testPermission(sender)) {
+            return false;
+        }
+        if (args.length < 4) {
+            sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
+            return false;
+        }
+        String itemName = args[3];
+        if (!itemName.startsWith("minecraft:")) {
+            itemName = "minecraft:" + itemName;
+        }
+        Material type = ItemIds.getItem(itemName);
+        Location location = CommandUtils.getLocation(CommandUtils.getLocation(sender), args[0], args[1], args[2]);
+        Block block = location.getBlock();
+        if (block.getType() != type) {
+            sender.sendMessage(ChatColor.RED + "The block at " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() +
+                    " is " + ItemIds.getName(block.getType()) + " (expected: " + ItemIds.getName(type) + ")");
+            return false;
+        }
+        if (args.length > 4) {
+            String state = args[4];
+            try {
+                int data = Integer.valueOf(state);
+                if (data != -1 && block.getData() != data) {
+                    sender.sendMessage(ChatColor.RED + "The block at " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() +
+                            " had the data value of " + block.getData() + " (expected: " + data + ")");
+                    return false;
+                }
+            } catch (NumberFormatException numberEx) {
+                // It's not a data value
+                try {
+                    BlockStateData data = StateSerialization.parse(block.getType(), state);
+                    boolean matches = StateSerialization.matches(block.getType(), block.getState().getData(), data);
+                    if (!matches) {
+                        // TODO: Print the actual state of the block
+                        sender.sendMessage(ChatColor.RED + "The block at " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() +
+                                " did not match the expected state of " + state);
+                        return false;
+                    }
+                } catch (InvalidBlockStateException e) {
+                    sender.sendMessage(ChatColor.RED + e.getMessage());
+                    return false;
+                }
+            }
+        }
+        // TODO: Data Tag
+        // All is well
+        sendSuccess(sender, location);
+        return true;
+    }
+
+    private void sendSuccess(CommandSender sender, Location location) {
+        sender.sendMessage("Successfully found the block at " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ());
+    }
+}

--- a/src/main/java/net/glowstone/command/minecraft/TestForBlockCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/TestForBlockCommand.java
@@ -53,17 +53,16 @@ public class TestForBlockCommand extends VanillaCommand {
         }
         if (args.length > 4) {
             String state = args[4];
-            try {
-                int data = Integer.valueOf(state);
-                if (data != -1 && block.getData() != data) {
-                    sender.sendMessage(ChatColor.RED + "The block at " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() +
-                            " had the data value of " + block.getData() + " (expected: " + data + ")");
-                    return false;
-                }
-            } catch (NumberFormatException numberEx) {
-                // It's not a data value
+            BlockStateData data = CommandUtils.readState(sender, block, state);
+            if (data == null) {
+                return false;
+            }
+            if (data.isNumeric() && block.getData() != data.getNumericValue()) {
+                sender.sendMessage(ChatColor.RED + "The block at " + location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ() +
+                        " had the data value of " + block.getData() + " (expected: " + data + ")");
+                return false;
+            } else if (!data.isNumeric()) {
                 try {
-                    BlockStateData data = StateSerialization.parse(block.getType(), state);
                     boolean matches = StateSerialization.matches(block.getType(), block.getState().getData(), data);
                     if (!matches) {
                         // TODO: Print the actual state of the block

--- a/src/main/java/net/glowstone/dispenser/EmptyBucketDispenseBehavior.java
+++ b/src/main/java/net/glowstone/dispenser/EmptyBucketDispenseBehavior.java
@@ -5,7 +5,7 @@ import net.glowstone.block.ItemTable;
 import net.glowstone.block.blocktype.BlockDispenser;
 import net.glowstone.block.blocktype.BlockLiquid;
 import net.glowstone.block.blocktype.BlockType;
-import net.glowstone.block.state.GlowDispenser;
+import net.glowstone.block.entity.state.GlowDispenser;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 

--- a/src/main/java/net/glowstone/inventory/GlowChestInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowChestInventory.java
@@ -1,6 +1,6 @@
 package net.glowstone.inventory;
 
-import net.glowstone.block.state.GlowChest;
+import net.glowstone.block.entity.state.GlowChest;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryType;
 

--- a/src/main/java/net/glowstone/inventory/GlowDoubleChestInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowDoubleChestInventory.java
@@ -1,7 +1,7 @@
 package net.glowstone.inventory;
 
 import com.google.common.collect.ImmutableList;
-import net.glowstone.block.state.GlowChest;
+import net.glowstone.block.entity.state.GlowChest;
 import org.bukkit.block.DoubleChest;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.inventory.InventoryType;

--- a/src/test/java/net/glowstone/command/minecraft/PlaySoundCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/PlaySoundCommandTest.java
@@ -53,7 +53,7 @@ public class PlaySoundCommandTest {
         fakePlayer2 = PowerMockito.mock(GlowPlayer.class);
         fakePlayer3 = PowerMockito.mock(GlowPlayer.class);
 
-        final Location location = new Location(world, 10.5, 20.5, 30.5);
+        final Location location = new Location(world, 10.5, 20.0, 30.5);
         Mockito.when(fakePlayer1.getName()).thenReturn("player1");
         Mockito.when(fakePlayer2.getName()).thenReturn("player2");
         Mockito.when(fakePlayer3.getName()).thenReturn("thePlayer3");
@@ -153,53 +153,53 @@ public class PlaySoundCommandTest {
     @Test
     public void testExecuteSucceedsWithoutMinecraftPrefix() {
         assertThat(command.execute(opSender, "label", new String[]{"entity.parrot.imitate.wither", "master", "player1"}), is(true));
-        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 10.5, 20.5, 30.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 1, 1);
+        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 10.5, 20.0, 30.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 1, 1);
     }
 
     @Test
     public void testExecuteSucceedsOnAnotherPlayerWithCurrentLocation() {
         assertThat(command.execute(opSender, "label", new String[]{"minecraft:entity.parrot.imitate.wither", "master", "player1"}), is(true));
-        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 10.5, 20.5, 30.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 1, 1);
+        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 10.5, 20.0, 30.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 1, 1);
     }
 
     @Test
     public void testExecuteSucceedsOnAllPlayersWithCurrentLocation() {
         assertThat(command.execute(opPlayer, "label", new String[]{"minecraft:entity.parrot.imitate.wither", "master", "@a"}), is(true));
-        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 10.5, 20.5, 30.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 1, 1);
-        Mockito.verify(Bukkit.getPlayerExact("player2")).playSound(new Location(world, 10.5, 20.5, 30.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 1, 1);
-        Mockito.verify(Bukkit.getPlayerExact("thePlayer3")).playSound(new Location(world, 10.5, 20.5, 30.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 1, 1);
+        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 10.5, 20.0, 30.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 1, 1);
+        Mockito.verify(Bukkit.getPlayerExact("player2")).playSound(new Location(world, 10.5, 20.0, 30.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 1, 1);
+        Mockito.verify(Bukkit.getPlayerExact("thePlayer3")).playSound(new Location(world, 10.5, 20.0, 30.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 1, 1);
     }
 
     @Test
     public void testExecuteSucceedsOnAnotherPlayerWithSpecificLocation() {
         assertThat(command.execute(opSender, "label", new String[]{"minecraft:entity.parrot.imitate.wither", "master", "player1", "0", "0", "0", "200"}), is(true));
-        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 0.5, 0.5, 0.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, 1);
+        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 0.5, 0.0, 0.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, 1);
     }
 
     @Test
     public void testExecuteSucceedsOnAllPlayersWithSpecificLocation() {
         assertThat(command.execute(opPlayer, "label", new String[]{"minecraft:entity.parrot.imitate.wither", "master", "@a", "0", "0", "0", "200"}), is(true));
-        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 0.5, 0.5, 0.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, 1);
-        Mockito.verify(Bukkit.getPlayerExact("player2")).playSound(new Location(world, 0.5, 0.5, 0.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, 1);
-        Mockito.verify(Bukkit.getPlayerExact("thePlayer3")).playSound(new Location(world, 0.5, 0.5, 0.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, 1);
+        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 0.5, 0.0, 0.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, 1);
+        Mockito.verify(Bukkit.getPlayerExact("player2")).playSound(new Location(world, 0.5, 0.0, 0.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, 1);
+        Mockito.verify(Bukkit.getPlayerExact("thePlayer3")).playSound(new Location(world, 0.5, 0.0, 0.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, 1);
     }
 
     @Test
     public void testExecuteSucceedsOnAnotherPlayerWithRelativeLocation() {
         assertThat(command.execute(opSender, "label", new String[]{"minecraft:entity.parrot.imitate.wither", "master", "player1", "~20", "~20", "~5", "200"}), is(true));
-        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 31, 41, 36), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, 1);
+        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 31, 40.0, 36), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, 1);
     }
 
     @Test
     public void testExecuteSucceedsOnAnotherPlayerWithSmallPitch() {
         assertThat(command.execute(opSender, "label", new String[]{"minecraft:entity.parrot.imitate.wither", "master", "player1", "0", "0", "0", "200", "0.05"}), is(true));
-        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 0.5, 0.5, 0.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, (float) 0.5);
+        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 0.5, 0.0, 0.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, (float) 0.5);
     }
 
     @Test
     public void testExecuteSucceedsOnAnotherPlayerWithSpecificPitch() {
         assertThat(command.execute(opSender, "label", new String[]{"minecraft:entity.parrot.imitate.wither", "master", "player1", "0", "0", "0", "200", "0.6"}), is(true));
-        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 0.5, 0.5, 0.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, (float) 0.6);
+        Mockito.verify(Bukkit.getPlayerExact("player1")).playSound(new Location(world, 0.5, 0.0, 0.5), Sound.ENTITY_PARROT_IMITATE_WITHER, SoundCategory.MASTER, 200, (float) 0.6);
     }
 
     @Test

--- a/src/test/java/net/glowstone/command/minecraft/SetWorldSpawnCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SetWorldSpawnCommandTest.java
@@ -46,7 +46,7 @@ public class SetWorldSpawnCommandTest {
 
         Mockito.when(opPlayer.hasPermission(Mockito.anyString())).thenReturn(true);
         Mockito.when(opPlayer.getName()).thenReturn("ChuckNorris");
-        Mockito.when(((Entity)opPlayer).getLocation()).thenReturn(new Location(world, 10.5, 20.5, 30.5));
+        Mockito.when(((Entity)opPlayer).getLocation()).thenReturn(new Location(world, 10.5, 20.0, 30.5));
 
         Mockito.when(world.getMaxHeight()).thenReturn(50);
 
@@ -100,7 +100,7 @@ public class SetWorldSpawnCommandTest {
     public void testExecuteFailsWithYCoordinatesTooSmall() {
         assertThat(command.execute(opSender, "label", new String[]{"2", "-10000", "4"}), is(false));
         // -10001 because of the floor, it's not supposed to be negative
-        Mockito.verify(opSender).sendMessage(eq(ChatColor.RED + "The y coordinate (-10001) is too small, it must be at least 0."));
+        Mockito.verify(opSender).sendMessage(eq(ChatColor.RED + "The y coordinate (-10000) is too small, it must be at least 0."));
     }
 
     @Test
@@ -118,7 +118,7 @@ public class SetWorldSpawnCommandTest {
     @Test
     public void testExecuteSucceedsWithRelativeLocation() {
         assertThat(command.execute(opPlayer, "label", new String[]{"30", "~20", "10"}), is(true));
-        Mockito.verify(world).setSpawnLocation(30, 41, 10);
+        Mockito.verify(world).setSpawnLocation(30, 40, 10);
     }
 
     @Test

--- a/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
@@ -55,7 +55,7 @@ public class SpawnPointCommandTest {
         world = PowerMockito.mock(GlowWorld.class);
         command = new SpawnPointCommand();
 
-        final Location location = new Location(world, 10.5, 20.5, 30.5);
+        final Location location = new Location(world, 10.5, 20.0, 30.5);
         Mockito.when(fakePlayer1.getName()).thenReturn("player1");
         Mockito.when(fakePlayer2.getName()).thenReturn("player2");
         Mockito.when(fakePlayer3.getName()).thenReturn("thePlayer3");
@@ -132,55 +132,55 @@ public class SpawnPointCommandTest {
     @Test
     public void testExecuteFailsWithYCoordinatesTooHigh() {
         assertThat(command.execute(opSender, "label", new String[]{"player1", "2", "10000", "4"}), is(false));
-        Mockito.verify(opSender).sendMessage(eq(ChatColor.RED + "'10000.5' is too high for the current world. Max value is '50'."));
+        Mockito.verify(opSender).sendMessage(eq(ChatColor.RED + "'10000.0' is too high for the current world. Max value is '50'."));
     }
 
     @Test
     public void testExecuteFailsWithYCoordinatesTooSmall() {
         assertThat(command.execute(opSender, "label", new String[]{"player1", "2", "-10000", "4"}), is(false));
-        Mockito.verify(opSender).sendMessage(eq(ChatColor.RED + "The y coordinate (-10000.5) is too small, it must be at least 0."));
+        Mockito.verify(opSender).sendMessage(eq(ChatColor.RED + "The y coordinate (-10000.0) is too small, it must be at least 0."));
     }
 
     @Test
     public void testExecuteSucceedsWithCurrentLocation() {
         assertThat(command.execute(opPlayer, "label", new String[0]), is(true));
-        Mockito.verify((Player) opPlayer).setBedSpawnLocation(new Location(world, 10.5, 20.5, 30.5), true);
+        Mockito.verify((Player) opPlayer).setBedSpawnLocation(new Location(world, 10.5, 20.0, 30.5), true);
     }
 
     @Test
     public void testExecuteSucceedsOnAnotherPlayerWithCurrentLocation() {
         assertThat(command.execute(opPlayer, "label", new String[]{"player1"}), is(true));
-        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 10.5, 20.5, 30.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 10.5, 20.0, 30.5), true);
     }
 
     @Test
     public void testExecuteSucceedsOnAnotherPlayerWithSpecificLocation() {
         assertThat(command.execute(opPlayer, "label", new String[]{"player1", "30", "20", "10"}), is(true));
-        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 30.5, 20.5, 10.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 30.5, 20.0, 10.5), true);
     }
 
     @Test
     public void testExecuteSucceedsAllPlayersWithCurrentLocation() {
         assertThat(command.execute(opPlayer, "label", new String[]{"@a"}), is(true));
-        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 10.5, 20.5, 30.5), true);
-        Mockito.verify(Bukkit.getPlayerExact("player2")).setBedSpawnLocation(new Location(world, 10.5, 20.5, 30.5), true);
-        Mockito.verify(Bukkit.getPlayerExact("thePlayer3")).setBedSpawnLocation(new Location(world, 10.5, 20.5, 30.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 10.5, 20.0, 30.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("player2")).setBedSpawnLocation(new Location(world, 10.5, 20.0, 30.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("thePlayer3")).setBedSpawnLocation(new Location(world, 10.5, 20.0, 30.5), true);
     }
 
     @Test
     public void testExecuteSucceedsAllPlayersWithSpecificLocation() {
         assertThat(command.execute(opPlayer, "label", new String[]{"@a", "30", "20", "10"}), is(true));
-        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 30.5, 20.5, 10.5), true);
-        Mockito.verify(Bukkit.getPlayerExact("player2")).setBedSpawnLocation(new Location(world, 30.5, 20.5, 10.5), true);
-        Mockito.verify(Bukkit.getPlayerExact("thePlayer3")).setBedSpawnLocation(new Location(world, 30.5, 20.5, 10.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 30.5, 20.0, 10.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("player2")).setBedSpawnLocation(new Location(world, 30.5, 20.0, 10.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("thePlayer3")).setBedSpawnLocation(new Location(world, 30.5, 20.0, 10.5), true);
     }
 
     @Test
     public void testExecuteSucceedsAllPlayersWithRelativeLocation() {
         assertThat(command.execute(opPlayer, "label", new String[]{"@a", "30", "~20", "10"}), is(true));
-        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 30.5, 41, 10.5), true);
-        Mockito.verify(Bukkit.getPlayerExact("player2")).setBedSpawnLocation(new Location(world, 30.5, 41, 10.5), true);
-        Mockito.verify(Bukkit.getPlayerExact("thePlayer3")).setBedSpawnLocation(new Location(world, 30.5, 41, 10.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("player1")).setBedSpawnLocation(new Location(world, 30.5, 40.0, 10.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("player2")).setBedSpawnLocation(new Location(world, 30.5, 40.0, 10.5), true);
+        Mockito.verify(Bukkit.getPlayerExact("thePlayer3")).setBedSpawnLocation(new Location(world, 30.5, 40.0, 10.5), true);
     }
 
     @Test


### PR DESCRIPTION
This PR adds the system to parse and compare block state data as strings instead of numerical data values. This feature was added to some commands in 1.11, and allows using `color=orange` instead of the data value `1` for wool blocks, for example.

- Implements a parsing system to read such block state strings and compare them
  - Currently only supports Wool block state as proof-of-concept, needs to be expanded to [other blocks](https://minecraft.gamepedia.com/Block_states).
- Implements the `/testforblock` command, which uses this new functionality.
  - Sample usage: `/testforblock ~ ~-1 ~ minecraft:wool color=light_blue`
- Fixed an inconsistency with tilde notation (e.g. `~ ~-1 ~`), where the relative Y value would be shifted by 0.5 blocks like the X and Z axis. Some tests needed to be fixed to pass with this correction.
- Moved the block entity states inside the `net.glowstone.block.entity.state` package to avoid confusion.

I still need to add some documentation for the block state parsing system.

Related to #499 