### PR TITLE
Move array of BlockFaces to BlockType

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockButton.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockButton.java
@@ -15,9 +15,6 @@ import org.bukkit.util.Vector;
 
 public class BlockButton extends BlockAttachable {
 
-    private static final BlockFace[] ADJACENT = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN};
-    private static final BlockFace[] SIDES = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
-
     public BlockButton(Material material) {
         setDrops(new ItemStack(material));
     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockCactus.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCactus.java
@@ -10,8 +10,6 @@ import org.bukkit.event.block.BlockGrowEvent;
 
 public class BlockCactus extends BlockType {
 
-    private static final BlockFace[] NEAR_BLOCKS = new BlockFace[]{BlockFace.NORTH, BlockFace.SOUTH, BlockFace.WEST, BlockFace.EAST};
-
     @Override
     public boolean canPlaceAt(GlowBlock block, BlockFace against) {
         Material below = block.getRelative(BlockFace.DOWN).getType();
@@ -73,7 +71,7 @@ public class BlockCactus extends BlockType {
     }
 
     private boolean hasNearBlocks(GlowBlock block) {
-        for (BlockFace face : NEAR_BLOCKS) {
+        for (BlockFace face : SIDES) {
             if (!canPlaceNear(block.getRelative(face).getType())) {
                 return true;
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockChest.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockChest.java
@@ -21,9 +21,6 @@ import java.util.Collection;
 
 public class BlockChest extends BlockContainer {
 
-    private static final BlockFace[] NEAR_CHESTS = new BlockFace[]{
-            BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST
-    };
     private final boolean isTrapped;
 
     public BlockChest() {
@@ -148,7 +145,7 @@ public class BlockChest extends BlockContainer {
     private Collection<BlockFace> searchChests(GlowBlock block) {
         Collection<BlockFace> chests = new ArrayList<>();
 
-        for (BlockFace face : NEAR_CHESTS) {
+        for (BlockFace face : SIDES) {
             GlowBlock possibleChest = block.getRelative(face);
             if (possibleChest.getType() == (isTrapped ? Material.TRAPPED_CHEST : Material.CHEST)) {
                 chests.add(face);

--- a/src/main/java/net/glowstone/block/blocktype/BlockChorusFlower.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockChorusFlower.java
@@ -6,8 +6,6 @@ import org.bukkit.block.BlockFace;
 
 public class BlockChorusFlower extends BlockType {
 
-    private static final BlockFace[] FACES = new BlockFace[] {BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
-
     @Override
     public boolean canPlaceAt(GlowBlock block, BlockFace against) {
         GlowBlock under = block.getRelative(BlockFace.DOWN);
@@ -15,7 +13,7 @@ public class BlockChorusFlower extends BlockType {
             return true;
         } else if (under.getType() == Material.AIR) {
             boolean hasSupport = false;
-            for (BlockFace side : FACES) {
+            for (BlockFace side : SIDES) {
                 GlowBlock relative = block.getRelative(side);
                 if (relative.getType() == Material.CHORUS_PLANT) {
                     if (hasSupport) { //only one chorus plant allowed on the side

--- a/src/main/java/net/glowstone/block/blocktype/BlockChorusPlant.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockChorusPlant.java
@@ -13,8 +13,6 @@ import org.bukkit.inventory.ItemStack;
 
 public class BlockChorusPlant extends BlockType {
 
-    private static final BlockFace[] FACES = new BlockFace[] {BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
-
     @Override
     public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {
         if (ThreadLocalRandom.current().nextBoolean()) {
@@ -27,7 +25,7 @@ public class BlockChorusPlant extends BlockType {
     @Override
     public boolean canPlaceAt(GlowBlock block, BlockFace against) {
         boolean sideSupport = false;
-        for (BlockFace face : FACES) {
+        for (BlockFace face : SIDES) {
             Block relative = block.getRelative(face);
             if (relative.getType() == Material.CHORUS_PLANT && hasDownSupport(relative)) {
                 sideSupport = true;

--- a/src/main/java/net/glowstone/block/blocktype/BlockCocoa.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCocoa.java
@@ -22,8 +22,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockCocoa extends BlockNeedsAttached implements IBlockGrowable {
 
-    private static final BlockFace[] FACES = {BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
-
     @Override
     public void placeBlock(GlowPlayer player, GlowBlockState state, BlockFace face, ItemStack holding, Vector clickedLoc) {
         state.setType(getMaterial());
@@ -45,7 +43,7 @@ public class BlockCocoa extends BlockNeedsAttached implements IBlockGrowable {
     @Override
     public boolean canPlaceAt(GlowBlock block, BlockFace against) {
         BlockFace face = against.getOppositeFace();
-        if (Arrays.asList(FACES).contains(face) && block.getRelative(face).getType() == Material.LOG) {
+        if (Arrays.asList(SIDES).contains(face) && block.getRelative(face).getType() == Material.LOG) {
             MaterialData data = block.getRelative(face).getState().getData();
             if (data instanceof Tree) {
                 if (((Tree) data).getSpecies() == TreeSpecies.JUNGLE) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockConcretePowder.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockConcretePowder.java
@@ -23,11 +23,9 @@ public class BlockConcretePowder extends BlockFalling {
         }
     }
 
-    private BlockFace[] faces = {BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN};
-
     @Override
     public void onBlockChanged(GlowBlock block, Material oldType, byte oldData, Material newType, byte data) {
-        for (BlockFace face : faces) {
+        for (BlockFace face : ADJACENT) {
             if (block.getRelative(face).isLiquid()) {
                 block.setType(Material.CONCRETE);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockEnderPortalFrame.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockEnderPortalFrame.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class BlockEnderPortalFrame extends BlockDropless {
-    private static final BlockFace[] DIRECTION = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
 
     @Override
     public void placeBlock(GlowPlayer player, GlowBlockState state, BlockFace face, ItemStack holding, Vector clickedLoc) {
@@ -68,7 +67,7 @@ public class BlockEnderPortalFrame extends BlockDropless {
     private void searchForCompletedPortal(GlowPlayer player, GlowBlock changed) {
         for (int i = 0; i < 4; i++) {
             for (int j = -1; j <= 1; j++) {
-                GlowBlock center = changed.getRelative(DIRECTION[i], 2).getRelative(DIRECTION[(i + 1) % 4], j);
+                GlowBlock center = changed.getRelative(SIDES[i], 2).getRelative(SIDES[(i + 1) % 4], j);
                 if (isCompletedPortal(center)) {
                     createPortal(player, center);
                     return;
@@ -83,7 +82,7 @@ public class BlockEnderPortalFrame extends BlockDropless {
     private boolean isCompletedPortal(GlowBlock center) {
         for (int i = 0; i < 4; i++) {
             for (int j = -1; j <= 1; j++) {
-                GlowBlock block = center.getRelative(DIRECTION[i], 2).getRelative(DIRECTION[(i + 1) % 4], j);
+                GlowBlock block = center.getRelative(SIDES[i], 2).getRelative(SIDES[(i + 1) % 4], j);
                 if (block.getType() != Material.ENDER_PORTAL_FRAME || (block.getData() & 0x4) == 0) {
                     return false;
                 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockFire.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockFire.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockFire extends BlockNeedsAttached {
 
-    private static final BlockFace[] FLAMMABLE_FACES = {BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN};
     private static final BlockFace[] RAIN_FACES = {BlockFace.SELF, BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST};
     private static final int TICK_RATE = 20;
     private static final int MAX_FIRE_AGE = 15;
@@ -190,7 +189,7 @@ public class BlockFire extends BlockNeedsAttached {
 
     private boolean hasNearFlammableBlock(GlowBlock block) {
         // check there's at least a flammable block around
-        for (BlockFace face : FLAMMABLE_FACES) {
+        for (BlockFace face : ADJACENT) {
             if (block.getRelative(face).isFlammable()) {
                 return true;
             }
@@ -203,7 +202,7 @@ public class BlockFire extends BlockNeedsAttached {
             return 0;
         } else {
             int flameResistance = 0;
-            for (BlockFace face : FLAMMABLE_FACES) {
+            for (BlockFace face : ADJACENT) {
                 flameResistance = Math.max(flameResistance, block.getRelative(face).getMaterialValues().getFlameResistance());
             }
             return flameResistance;

--- a/src/main/java/net/glowstone/block/blocktype/BlockLava.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLava.java
@@ -12,8 +12,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockLava extends BlockLiquid {
 
-    private static final BlockFace[] FLAMMABLE_FACES = {BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN};
-
     public BlockLava() {
         super(Material.LAVA_BUCKET);
     }
@@ -68,7 +66,7 @@ public class BlockLava extends BlockLiquid {
 
     private boolean hasNearFlammableBlock(GlowBlock block) {
         // check there's at least a flammable block around
-        for (BlockFace face : FLAMMABLE_FACES) {
+        for (BlockFace face : ADJACENT) {
             if (block.getRelative(face).isFlammable()) {
                 return true;
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockLever.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLever.java
@@ -14,8 +14,6 @@ import org.bukkit.util.Vector;
 
 public class BlockLever extends BlockAttachable {
 
-    private static final BlockFace[] ADJACENT = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN};
-
     public BlockLever() {
         setDrops(new ItemStack(Material.LEVER));
     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockLiquid.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLiquid.java
@@ -24,7 +24,7 @@ public abstract class BlockLiquid extends BlockType {
     private static final int TICK_RATE_WATER = 4;
     private static final int TICK_RATE_LAVA = 20;
     private final Material bucketType;
-    private BlockFace[] sides = {NORTH, EAST, SOUTH, WEST};
+
     protected BlockLiquid(Material bucketType) {
         this.bucketType = bucketType;
     }
@@ -119,7 +119,7 @@ public abstract class BlockLiquid extends BlockType {
             if (block.getY() > 0) {
                 if (calculateTarget(block.getRelative(DOWN), DOWN, true)) {
                     if (!block.getRelative(UP).isLiquid() && Byte.compare(state.getRawData(), STRENGTH_SOURCE) == 0) {
-                        for (BlockFace face : sides) {
+                        for (BlockFace face : SIDES) {
                             calculateTarget(block.getRelative(face), face, true);
                         }
                     }
@@ -128,7 +128,7 @@ public abstract class BlockLiquid extends BlockType {
                     // search 5 blocks out
                     for (int j = 1; j < 6; j++) {
                         // from each horizontal face
-                        for (BlockFace face : sides) {
+                        for (BlockFace face : SIDES) {
                             if (calculateTarget(block.getRelative(face, j).getRelative(DOWN), face, false) && calculateTarget(block.getRelative(face), face, true)) {
                                 state.setFlowed(true);
                             }
@@ -138,7 +138,7 @@ public abstract class BlockLiquid extends BlockType {
                             return;
                         }
                     }
-                    for (BlockFace face : sides) {
+                    for (BlockFace face : SIDES) {
                         calculateTarget(block.getRelative(face), face, true);
                     }
                     state.setFlowed(true);

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstone.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstone.java
@@ -20,9 +20,6 @@ import java.util.List;
  */
 public class BlockRedstone extends BlockNeedsAttached {
 
-    private static final BlockFace[] ADJACENT = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN};
-    private static final BlockFace[] SIDES = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
-
     public BlockRedstone() {
         setDrops(new ItemStack(Material.REDSTONE));
     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneRepeater.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneRepeater.java
@@ -13,8 +13,6 @@ import org.bukkit.util.Vector;
 
 public class BlockRedstoneRepeater extends BlockNeedsAttached {
 
-    private static final BlockFace[] ADJACENT = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN};
-
     public BlockRedstoneRepeater() {
         setDrops(new ItemStack(Material.DIODE));
     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneTorch.java
@@ -16,8 +16,6 @@ import org.bukkit.util.Vector;
 
 public class BlockRedstoneTorch extends BlockNeedsAttached {
 
-    private static final BlockFace[] ADJACENT = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN};
-
     public BlockRedstoneTorch() {
         setDrops(new ItemStack(Material.REDSTONE_TORCH_ON));
     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockSugarCane.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSugarCane.java
@@ -15,8 +15,6 @@ import java.util.Collections;
 
 public class BlockSugarCane extends BlockNeedsAttached {
 
-    private static final BlockFace[] DIRECT_FACES = new BlockFace[]{BlockFace.NORTH, BlockFace.EAST, BlockFace.WEST, BlockFace.SOUTH};
-
     @Override
     public void onNearBlockChanged(GlowBlock block, BlockFace face, GlowBlock changedBlock, Material oldType, byte oldData, Material newType, byte newData) {
         updatePhysics(block);
@@ -85,7 +83,7 @@ public class BlockSugarCane extends BlockNeedsAttached {
     }
 
     private boolean isNearWater(Block block) {
-        for (BlockFace face : DIRECT_FACES) {
+        for (BlockFace face : SIDES) {
             switch (block.getRelative(face).getType()) {
                 case WATER:
                 case STATIONARY_WATER:

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -29,6 +29,10 @@ import java.util.*;
  * Base class for specific types of blocks.
  */
 public class BlockType extends ItemType {
+
+    protected static final BlockFace[] SIDES = new BlockFace[] {BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
+    protected static final BlockFace[] ADJACENT = new BlockFace[] {BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN};
+
     protected List<ItemStack> drops;
 
     protected SoundInfo placeSound = new SoundInfo(Sound.BLOCK_WOOD_BREAK, 1F, 0.75F);

--- a/src/main/java/net/glowstone/block/blocktype/BlockVine.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockVine.java
@@ -19,7 +19,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockVine extends BlockClimbable {
 
-    private static final BlockFace[] FACES = {BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST, BlockFace.DOWN, BlockFace.UP};
     private static final BlockFace[] HORIZONTAL_FACES = {BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST};
 
     private static BlockFace getClockwiseFace(BlockFace face) {
@@ -115,7 +114,7 @@ public class BlockVine extends BlockClimbable {
             if (data instanceof Vine) {
                 Vine vine = (Vine) data;
                 boolean hasNearVineBlocks = hasNearVineBlocks(block);
-                BlockFace face = FACES[ThreadLocalRandom.current().nextInt(FACES.length)];
+                BlockFace face = ADJACENT[ThreadLocalRandom.current().nextInt(ADJACENT.length)];
                 if (block.getY() < 255 && face == BlockFace.UP && block.getRelative(face).isEmpty()) {
                     if (!hasNearVineBlocks) {
                         Vine v = (Vine) data;

--- a/src/main/java/net/glowstone/block/blocktype/BlockWater.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockWater.java
@@ -11,8 +11,6 @@ import org.bukkit.material.MaterialData;
 
 public class BlockWater extends BlockLiquid {
 
-    private static final BlockFace[] SOLID_FACES = {BlockFace.NORTH, BlockFace.SOUTH, BlockFace.EAST, BlockFace.WEST};
-
     public BlockWater() {
         super(Material.WATER_BUCKET);
     }
@@ -42,7 +40,7 @@ public class BlockWater extends BlockLiquid {
 
     private boolean hasNearSolidBlock(GlowBlock block) {
         // check there's at least a solid block around
-        for (BlockFace face : SOLID_FACES) {
+        for (BlockFace face : SIDES) {
             if (block.getRelative(face).getType().isSolid()) {
                 return true;
             }


### PR DESCRIPTION
This PR moves many of the used BlockFace arrays to the BlockType parent class.

As the same arrays (one with the horizontal BlockFaces and one with additional up and down faces) are used over and over in the BlockType implementations, I moved these two arrays to a central place and renamed similiar arrays.

In case the order of the array was important and different from the default order, I didn't change the BlockFace array.