### PR TITLE
Add placement of chorus flower and plant, eating of chorus fruit

### DIFF
--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -245,6 +245,8 @@ public final class ItemTable {
         reg(Material.RED_GLAZED_TERRACOTTA, new BlockDirectDrops(Material.RED_GLAZED_TERRACOTTA));
         reg(Material.SILVER_GLAZED_TERRACOTTA, new BlockDirectDrops(Material.SILVER_GLAZED_TERRACOTTA));
         reg(Material.YELLOW_GLAZED_TERRACOTTA, new BlockDirectDrops(Material.YELLOW_GLAZED_TERRACOTTA));
+        reg(Material.CHORUS_FLOWER, new BlockChorusFlower());
+        reg(Material.CHORUS_PLANT, new BlockChorusPlant());
 
 
         reg(Material.FLINT_AND_STEEL, new ItemFlintAndSteel());
@@ -316,7 +318,7 @@ public final class ItemTable {
         reg(Material.RABBIT, new ItemFood(3, 1.8f));
         reg(Material.ROTTEN_FLESH, new ItemRottenFlesh());
         reg(Material.SPIDER_EYE, new ItemSpiderEye());
-        reg(Material.CHORUS_FRUIT, new ItemFood(4, 2.4f)); //todo: chorus fruit teleportation
+        reg(Material.CHORUS_FRUIT, new ItemChorusFruit());
         reg(Material.ARMOR_STAND, new ItemArmorStand());
         reg(Material.MILK_BUCKET, new ItemMilk());
         reg(Material.MINECART, new ItemMinecart(GlowMinecart.MinecartType.RIDEABLE));

--- a/src/main/java/net/glowstone/block/blocktype/BlockChorusFlower.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockChorusFlower.java
@@ -1,0 +1,34 @@
+package net.glowstone.block.blocktype;
+
+import net.glowstone.block.GlowBlock;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+
+public class BlockChorusFlower extends BlockType {
+
+    private static final BlockFace[] FACES = new BlockFace[] { BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST };
+
+    @Override
+    public boolean canPlaceAt(GlowBlock block, BlockFace against) {
+        GlowBlock under = block.getRelative(BlockFace.DOWN);
+        if (under.getType() == Material.ENDER_STONE || under.getType() == Material.CHORUS_PLANT) {
+            return true;
+        } else if (under.getType() == Material.AIR) {
+            boolean hasSupport = false;
+            for (BlockFace side : FACES) {
+                GlowBlock relative = block.getRelative(side);
+                if (relative.getType() == Material.CHORUS_PLANT) {
+                    if (hasSupport) { //only one chorus plant allowed on the side
+                        return false;
+                    } else {
+                        hasSupport = true;
+                    }
+                }
+            }
+            if (hasSupport) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/net/glowstone/block/blocktype/BlockChorusFlower.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockChorusFlower.java
@@ -6,7 +6,7 @@ import org.bukkit.block.BlockFace;
 
 public class BlockChorusFlower extends BlockType {
 
-    private static final BlockFace[] FACES = new BlockFace[] { BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST };
+    private static final BlockFace[] FACES = new BlockFace[] {BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
 
     @Override
     public boolean canPlaceAt(GlowBlock block, BlockFace against) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockChorusPlant.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockChorusPlant.java
@@ -11,7 +11,7 @@ import org.bukkit.inventory.ItemStack;
 
 public class BlockChorusPlant extends BlockType {
 
-    private static final BlockFace[] FACES = new BlockFace[] { BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST };
+    private static final BlockFace[] FACES = new BlockFace[] {BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
 
     @Override
     public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockChorusPlant.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockChorusPlant.java
@@ -1,0 +1,48 @@
+package net.glowstone.block.blocktype;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import net.glowstone.block.GlowBlock;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.ItemStack;
+
+public class BlockChorusPlant extends BlockType {
+
+    private static final BlockFace[] FACES = new BlockFace[] { BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST };
+
+    @Override
+    public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {
+        if (random.nextBoolean()) {
+            return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.CHORUS_FRUIT, 1)));
+        } else {
+            return Collections.unmodifiableList(Arrays.asList());
+        }
+    }
+
+    @Override
+    public boolean canPlaceAt(GlowBlock block, BlockFace against) {
+        boolean sideSupport = false;
+        for (BlockFace face : FACES) {
+            Block relative = block.getRelative(face);
+            if (relative.getType() == Material.CHORUS_PLANT && hasDownSupport(relative)) {
+                sideSupport = true;
+                break;
+            }
+        }
+        if (sideSupport) {
+            boolean upperBlocked = !block.getRelative(BlockFace.UP).isEmpty();
+            boolean downBlocked = !block.getRelative(BlockFace.DOWN).isEmpty();
+            return !(upperBlocked && downBlocked); //Both of the two can't be blocked
+        } else {
+            return hasDownSupport(block);
+        }
+    }
+
+    private boolean hasDownSupport(Block block) {
+        Block down = block.getRelative(BlockFace.DOWN);
+        return down.getType() == Material.CHORUS_PLANT || down.getType() == Material.ENDER_STONE;
+    }
+}

--- a/src/main/java/net/glowstone/block/itemtype/ItemChorusFruit.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemChorusFruit.java
@@ -1,5 +1,6 @@
 package net.glowstone.block.itemtype;
 
+import java.util.concurrent.ThreadLocalRandom;
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.Location;
 import org.bukkit.Sound;
@@ -23,9 +24,9 @@ public class ItemChorusFruit extends ItemFood {
 
         for (int i = 0; i < 16; i++) { //16 attempts: +/- 8 blocks in every direction
             Location attempt = player.getLocation();
-            double deltaX = Math.random() * 16 - 8;
-            double deltaY = Math.random() * 16 - 8;
-            double deltaZ = Math.random() * 16 - 8;
+            double deltaX = ThreadLocalRandom.current().nextDouble() * 16 - 8;
+            double deltaY = ThreadLocalRandom.current().nextDouble() * 16 - 8;
+            double deltaZ = ThreadLocalRandom.current().nextDouble() * 16 - 8;
             attempt.setX(attempt.getX() + deltaX);
             attempt.setY(Math.min(Math.max(attempt.getY() + deltaY, 0), player.getWorld().getMaxHeight() - 1));
             attempt.setZ(attempt.getZ() + deltaZ);

--- a/src/main/java/net/glowstone/block/itemtype/ItemChorusFruit.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemChorusFruit.java
@@ -1,0 +1,74 @@
+package net.glowstone.block.itemtype;
+
+import net.glowstone.entity.GlowPlayer;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.SoundCategory;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.ItemStack;
+
+public class ItemChorusFruit extends ItemFood {
+
+    public ItemChorusFruit() {
+        super(4, 2.4f);
+    }
+
+    @Override
+    public boolean eat(GlowPlayer player, ItemStack item) {
+        if (!super.eat(player, item)) {
+            return false;
+        }
+
+        for (int i = 0; i < 16; i++) { //16 attempts: +/- 8 blocks in every direction
+            Location attempt = player.getLocation();
+            double deltaX = Math.random() * 16 - 8;
+            double deltaY = Math.random() * 16 - 8;
+            double deltaZ = Math.random() * 16 - 8;
+            attempt.setX(attempt.getX() + deltaX);
+            attempt.setY(Math.min(Math.max(attempt.getY() + deltaY, 0), player.getWorld().getMaxHeight() - 1));
+            attempt.setZ(attempt.getZ() + deltaZ);
+            attempt = getSafeLocation(attempt);
+            if (attempt != null) {
+                player.getWorld().playSound(player.getLocation(), Sound.ITEM_CHORUS_FRUIT_TELEPORT, SoundCategory.PLAYERS, 1, 1);
+                player.teleport(attempt);
+                break;
+            }
+        }
+        return true;
+    }
+
+    private Location getSafeLocation(Location loc) {
+        int yCoord = loc.getBlockY();
+        World world = loc.getWorld();
+        if (yCoord > world.getHighestBlockYAt(loc)) {
+            yCoord = world.getHighestBlockYAt(loc) + 1;
+        }
+        boolean found = false;
+        boolean hadSpace = false;
+        while (yCoord > 0) {
+            Block current = world.getBlockAt(loc.getBlockX(), yCoord, loc.getBlockZ());
+            if (current.isEmpty() && current.getRelative(BlockFace.UP).isEmpty()) {
+                hadSpace = true;
+            } else if (hadSpace) {
+                if (current.getType().isSolid()) {
+                    found = true;
+                    yCoord++;
+                    break;
+                } else {
+                    hadSpace = false;
+                }
+            }
+            yCoord--;
+        }
+        if (found) {
+            loc.setY(yCoord);
+            loc.setX(loc.getBlockX() + 0.5); //TODO: Do a proper bounding box check instead of just centering the location
+            loc.setZ(loc.getBlockZ() + 0.5);
+            return loc;
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This pull request implements the chorus plant items/blocks.

1. Chorus fruit
The chorus fruit is edible and teleports the player to a random location as described in the [Minecraft Wiki](https://minecraft.gamepedia.com/Chorus_Fruit). The location check currently doesn't check for the bounding box of the player to be empty, but rather centers the location and checks for two air blocks.

2. Chorus flower/plant
Implement placing restrictions and drops for the chorus flower and plant blocks.
This does not include dropping the plant if certain conditions are met.