### PR TITLE
Use ThreadLocalRandom

### DIFF
--- a/src/main/java/net/glowstone/Explosion.java
+++ b/src/main/java/net/glowstone/Explosion.java
@@ -1,12 +1,5 @@
 package net.glowstone;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
-import java.util.stream.Collectors;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.blocktype.BlockTNT;
 import net.glowstone.entity.GlowEntity;
@@ -32,6 +25,10 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.BlockVector;
 import org.bukkit.util.Vector;
 
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
 public final class Explosion {
 
     public static final int POWER_TNT = 4;
@@ -42,7 +39,6 @@ public final class Explosion {
     public static final int POWER_WITHER_SKULL = 1;
     public static final int POWER_WITHER_CREATION = 7;
     public static final int POWER_ENDER_CRYSTAL = 6;
-    private static final Random random = new Random();
     public static final int EXPLOSION_VISIBILITY_RADIUS = 64;
     private static final List<Vector> RAY_DIRECTIONS = new ArrayList<>();
 
@@ -196,7 +192,7 @@ public final class Explosion {
     }
 
     private float calculateStartPower() {
-        float rand = random.nextFloat();
+        float rand = ThreadLocalRandom.current().nextFloat();
         rand *= 0.6F; // (max - 0.7)
         rand += 0.7; // min
         return rand * power;
@@ -213,7 +209,7 @@ public final class Explosion {
     }
 
     private void setBlockOnFire(GlowBlock block) {
-        if (random.nextInt(3) != 0) {
+        if (ThreadLocalRandom.current().nextInt(3) != 0) {
             return;
         }
         Block below = block.getRelative(BlockFace.DOWN);
@@ -327,7 +323,7 @@ public final class Explosion {
     ///////////////////////////////////////
     // Visualize
     private void playOutSoundAndParticles() {
-        world.playSound(location, Sound.ENTITY_GENERIC_EXPLODE, 4, (1.0F + (random.nextFloat() - random.nextFloat()) * 0.2F) * 0.7F);
+        world.playSound(location, Sound.ENTITY_GENERIC_EXPLODE, 4, (1.0F + (ThreadLocalRandom.current().nextFloat() - ThreadLocalRandom.current().nextFloat()) * 0.2F) * 0.7F);
 
         if (power >= 2.0F && breakBlocks) {
             // send huge explosion

--- a/src/main/java/net/glowstone/block/GlowBlock.java
+++ b/src/main/java/net/glowstone/block/GlowBlock.java
@@ -27,6 +27,7 @@ import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.Plugin;
 
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Represents a single block in a world.
@@ -453,14 +454,12 @@ public final class GlowBlock implements Block {
     }
 
     public boolean breakNaturally(float yield, Collection<ItemStack> drops) {
-        Random r = new Random();
-
         if (getType() == Material.AIR) {
             return false;
         }
 
         Location location = getLocation();
-        drops.stream().filter(stack -> r.nextFloat() < yield).forEach(stack -> getWorld().dropItemNaturally(location, stack));
+        drops.stream().filter(stack -> ThreadLocalRandom.current().nextFloat() < yield).forEach(stack -> getWorld().dropItemNaturally(location, stack));
 
         setType(Material.AIR);
         return true;

--- a/src/main/java/net/glowstone/block/blocktype/BlockCarrot.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCarrot.java
@@ -8,13 +8,14 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockCarrot extends BlockCrops {
 
     @Override
     public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {
         if (block.getData() >= CropState.RIPE.ordinal()) {
-            return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.CARROT_ITEM, random.nextInt(4) + 1)));
+            return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.CARROT_ITEM, ThreadLocalRandom.current().nextInt(4) + 1)));
         } else {
             return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.CARROT_ITEM, 1)));
         }

--- a/src/main/java/net/glowstone/block/blocktype/BlockCocoa.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCocoa.java
@@ -18,6 +18,7 @@ import org.bukkit.util.Vector;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockCocoa extends BlockNeedsAttached implements IBlockGrowable {
 
@@ -126,7 +127,7 @@ public class BlockCocoa extends BlockNeedsAttached implements IBlockGrowable {
         if (data instanceof CocoaPlant) {
             CocoaPlant cocoa = (CocoaPlant) data;
             CocoaPlantSize size = cocoa.getSize();
-            if (size != CocoaPlantSize.LARGE && random.nextInt(5) == 0) {
+            if (size != CocoaPlantSize.LARGE && ThreadLocalRandom.current().nextInt(5) == 0) {
                 if (size == CocoaPlantSize.SMALL) {
                     cocoa.setSize(CocoaPlantSize.MEDIUM);
                 } else if (size == CocoaPlantSize.MEDIUM) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockCrops.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCrops.java
@@ -13,6 +13,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockCrops extends BlockNeedsAttached implements IBlockGrowable {
 
@@ -24,7 +25,7 @@ public class BlockCrops extends BlockNeedsAttached implements IBlockGrowable {
     @Override
     public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {
         if (block.getData() >= CropState.RIPE.ordinal()) {
-            return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.SEEDS, random.nextInt(4)),
+            return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.SEEDS, ThreadLocalRandom.current().nextInt(4)),
                     new ItemStack(Material.WHEAT, 1)));
         } else {
             return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.SEEDS, 1)));
@@ -45,7 +46,7 @@ public class BlockCrops extends BlockNeedsAttached implements IBlockGrowable {
     public void grow(GlowPlayer player, GlowBlock block) {
         GlowBlockState state = block.getState();
         int cropState = block.getData()
-                + random.nextInt(CropState.MEDIUM.ordinal())
+                + ThreadLocalRandom.current().nextInt(CropState.MEDIUM.ordinal())
                 + CropState.VERY_SMALL.ordinal();
         if (cropState > CropState.RIPE.ordinal()) {
             cropState = CropState.RIPE.ordinal();
@@ -70,7 +71,7 @@ public class BlockCrops extends BlockNeedsAttached implements IBlockGrowable {
         // we check light level on the above block, meaning crops needs at least one free block above it
         // in order to grow naturally (vanilla behavior)
         if (cropState < CropState.RIPE.ordinal() && block.getRelative(BlockFace.UP).getLightLevel() >= 9 &&
-                random.nextInt((int) (25.0F / getGrowthRateModifier(block)) + 1) == 0) {
+                ThreadLocalRandom.current().nextInt((int) (25.0F / getGrowthRateModifier(block)) + 1) == 0) {
             cropState++;
             if (cropState > CropState.RIPE.ordinal()) {
                 cropState = CropState.RIPE.ordinal();

--- a/src/main/java/net/glowstone/block/blocktype/BlockFire.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockFire.java
@@ -19,6 +19,7 @@ import org.bukkit.util.Vector;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map.Entry;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockFire extends BlockNeedsAttached {
 
@@ -103,7 +104,7 @@ public class BlockFire extends BlockNeedsAttached {
         int age = state.getRawData();
         if (age < MAX_FIRE_AGE) {
             // increase fire age
-            state.setRawData((byte) (age + random.nextInt(3) / 2));
+            state.setRawData((byte) (age + ThreadLocalRandom.current().nextInt(3) / 2));
             state.update(true);
         }
 
@@ -114,7 +115,7 @@ public class BlockFire extends BlockNeedsAttached {
                     block.breakNaturally();
                     world.cancelPulse(block);
                 }
-            } else if (age == MAX_FIRE_AGE && !block.getRelative(BlockFace.DOWN).isFlammable() && random.nextInt(4) == 0) {
+            } else if (age == MAX_FIRE_AGE && !block.getRelative(BlockFace.DOWN).isFlammable() && ThreadLocalRandom.current().nextInt(4) == 0) {
                 // if fire reached max age, bottom block is not flammable, 25% chance to stop fire
                 block.breakNaturally();
                 world.cancelPulse(block);
@@ -157,7 +158,7 @@ public class BlockFire extends BlockNeedsAttached {
                                         resistance /= 2;
                                     }
                                     if ((!world.hasStorm() || !isRainingAround(propagationBlock))
-                                            && resistance > 0 && random.nextInt(y > 1 ? 100 + 100 * (y - 1) : 100) <= resistance) {
+                                            && resistance > 0 && ThreadLocalRandom.current().nextInt(y > 1 ? 100 + 100 * (y - 1) : 100) <= resistance) {
                                         BlockIgniteEvent igniteEvent = new BlockIgniteEvent(propagationBlock, IgniteCause.SPREAD, block);
                                         EventFactory.callEvent(igniteEvent);
                                         if (!igniteEvent.isCancelled()) {
@@ -220,7 +221,7 @@ public class BlockFire extends BlockNeedsAttached {
     }
 
     private void burnBlock(GlowBlock block, int burnResistance, int fireAge) {
-        if (random.nextInt(burnResistance) < block.getMaterialValues().getFireResistance()) {
+        if (ThreadLocalRandom.current().nextInt(burnResistance) < block.getMaterialValues().getFireResistance()) {
             BlockBurnEvent burnEvent = new BlockBurnEvent(block);
             EventFactory.callEvent(burnEvent);
             if (!burnEvent.isCancelled()) {
@@ -228,7 +229,7 @@ public class BlockFire extends BlockNeedsAttached {
                     BlockTNT.igniteBlock(block, false);
                 } else {
                     GlowBlockState state = block.getState();
-                    if (random.nextInt(10 + fireAge) < 5 && !GlowBiomeClimate.isRainy(block)) {
+                    if (ThreadLocalRandom.current().nextInt(10 + fireAge) < 5 && !GlowBiomeClimate.isRainy(block)) {
                         int increasedAge = increaseFireAge(fireAge);
                         state.setType(Material.FIRE);
                         state.setRawData((byte) (increasedAge > MAX_FIRE_AGE ? MAX_FIRE_AGE : increasedAge));
@@ -243,7 +244,7 @@ public class BlockFire extends BlockNeedsAttached {
     }
 
     private int increaseFireAge(int age) {
-        return age + random.nextInt(5) / 4;
+        return age + ThreadLocalRandom.current().nextInt(5) / 4;
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/blocktype/BlockGrass.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockGrass.java
@@ -17,6 +17,8 @@ import org.bukkit.event.block.BlockSpreadEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.LongGrass;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 public class BlockGrass extends BlockType implements IBlockGrowable {
 
     public BlockGrass() {
@@ -51,12 +53,12 @@ public class BlockGrass extends BlockType implements IBlockGrowable {
                 if (block.getRelative(BlockFace.UP).getType() == Material.AIR) {
                     GlowBlock b = block.getRelative(BlockFace.UP);
                     GlowBlockState blockState = b.getState();
-                    if (random.nextFloat() < 0.125D) {
+                    if (ThreadLocalRandom.current().nextFloat() < 0.125D) {
                         // sometimes grow random flower
                         // would be better to call a method that choose a random
                         // flower depending on the biome
                         FlowerType[] flowers = FlowerForestPopulator.FLOWERS;
-                        Material flower = flowers[random.nextInt(flowers.length)].getType();
+                        Material flower = flowers[ThreadLocalRandom.current().nextInt(flowers.length)].getType();
                         if (ItemTable.instance().getBlock(flower).canPlaceAt(b, BlockFace.DOWN)) {
                             blockState.setType(flower);
                         }
@@ -77,9 +79,9 @@ public class BlockGrass extends BlockType implements IBlockGrowable {
                     int x = block.getX();
                     int y = block.getY();
                     int z = block.getZ();
-                    x += random.nextInt(3) - 1;
-                    y += random.nextInt(3) * random.nextInt(3) / 2;
-                    z += random.nextInt(3) - 1;
+                    x += ThreadLocalRandom.current().nextInt(3) - 1;
+                    y += ThreadLocalRandom.current().nextInt(3) * ThreadLocalRandom.current().nextInt(3) / 2;
+                    z += ThreadLocalRandom.current().nextInt(3) - 1;
                     if (world.getBlockAt(x, y, z).getType() == Material.GRASS) {
                         j++;
                         continue;
@@ -111,9 +113,9 @@ public class BlockGrass extends BlockType implements IBlockGrowable {
 
             // grass spread randomly around
             for (int i = 0; i < 4; i++) {
-                int x = sourceX + random.nextInt(3) - 1;
-                int z = sourceZ + random.nextInt(3) - 1;
-                int y = sourceY + random.nextInt(5) - 3;
+                int x = sourceX + ThreadLocalRandom.current().nextInt(3) - 1;
+                int z = sourceZ + ThreadLocalRandom.current().nextInt(3) - 1;
+                int y = sourceY + ThreadLocalRandom.current().nextInt(5) - 3;
 
                 GlowBlock targetBlock = world.getBlockAt(x, y, z);
                 GlowBlock targetAbove = targetBlock.getRelative(BlockFace.UP);

--- a/src/main/java/net/glowstone/block/blocktype/BlockGravel.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockGravel.java
@@ -7,6 +7,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockGravel extends BlockFalling {
 
@@ -16,7 +17,7 @@ public class BlockGravel extends BlockFalling {
 
     @Override
     public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {
-        return Collections.unmodifiableList(Arrays.asList(new ItemStack(random.nextInt(10) == 1 ? Material.FLINT : Material.GRAVEL, 1)));
+        return Collections.unmodifiableList(Arrays.asList(new ItemStack(ThreadLocalRandom.current().nextInt(10) == 1 ? Material.FLINT : Material.GRAVEL, 1)));
     }
 
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockHugeMushroom.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockHugeMushroom.java
@@ -7,6 +7,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockHugeMushroom extends BlockType {
     private final Material mushroomType;
@@ -27,7 +28,7 @@ public class BlockHugeMushroom extends BlockType {
 
     @Override
     public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {
-        int rnd = random.nextInt(100);
+        int rnd = ThreadLocalRandom.current().nextInt(100);
         if (rnd < 80) {
             return BlockDropless.EMPTY_STACK;
         } else {

--- a/src/main/java/net/glowstone/block/blocktype/BlockLava.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLava.java
@@ -8,6 +8,8 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.event.block.BlockIgniteEvent;
 import org.bukkit.event.block.BlockIgniteEvent.IgniteCause;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 public class BlockLava extends BlockLiquid {
 
     private static final BlockFace[] FLAMMABLE_FACES = {BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN};
@@ -28,10 +30,10 @@ public class BlockLava extends BlockLiquid {
         if (!block.getWorld().getGameRuleMap().getBoolean("doFireTick")) {
             return;
         }
-        int n = random.nextInt(3);
+        int n = ThreadLocalRandom.current().nextInt(3);
         if (n == 0) {
             for (int i = 0; i < 3; i++) {
-                GlowBlock b = (GlowBlock) block.getLocation().add(-1 + random.nextInt(3), 0, -1 + random.nextInt(3)).getBlock();
+                GlowBlock b = (GlowBlock) block.getLocation().add(-1 + ThreadLocalRandom.current().nextInt(3), 0, -1 + ThreadLocalRandom.current().nextInt(3)).getBlock();
                 GlowBlock bAbove = b.getRelative(BlockFace.UP);
                 if (bAbove.isEmpty() && b.isFlammable()) {
                     BlockIgniteEvent igniteEvent = new BlockIgniteEvent(bAbove, IgniteCause.LAVA, block);
@@ -45,7 +47,7 @@ public class BlockLava extends BlockLiquid {
             }
         } else {
             for (int i = 0; i < n; i++) {
-                GlowBlock b = (GlowBlock) block.getLocation().add(-1 + random.nextInt(3), 1, -1 + random.nextInt(3)).getBlock();
+                GlowBlock b = (GlowBlock) block.getLocation().add(-1 + ThreadLocalRandom.current().nextInt(3), 1, -1 + ThreadLocalRandom.current().nextInt(3)).getBlock();
                 if (b.isEmpty()) {
                     if (hasNearFlammableBlock(b)) {
                         BlockIgniteEvent igniteEvent = new BlockIgniteEvent(b, IgniteCause.LAVA, block);

--- a/src/main/java/net/glowstone/block/blocktype/BlockLeaves.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLeaves.java
@@ -12,6 +12,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockLeaves extends BlockType {
 
@@ -39,10 +40,10 @@ public class BlockLeaves extends BlockType {
 
         List<ItemStack> drops = new ArrayList<>();
 
-        if (random.nextFloat() < (block.getData() == 3 ? .025f : .05f)) { //jungle leaves drop with 2.5% chance, others drop with 5%
+        if (ThreadLocalRandom.current().nextFloat() < (block.getData() == 3 ? .025f : .05f)) { //jungle leaves drop with 2.5% chance, others drop with 5%
             drops.add(new ItemStack(Material.SAPLING, 1, (short) data));
         }
-        if (data == 0 && random.nextFloat() < .005) { //oak leaves have a .5% chance to drop an apple
+        if (data == 0 && ThreadLocalRandom.current().nextFloat() < .005) { //oak leaves have a .5% chance to drop an apple
             drops.add(new ItemStack(Material.APPLE));
         }
         return Collections.unmodifiableList(drops);

--- a/src/main/java/net/glowstone/block/blocktype/BlockMelon.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockMelon.java
@@ -7,11 +7,12 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockMelon extends BlockType {
 
     @Override
     public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {
-        return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.MELON, random.nextInt(5) + 3)));
+        return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.MELON, ThreadLocalRandom.current().nextInt(5) + 3)));
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockMushroom.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockMushroom.java
@@ -20,6 +20,7 @@ import org.bukkit.material.MaterialData;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockMushroom extends BlockNeedsAttached implements IBlockGrowable {
 
@@ -57,7 +58,7 @@ public class BlockMushroom extends BlockNeedsAttached implements IBlockGrowable 
 
     @Override
     public boolean canGrowWithChance(GlowBlock block) {
-        return random.nextFloat() < 0.4D;
+        return ThreadLocalRandom.current().nextFloat() < 0.4D;
     }
 
     @Override
@@ -72,7 +73,7 @@ public class BlockMushroom extends BlockNeedsAttached implements IBlockGrowable 
         }
         Location loc = block.getLocation();
         BlockStateDelegate blockStateDelegate = new BlockStateDelegate();
-        if (GlowTree.newInstance(type, random, loc, blockStateDelegate).generate()) {
+        if (GlowTree.newInstance(type, ThreadLocalRandom.current(), loc, blockStateDelegate).generate()) {
             List<BlockState> blockStates = new ArrayList<>(blockStateDelegate.getBlockStates());
             StructureGrowEvent growEvent = new StructureGrowEvent(loc, type, true, player, blockStates);
             EventFactory.callEvent(growEvent);
@@ -86,7 +87,7 @@ public class BlockMushroom extends BlockNeedsAttached implements IBlockGrowable 
 
     @Override
     public void updateBlock(GlowBlock block) {
-        if (random.nextInt(25) == 0) {
+        if (ThreadLocalRandom.current().nextInt(25) == 0) {
             GlowWorld world = block.getWorld();
             int x, y, z;
             int i = 0;
@@ -103,9 +104,9 @@ public class BlockMushroom extends BlockNeedsAttached implements IBlockGrowable 
             }
 
             int nX, nY, nZ;
-            nX = block.getX() + random.nextInt(3) - 1;
-            nY = block.getY() + random.nextInt(2) - random.nextInt(2);
-            nZ = block.getZ() + random.nextInt(3) - 1;
+            nX = block.getX() + ThreadLocalRandom.current().nextInt(3) - 1;
+            nY = block.getY() + ThreadLocalRandom.current().nextInt(2) - ThreadLocalRandom.current().nextInt(2);
+            nZ = block.getZ() + ThreadLocalRandom.current().nextInt(3) - 1;
 
             x = block.getX();
             y = block.getY();
@@ -117,9 +118,9 @@ public class BlockMushroom extends BlockNeedsAttached implements IBlockGrowable 
                     y = nY;
                     z = nZ;
                 }
-                nX = x + random.nextInt(3) - 1;
-                nY = y + random.nextInt(2) - random.nextInt(2);
-                nZ = z + random.nextInt(3) - 1;
+                nX = x + ThreadLocalRandom.current().nextInt(3) - 1;
+                nY = y + ThreadLocalRandom.current().nextInt(2) - ThreadLocalRandom.current().nextInt(2);
+                nZ = z + ThreadLocalRandom.current().nextInt(3) - 1;
             }
 
             if (world.getBlockAt(nX, nY, nZ).getType() == Material.AIR

--- a/src/main/java/net/glowstone/block/blocktype/BlockMycel.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockMycel.java
@@ -10,6 +10,8 @@ import org.bukkit.event.block.BlockFadeEvent;
 import org.bukkit.event.block.BlockSpreadEvent;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 public class BlockMycel extends BlockType {
 
     public BlockMycel() {
@@ -41,9 +43,9 @@ public class BlockMycel extends BlockType {
 
             // mycel spread randomly around
             for (int i = 0; i < 4; i++) {
-                int x = sourceX + random.nextInt(3) - 1;
-                int z = sourceZ + random.nextInt(3) - 1;
-                int y = sourceY + random.nextInt(5) - 3;
+                int x = sourceX + ThreadLocalRandom.current().nextInt(3) - 1;
+                int z = sourceZ + ThreadLocalRandom.current().nextInt(3) - 1;
+                int y = sourceY + ThreadLocalRandom.current().nextInt(5) - 3;
 
                 GlowBlock targetBlock = world.getBlockAt(x, y, z);
                 GlowBlock targetAbove = targetBlock.getRelative(BlockFace.UP);

--- a/src/main/java/net/glowstone/block/blocktype/BlockNetherWart.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockNetherWart.java
@@ -9,6 +9,8 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.event.block.BlockGrowEvent;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 public class BlockNetherWart extends BlockNeedsAttached {
 
     public BlockNetherWart() {
@@ -28,7 +30,7 @@ public class BlockNetherWart extends BlockNeedsAttached {
     @Override
     public void updateBlock(GlowBlock block) {
         int cropState = block.getData();
-        if (cropState < NetherWartsState.RIPE.ordinal() && random.nextInt(10) == 0) {
+        if (cropState < NetherWartsState.RIPE.ordinal() && ThreadLocalRandom.current().nextInt(10) == 0) {
             cropState++;
             GlowBlockState state = block.getState();
             state.setRawData((byte) cropState);

--- a/src/main/java/net/glowstone/block/blocktype/BlockPotato.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockPotato.java
@@ -8,17 +8,18 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockPotato extends BlockCrops {
 
     @Override
     public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {
         if (block.getData() >= CropState.RIPE.ordinal()) {
-            if (random.nextInt(100) < 2) {
-                return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.POTATO_ITEM, random.nextInt(4) + 1),
+            if (ThreadLocalRandom.current().nextInt(100) < 2) {
+                return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.POTATO_ITEM, ThreadLocalRandom.current().nextInt(4) + 1),
                         new ItemStack(Material.POISONOUS_POTATO, 1)));
             } else {
-                return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.POTATO_ITEM, random.nextInt(4) + 1)));
+                return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.POTATO_ITEM, ThreadLocalRandom.current().nextInt(4) + 1)));
             }
         } else {
             return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.POTATO_ITEM, 1)));

--- a/src/main/java/net/glowstone/block/blocktype/BlockRandomDrops.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRandomDrops.java
@@ -8,6 +8,7 @@ import org.bukkit.inventory.ItemStack;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockRandomDrops extends BlockNeedsTool {
     private final Material dropType;
@@ -38,7 +39,7 @@ public class BlockRandomDrops extends BlockNeedsTool {
 
     @Override
     public Collection<ItemStack> getMinedDrops(GlowBlock block) {
-        return Collections.unmodifiableList(Arrays.asList(new ItemStack(dropType, random.nextInt(maxDrops - minDrops + 1) + minDrops, data)));
+        return Collections.unmodifiableList(Arrays.asList(new ItemStack(dropType, ThreadLocalRandom.current().nextInt(maxDrops - minDrops + 1) + minDrops, data)));
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/blocktype/BlockSapling.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSapling.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockSapling extends BlockNeedsAttached implements IBlockGrowable {
 
@@ -43,7 +44,7 @@ public class BlockSapling extends BlockNeedsAttached implements IBlockGrowable {
 
     @Override
     public boolean canGrowWithChance(GlowBlock block) {
-        return random.nextFloat() < 0.45D;
+        return ThreadLocalRandom.current().nextFloat() < 0.45D;
     }
 
     @Override
@@ -58,7 +59,7 @@ public class BlockSapling extends BlockNeedsAttached implements IBlockGrowable {
 
         if (data == TreeSpecies.GENERIC.ordinal()) {
             // 1 chance on 10 to grow a big oak tree
-            if (random.nextInt(10) > 0) {
+            if (ThreadLocalRandom.current().nextInt(10) > 0) {
                 generateTree(TreeType.TREE, block, player);
             } else {
                 generateTree(TreeType.BIG_TREE, block, player);
@@ -109,7 +110,7 @@ public class BlockSapling extends BlockNeedsAttached implements IBlockGrowable {
         Location loc = block.getLocation();
         BlockStateDelegate blockStateDelegate = new BlockStateDelegate();
         boolean canGrow = false;
-        if (GlowTree.newInstance(type, random, loc, blockStateDelegate).generate()) {
+        if (GlowTree.newInstance(type, ThreadLocalRandom.current(), loc, blockStateDelegate).generate()) {
             List<BlockState> blockStates = new ArrayList<>(blockStateDelegate.getBlockStates());
             StructureGrowEvent growEvent =
                     new StructureGrowEvent(loc, type, player != null, player, blockStates);
@@ -172,7 +173,7 @@ public class BlockSapling extends BlockNeedsAttached implements IBlockGrowable {
 
     @Override
     public void updateBlock(GlowBlock block) {
-        if (block.getRelative(BlockFace.UP).getLightLevel() >= 9 && random.nextInt(7) == 0) {
+        if (block.getRelative(BlockFace.UP).getLightLevel() >= 9 && ThreadLocalRandom.current().nextInt(7) == 0) {
             int dataValue = block.getData();
             if ((dataValue & 8) == 0) {
                 block.setData((byte) (dataValue | 8));

--- a/src/main/java/net/glowstone/block/blocktype/BlockStem.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockStem.java
@@ -14,6 +14,7 @@ import org.bukkit.material.Pumpkin;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockStem extends BlockCrops {
     private Material fruitType;
@@ -37,7 +38,7 @@ public class BlockStem extends BlockCrops {
     @Override
     public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {
         if (block.getState().getRawData() >= CropState.RIPE.ordinal()) {
-            return Collections.unmodifiableList(Arrays.asList(new ItemStack(seedsType, random.nextInt(4))));
+            return Collections.unmodifiableList(Arrays.asList(new ItemStack(seedsType, ThreadLocalRandom.current().nextInt(4))));
         } else {
             return BlockDropless.EMPTY_STACK;
         }
@@ -62,7 +63,7 @@ public class BlockStem extends BlockCrops {
     public void grow(GlowPlayer player, GlowBlock block) {
         GlowBlockState state = block.getState();
         int cropState = block.getData()
-                + random.nextInt(CropState.MEDIUM.ordinal())
+                + ThreadLocalRandom.current().nextInt(CropState.MEDIUM.ordinal())
                 + CropState.VERY_SMALL.ordinal();
         if (cropState > CropState.RIPE.ordinal()) {
             cropState = CropState.RIPE.ordinal();
@@ -80,7 +81,7 @@ public class BlockStem extends BlockCrops {
         // we check light level on the above block, meaning stems needs at least one free block above it
         // in order to grow naturally (vanilla behavior)
         if (block.getRelative(BlockFace.UP).getLightLevel() >= 9 &&
-                random.nextInt((int) (25.0F / getGrowthRateModifier(block)) + 1) == 0) {
+                ThreadLocalRandom.current().nextInt((int) (25.0F / getGrowthRateModifier(block)) + 1) == 0) {
 
             int cropState = block.getData();
             if (cropState >= CropState.RIPE.ordinal()) {
@@ -92,7 +93,7 @@ public class BlockStem extends BlockCrops {
                     return;
                 }
                 // produce a fruit if possible
-                int n = random.nextInt(4);
+                int n = ThreadLocalRandom.current().nextInt(4);
                 BlockFace face;
                 switch (n) {
                     case 1:

--- a/src/main/java/net/glowstone/block/blocktype/BlockTallGrass.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockTallGrass.java
@@ -17,6 +17,7 @@ import org.bukkit.material.MaterialData;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockTallGrass extends BlockNeedsAttached implements IBlockGrowable {
 
@@ -29,7 +30,7 @@ public class BlockTallGrass extends BlockNeedsAttached implements IBlockGrowable
 
     @Override
     public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {
-        if (random.nextFloat() < .125) {
+        if (ThreadLocalRandom.current().nextFloat() < .125) {
             return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.SEEDS, 1)));
         }
         return BlockDropless.EMPTY_STACK;

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -29,8 +29,6 @@ import java.util.*;
  * Base class for specific types of blocks.
  */
 public class BlockType extends ItemType {
-
-    protected static final Random random = new Random();
     protected List<ItemStack> drops;
 
     protected SoundInfo placeSound = new SoundInfo(Sound.BLOCK_WOOD_BREAK, 1F, 0.75F);

--- a/src/main/java/net/glowstone/block/blocktype/BlockVine.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockVine.java
@@ -15,6 +15,7 @@ import org.bukkit.util.Vector;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockVine extends BlockClimbable {
 
@@ -108,18 +109,18 @@ public class BlockVine extends BlockClimbable {
 
     @Override
     public void updateBlock(GlowBlock block) {
-        if (random.nextInt(4) == 0) {
+        if (ThreadLocalRandom.current().nextInt(4) == 0) {
             GlowBlockState state = block.getState();
             MaterialData data = state.getData();
             if (data instanceof Vine) {
                 Vine vine = (Vine) data;
                 boolean hasNearVineBlocks = hasNearVineBlocks(block);
-                BlockFace face = FACES[random.nextInt(FACES.length)];
+                BlockFace face = FACES[ThreadLocalRandom.current().nextInt(FACES.length)];
                 if (block.getY() < 255 && face == BlockFace.UP && block.getRelative(face).isEmpty()) {
                     if (!hasNearVineBlocks) {
                         Vine v = (Vine) data;
                         for (BlockFace f : HORIZONTAL_FACES) {
-                            if (random.nextInt(2) == 0 || !block.getRelative(f).getRelative(face).getType().isSolid()) {
+                            if (ThreadLocalRandom.current().nextInt(2) == 0 || !block.getRelative(f).getRelative(face).getType().isSolid()) {
                                 v.removeFromFace(f);
                             }
                         }
@@ -156,7 +157,7 @@ public class BlockVine extends BlockClimbable {
                     Vine v = (Vine) data;
                     if (b.getType() == Material.VINE || b.isEmpty()) {
                         for (BlockFace f : HORIZONTAL_FACES) {
-                            if (random.nextInt(2) == 0) {
+                            if (ThreadLocalRandom.current().nextInt(2) == 0) {
                                 v.removeFromFace(f);
                             }
                         }

--- a/src/main/java/net/glowstone/block/state/GlowDispenser.java
+++ b/src/main/java/net/glowstone/block/state/GlowDispenser.java
@@ -14,11 +14,9 @@ import org.bukkit.projectiles.BlockProjectileSource;
 import org.bukkit.util.Vector;
 
 import java.util.Map;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class GlowDispenser extends GlowContainer implements Dispenser, BlockProjectileSource {
-
-    private static final Random random = new Random();
 
     private static final DispenseBehaviorRegistry dispenseBehaviorRegistry = new DispenseBehaviorRegistry();
 
@@ -92,7 +90,7 @@ public class GlowDispenser extends GlowContainer implements Dispenser, BlockProj
     }
 
     public int getDispenseSlot() {
-        return InventoryUtil.getRandomSlot(random, getInventory(), true);
+        return InventoryUtil.getRandomSlot(ThreadLocalRandom.current(), getInventory(), true);
     }
 
     public ItemStack placeInDispenser(ItemStack toPlace) {

--- a/src/main/java/net/glowstone/command/CommandTarget.java
+++ b/src/main/java/net/glowstone/command/CommandTarget.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 public class CommandTarget {
@@ -234,14 +235,10 @@ public class CommandTarget {
             count = entities.size();
         List<Entity> matched = new ArrayList<>();
         List<Integer> used = new ArrayList<>();
-        Random rand = null;
         for (int i = 0; i < count; i++) {
             if (selector == SelectorType.RANDOM) {
-                if (rand == null) {
-                    rand = new Random();
-                }
                 while (true) {
-                    int random = rand.nextInt(entities.size());
+                    int random = ThreadLocalRandom.current().nextInt(entities.size());
                     if (!used.contains(random)) {
                         matched.add(entities.get(random));
                         used.add(random);

--- a/src/main/java/net/glowstone/dispenser/DefaultDispenseBehavior.java
+++ b/src/main/java/net/glowstone/dispenser/DefaultDispenseBehavior.java
@@ -11,11 +11,9 @@ import org.bukkit.event.block.BlockDispenseEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class DefaultDispenseBehavior implements DispenseBehavior {
-
-    private final Random random = new Random();
 
     @Override
     public ItemStack dispense(GlowBlock block, ItemStack stack) {
@@ -50,13 +48,13 @@ public class DefaultDispenseBehavior implements DispenseBehavior {
         }
 
 
-        double velocity = random.nextDouble() * 0.1 + 0.2;
+        double velocity = ThreadLocalRandom.current().nextDouble() * 0.1 + 0.2;
         double velocityX = facing.getModX() * velocity;
         double velocityY = 0.2;
         double velocityZ = facing.getModZ() * velocity;
-        velocityX += random.nextGaussian() * 0.0075 * power;
-        velocityY += random.nextGaussian() * 0.0075 * power;
-        velocityZ += random.nextGaussian() * 0.0075 * power;
+        velocityX += ThreadLocalRandom.current().nextGaussian() * 0.0075 * power;
+        velocityY += ThreadLocalRandom.current().nextGaussian() * 0.0075 * power;
+        velocityZ += ThreadLocalRandom.current().nextGaussian() * 0.0075 * power;
 
         BlockDispenseEvent dispenseEvent = new BlockDispenseEvent(block, items, new Vector(velocityX, velocityY, velocityZ));
         EventFactory.callEvent(dispenseEvent);

--- a/src/main/java/net/glowstone/entity/GlowLightningStrike.java
+++ b/src/main/java/net/glowstone/entity/GlowLightningStrike.java
@@ -1,8 +1,6 @@
 package net.glowstone.entity;
 
 import com.flowpowered.network.Message;
-import java.util.Collections;
-import java.util.concurrent.ThreadLocalRandom;
 import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
@@ -23,8 +21,9 @@ import org.bukkit.event.block.BlockIgniteEvent.IgniteCause;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.util.Vector;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * A GlowLightning strike is an entity produced during thunderstorms.
@@ -35,7 +34,6 @@ public class GlowLightningStrike extends GlowWeather implements LightningStrike 
      * How long this lightning strike has to remain in the world.
      */
     private final int ticksToLive;
-    private final Random random;
     /**
      * Whether the lightning strike is just for effect.
      */
@@ -52,15 +50,14 @@ public class GlowLightningStrike extends GlowWeather implements LightningStrike 
     };
 
     public GlowLightningStrike(Location location) {
-        this(location, false, false, ThreadLocalRandom.current());
+        this(location, false, false);
     }
 
-    public GlowLightningStrike(Location location, boolean effect, boolean isSilent, Random random) {
+    public GlowLightningStrike(Location location, boolean effect, boolean isSilent) {
         super(location);
         this.effect = effect;
         this.isSilent = isSilent;
         ticksToLive = 30;
-        this.random = random;
     }
 
     @Override
@@ -83,8 +80,8 @@ public class GlowLightningStrike extends GlowWeather implements LightningStrike 
             GlowWorld world = (GlowWorld) location.getWorld();
             // Play Sound
             if (!isSilent) {
-                world.playSound(location, Sound.ENTITY_LIGHTNING_THUNDER, 10000, 0.8F + random.nextFloat() * 0.2F);
-                world.playSound(location, Sound.ENTITY_GENERIC_EXPLODE, 2, 0.5F + random.nextFloat() * 0.2F);
+                world.playSound(location, Sound.ENTITY_LIGHTNING_THUNDER, 10000, 0.8F + ThreadLocalRandom.current().nextFloat() * 0.2F);
+                world.playSound(location, Sound.ENTITY_GENERIC_EXPLODE, 2, 0.5F + ThreadLocalRandom.current().nextFloat() * 0.2F);
             }
 
             if (!effect) { // if it's not just a visual effect
@@ -93,9 +90,9 @@ public class GlowLightningStrike extends GlowWeather implements LightningStrike 
                     GlowBlock block = world.getBlockAt(location);
                     setBlockOnFire(block);
                     for (int i = 0; i < 4; i++) {
-                        int x = location.getBlockX() - 1 + random.nextInt(3);
-                        int z = location.getBlockZ() - 1 + random.nextInt(3);
-                        int y = location.getBlockY() - 1 + random.nextInt(3);
+                        int x = location.getBlockX() - 1 + ThreadLocalRandom.current().nextInt(3);
+                        int z = location.getBlockZ() - 1 + ThreadLocalRandom.current().nextInt(3);
+                        int y = location.getBlockY() - 1 + ThreadLocalRandom.current().nextInt(3);
                         block = world.getBlockAt(x, y, z);
                         setBlockOnFire(block);
                     }

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -713,9 +713,8 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                     if (data.getExperience() > 0) {
                         // split experience
                         Integer[] values = ExperienceSplitter.cut(data.getExperience());
-                        Random random = new Random();
                         for (Integer exp : values) {
-                            double xMod = random.nextDouble() - 0.5, zMod = random.nextDouble() - 0.5;
+                            double xMod = ThreadLocalRandom.current().nextDouble() - 0.5, zMod = ThreadLocalRandom.current().nextDouble() - 0.5;
                             Location xpLocation = new Location(world, location.getBlockX() + 0.5 + xMod, location.getY(), location.getBlockZ() + 0.5 + zMod);
                             GlowExperienceOrb orb = (GlowExperienceOrb) world.spawnEntity(xpLocation, EntityType.EXPERIENCE_ORB);
                             orb.setExperience(exp);

--- a/src/main/java/net/glowstone/entity/ai/EntityTask.java
+++ b/src/main/java/net/glowstone/entity/ai/EntityTask.java
@@ -2,12 +2,9 @@ package net.glowstone.entity.ai;
 
 import net.glowstone.entity.GlowLivingEntity;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public abstract class EntityTask {
-
-    protected static final Random random = new Random();
-
     private final String name;
     private boolean executing = false;
     private int duration = 0;
@@ -36,7 +33,7 @@ public abstract class EntityTask {
             return;
         }
         if (!executing && shouldStart(entity)) {
-            duration = getDurationMin() == getDurationMax() ? getDurationMin() : random.nextInt(getDurationMax() - getDurationMin()) + getDurationMin();
+            duration = getDurationMin() == getDurationMax() ? getDurationMin() : ThreadLocalRandom.current().nextInt(getDurationMax() - getDurationMin()) + getDurationMin();
             executing = true;
             start(entity);
         }

--- a/src/main/java/net/glowstone/entity/ai/LookAroundTask.java
+++ b/src/main/java/net/glowstone/entity/ai/LookAroundTask.java
@@ -2,9 +2,11 @@ package net.glowstone.entity.ai;
 
 import net.glowstone.entity.GlowLivingEntity;
 
+import java.util.concurrent.ThreadLocalRandom;
+
 public class LookAroundTask extends EntityTask {
 
-    private int delay = random.nextInt(10) + 15;
+    private int delay = ThreadLocalRandom.current().nextInt(10) + 15;
 
     public LookAroundTask() {
         super("look_around");
@@ -28,7 +30,7 @@ public class LookAroundTask extends EntityTask {
     @Override
     public boolean shouldStart(GlowLivingEntity entity) {
         EntityTask task = entity.getTaskManager().getTask("look_player");
-        return (task == null || !task.isExecuting()) && random.nextFloat() <= 0.1;
+        return (task == null || !task.isExecuting()) && ThreadLocalRandom.current().nextFloat() <= 0.1;
     }
 
     @Override
@@ -37,13 +39,13 @@ public class LookAroundTask extends EntityTask {
 
     @Override
     public void end(GlowLivingEntity entity) {
-        delay = random.nextInt(20) + 60;
+        delay = ThreadLocalRandom.current().nextInt(20) + 60;
     }
 
     @Override
     public void execute(GlowLivingEntity entity) {
-        if (random.nextFloat() <= 0.15 && delay == 0) {
-            entity.setHeadYaw(entity.getHeadYaw() + random.nextFloat() * 179 - 90); // todo: smooth
+        if (ThreadLocalRandom.current().nextFloat() <= 0.15 && delay == 0) {
+            entity.setHeadYaw(entity.getHeadYaw() + ThreadLocalRandom.current().nextFloat() * 179 - 90); // todo: smooth
             delay = 20;
         }
         if (delay > 0) delay--;

--- a/src/main/java/net/glowstone/entity/ai/LookAtPlayerTask.java
+++ b/src/main/java/net/glowstone/entity/ai/LookAtPlayerTask.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class LookAtPlayerTask extends EntityTask {
 
@@ -36,7 +37,7 @@ public class LookAtPlayerTask extends EntityTask {
     @Override
     public boolean shouldStart(GlowLivingEntity entity) {
         EntityTask task = entity.getTaskManager().getTask("look_around");
-        return task != null && !task.isExecuting() && random.nextFloat() <= 0.025;
+        return task != null && !task.isExecuting() && ThreadLocalRandom.current().nextFloat() <= 0.025;
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/monster/GlowSlime.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowSlime.java
@@ -6,7 +6,7 @@ import org.bukkit.Sound;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Slime;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class GlowSlime extends GlowMonster implements Slime {
 
@@ -18,10 +18,9 @@ public class GlowSlime extends GlowMonster implements Slime {
 
     protected GlowSlime(Location loc, EntityType type) {
         super(loc, type, 1);
-        Random r = new Random();
         byte size = 1;
         double health = 1;
-        switch (r.nextInt(3)) {
+        switch (ThreadLocalRandom.current().nextInt(3)) {
             case 0:
                 size = 1;
                 health = 1;

--- a/src/main/java/net/glowstone/entity/objects/GlowFallingBlock.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowFallingBlock.java
@@ -17,7 +17,7 @@ import org.bukkit.util.Vector;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class GlowFallingBlock extends GlowEntity implements FallingBlock {
 
@@ -176,8 +176,7 @@ public class GlowFallingBlock extends GlowEntity implements FallingBlock {
             } else {
                 placeFallingBlock();
                 if (material == Material.ANVIL) {
-                    Random random = new Random();
-                    world.playSound(location, Sound.BLOCK_ANVIL_FALL, 4, (1.0F + (random.nextFloat() - random.nextFloat()) * 0.2F) * 0.7F);
+                    world.playSound(location, Sound.BLOCK_ANVIL_FALL, 4, (1.0F + (ThreadLocalRandom.current().nextFloat() - ThreadLocalRandom.current().nextFloat()) * 0.2F) * 0.7F);
                 }
                 remove();
             }

--- a/src/main/java/net/glowstone/entity/passive/GlowChicken.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowChicken.java
@@ -8,7 +8,7 @@ import org.bukkit.entity.Chicken;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class GlowChicken extends GlowAnimal implements Chicken {
 
@@ -38,8 +38,7 @@ public class GlowChicken extends GlowAnimal implements Chicken {
     }
 
     private void generateEggLayDelay() {
-        Random r = new Random();
-        setEggLayTime(r.nextInt(20 * 60 * 5) + 20 * 60 * 5);
+        setEggLayTime(ThreadLocalRandom.current().nextInt(20 * 60 * 5) + 20 * 60 * 5);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/passive/GlowSheep.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowSheep.java
@@ -12,7 +12,7 @@ import org.bukkit.event.entity.SheepDyeWoolEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.Dye;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class GlowSheep extends GlowAnimal implements Sheep {
 
@@ -22,8 +22,7 @@ public class GlowSheep extends GlowAnimal implements Sheep {
     public GlowSheep(Location location) {
         super(location, EntityType.SHEEP, 8);
         setSize(0.9F, 1.3F);
-        Random r = new Random();
-        int colorpc = r.nextInt(10000);
+        int colorpc = ThreadLocalRandom.current().nextInt(10000);
         if (colorpc < 8184) {
             setColor(DyeColor.WHITE);
         } else if (colorpc >= 8184 && 8684 > colorpc) {
@@ -92,9 +91,7 @@ public class GlowSheep extends GlowAnimal implements Sheep {
 
                     getWorld().playSound(getLocation(), Sound.ENTITY_SHEEP_SHEAR, 1, 1);
 
-                    Random r = new Random();
-
-                    getWorld().dropItemNaturally(getLocation(), new ItemStack(Material.WOOL, r.nextInt(3) + 1, getColor().getWoolData()));
+                    getWorld().dropItemNaturally(getLocation(), new ItemStack(Material.WOOL, ThreadLocalRandom.current().nextInt(3) + 1, getColor().getWoolData()));
 
                     setSheared(true);
                     return true;

--- a/src/main/java/net/glowstone/entity/passive/GlowVillager.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowVillager.java
@@ -16,7 +16,6 @@ import org.bukkit.inventory.MerchantRecipe;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class GlowVillager extends GlowAgeable implements Villager {
@@ -31,8 +30,7 @@ public class GlowVillager extends GlowAgeable implements Villager {
 
     public GlowVillager(Location location) {
         super(location, EntityType.VILLAGER, 20);
-        Random random = ThreadLocalRandom.current();
-        setProfession(Profession.values()[random.nextInt(Profession.values().length - 2) + 1]);
+        setProfession(Profession.values()[ThreadLocalRandom.current().nextInt(Profession.values().length - 2) + 1]);
         setBoundingBox(0.6, 1.95);
     }
 
@@ -213,9 +211,8 @@ public class GlowVillager extends GlowAgeable implements Villager {
         if (profession == null || profession.isZombie()) {
             this.career = null;
         } else {
-            Random random = ThreadLocalRandom.current();
             Career[] careers = getCareersByProfession(profession);
-            this.career = careers[random.nextInt(careers.length)];
+            this.career = careers[ThreadLocalRandom.current().nextInt(careers.length)];
             this.careerLevel = 1;
         }
     }

--- a/src/main/java/net/glowstone/entity/passive/GlowWolf.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowWolf.java
@@ -8,7 +8,7 @@ import org.bukkit.entity.AnimalTamer;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Wolf;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 //import net.glowstone.entity.meta.MetadataIndex.TameableFlags;
 
@@ -18,8 +18,7 @@ public class GlowWolf extends GlowTameable implements Wolf {
 
     public GlowWolf(Location location) {
         super(location, EntityType.WOLF, 8);
-        Random r = new Random();
-        collarColor = DyeColor.getByDyeData((byte) r.nextInt(DyeColor.values().length));
+        collarColor = DyeColor.getByDyeData((byte) ThreadLocalRandom.current().nextInt(DyeColor.values().length));
         setBoundingBox(0.6, 0.85);
     }
 

--- a/src/main/java/net/glowstone/generator/biomegrid/MapLayer.java
+++ b/src/main/java/net/glowstone/generator/biomegrid/MapLayer.java
@@ -9,7 +9,6 @@ import org.bukkit.block.Biome;
 import java.util.Random;
 
 public abstract class MapLayer {
-
     private final Random random = new Random();
     private long seed;
 

--- a/src/main/java/net/glowstone/generator/objects/trees/BigOakTree.java
+++ b/src/main/java/net/glowstone/generator/objects/trees/BigOakTree.java
@@ -10,15 +10,12 @@ import java.util.Collection;
 import java.util.Random;
 
 public class BigOakTree extends GenericTree {
-
     private static final float LEAF_DENSITY = 1.0F;
-    private final Random random = new Random();
     private int maxLeafDistance = 5;
     private int trunkHeight;
 
     public BigOakTree(Random random, Location location, BlockStateDelegate delegate) {
         super(random, location, delegate);
-        this.random.setSeed(random.nextLong());
         setHeight(this.random.nextInt(12) + 5);
     }
 

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -62,11 +62,6 @@ public class GlowSession extends BasicSession {
     private final ConnectionManager connectionManager;
 
     /**
-     * The Random for this session
-     */
-    private final Random random = new Random();
-
-    /**
      * A queue of incoming and unprocessed messages.
      */
     private final Queue<Message> messageQueue = new ArrayDeque<>();

--- a/src/main/java/net/glowstone/util/loot/LootingManager.java
+++ b/src/main/java/net/glowstone/util/loot/LootingManager.java
@@ -14,7 +14,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class LootingManager {
 
@@ -91,19 +91,19 @@ public class LootingManager {
         if (!entities.containsKey(entity.getType())) {
             return new LootData(InventoryUtil.NO_ITEMS, 0);
         }
-        Random random = LootingUtil.random;
+
         EntityLootTable table = entities.get(entity.getType());
         ArrayList<ItemStack> items = new ArrayList<>();
         for (LootItem lootItem : table.getItems()) {
             DefaultLootItem defaultItem = lootItem.getDefaultItem();
-            int count = defaultItem.getCount().generate(random, entity);
+            int count = defaultItem.getCount().generate(ThreadLocalRandom.current(), entity);
             int data = 0;
             if (defaultItem.getData().isPresent()) {
-                data = defaultItem.getData().get().generate(random);
+                data = defaultItem.getData().get().generate(ThreadLocalRandom.current());
             } else if (defaultItem.getReflectiveData().isPresent()) {
                 data = ((Number) defaultItem.getReflectiveData().get().process(entity)).intValue();
             }
-            String name = defaultItem.getType().generate(random);
+            String name = defaultItem.getType().generate(ThreadLocalRandom.current());
             if (name == null) {
                 name = "";
             }
@@ -113,17 +113,17 @@ public class LootingManager {
             for (ConditionalLootItem condition : conditions) {
                 if (LootingUtil.conditionValue(entity, condition.getCondition())) {
                     if (condition.getCount().isPresent()) {
-                        count = condition.getCount().get().generate(random, entity);
+                        count = condition.getCount().get().generate(ThreadLocalRandom.current(), entity);
                     }
                     if (condition.getType().isPresent()) {
-                        name = condition.getType().get().generate(random);
+                        name = condition.getType().get().generate(ThreadLocalRandom.current());
                         if (name == null) {
                             name = "";
                         }
                         name = name.toUpperCase();
                     }
                     if (condition.getData().isPresent()) {
-                        data = condition.getData().get().generate(random);
+                        data = condition.getData().get().generate(ThreadLocalRandom.current());
                     } else if (condition.getReflectiveData().isPresent()) {
                         data = ((Number) condition.getReflectiveData().get().process(entity)).intValue();
                     }
@@ -134,7 +134,7 @@ public class LootingManager {
                 items.add(new ItemStack(material, count, (byte) data));
             }
         }
-        int experience = table.getExperience().generate(random, entity);
+        int experience = table.getExperience().generate(ThreadLocalRandom.current(), entity);
         return new LootData(items.toArray(new ItemStack[items.size()]), experience);
     }
 }

--- a/src/main/java/net/glowstone/util/loot/LootingUtil.java
+++ b/src/main/java/net/glowstone/util/loot/LootingUtil.java
@@ -6,12 +6,9 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 
 import java.util.Objects;
-import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class LootingUtil {
-
-    public static final Random random = ThreadLocalRandom.current();
 
     public static boolean is(Object a, Object b) {
         return Objects.equals(a, b);
@@ -53,6 +50,6 @@ public class LootingUtil {
     }
 
     public static long randomFishType() {
-        return random.nextInt(4);
+        return ThreadLocalRandom.current().nextInt(4);
     }
 }


### PR DESCRIPTION
This PR removes _most_ local instantiations of Random and replaces it with ThreadLocalRandom. This will improve performance and get rid of the _random_ Random instances that are scattered everywhere.