### PR TITLE
Fix editing signs on locations with yaw/pitch and opening sign editor when another inventory is opened

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -57,6 +57,7 @@ import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.entity.meta.profile.PlayerProfile;
 import net.glowstone.entity.objects.GlowItem;
 import net.glowstone.inventory.GlowInventory;
+import net.glowstone.inventory.GlowInventoryView;
 import net.glowstone.inventory.InventoryMonitor;
 import net.glowstone.inventory.crafting.PlayerRecipeMonitor;
 import net.glowstone.io.PlayerDataService.PlayerReader;
@@ -1065,6 +1066,14 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         signLocation.setX(loc.getBlockX());
         signLocation.setY(loc.getBlockY());
         signLocation.setZ(loc.getBlockZ());
+        signLocation.setYaw(0);
+        signLocation.setPitch(0);
+
+        // Client closes inventory when sign editor is opened
+        if (!GlowInventoryView.isDefault(getOpenInventory())) {
+            closeInventory();
+        }
+
         session.send(new SignEditorMessage(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()));
     }
 


### PR DESCRIPTION
This pull request fixes two bugs with opening the sign editor from a plugin:
1. When calling openSignEditor with non-zero yaw and pitch, a sign edit is not accepted by the server, because the given location and the edit location from the client (which includes only block coordinates) don't match (The check is [here](https://github.com/GlowstoneMC/Glowstone/blob/dev/src/main/java/net/glowstone/entity/GlowPlayer.java#L1078)). This PR just sets yaw and pitch to zero.

2. If openSignEditor is called while an inventory is opened, there's the following problem:
- A sign edit packet is sent to the player
- The client closes the old inventory silently and opens the sign editor
- The player edits the sign, the edit packet is sent and processed
- When interacting with the creative inventory the server still thinks the old inventory is open and [kicks the player](https://github.com/GlowstoneMC/Glowstone/blob/dev/src/main/java/net/glowstone/net/handler/play/inv/CreativeItemHandler.java#L41)

To fix it, I'm closing the inventory before sending the sign edit packet.


I was also wondering why a cancelled SignChangeEvent produces a [log message on level warning](https://github.com/GlowstoneMC/Glowstone/blob/dev/src/main/java/net/glowstone/net/handler/play/game/UpdateSignHandler.java#L34). Is there a reason behind this behaviour?