### PR TITLE
Fix fire not getting updated. Fixes #435

### DIFF
--- a/src/main/java/net/glowstone/block/itemtype/ItemFlintAndSteel.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFlintAndSteel.java
@@ -15,6 +15,10 @@ import org.bukkit.util.Vector;
 
 public class ItemFlintAndSteel extends ItemTool {
 
+    public ItemFlintAndSteel() {
+        this.setPlaceAs(Material.FIRE);
+    }
+
     @Override
     public boolean onToolRightClick(GlowPlayer player, GlowBlock target, BlockFace face, ItemStack holding, Vector clickedLoc, EquipmentSlot hand) {
         if (target.getType() == Material.OBSIDIAN) {


### PR DESCRIPTION
After causing a fire through flint and steel, fire did not behave properly: it just sat there doing nothing. The reason for this behavior was due to setting the type to the material the player was currently holding. Since it was flint and steel, it was set to that instead of a fire block. Running an update on that obviously does nothing.

Setting the block type to fire on the other hand does the right thing. Updates get propagated, it will spread and at some point stop.

The fire spreading seems to be a little off as well, but I left that for another day.