### PR TITLE
Improve hanging entities

### DIFF
--- a/src/main/java/net/glowstone/entity/objects/GlowPainting.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowPainting.java
@@ -23,6 +23,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Hanging;
 import org.bukkit.entity.Painting;
+import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.hanging.HangingBreakEvent.RemoveCause;
 import org.bukkit.inventory.ItemStack;
@@ -94,8 +95,7 @@ public class GlowPainting extends GlowHangingEntity implements Painting {
     @Override
     public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
         if (message.getAction() == Action.ATTACK.ordinal()) {
-            // TODO: use correct RemoveCause
-            if (EventFactory.callEvent(new HangingBreakEvent(this, RemoveCause.DEFAULT))
+            if (EventFactory.callEvent(new HangingBreakByEntityEvent(this, player))
                 .isCancelled()) {
                 return false;
             }
@@ -242,10 +242,9 @@ public class GlowPainting extends GlowHangingEntity implements Painting {
                 .isCancelled()) {
                 return;
             }
-            if (location.getBlock().getRelative(getAttachedFace()).getType() == Material.AIR) {
-                world.dropItemNaturally(location, new ItemStack(Material.PAINTING));
-                remove();
-            }
+
+            world.dropItemNaturally(location, new ItemStack(Material.PAINTING));
+            remove();
         }
     }
 

--- a/src/main/java/net/glowstone/entity/objects/GlowPainting.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowPainting.java
@@ -254,7 +254,7 @@ public class GlowPainting extends GlowHangingEntity implements Painting {
     }
 
     /**
-     * Check if the painting can survive at the current location.
+     * Check if the painting is obstructed at the current location.
      *
      * <p>Survivability is defined as:
      * <ul>
@@ -263,7 +263,7 @@ public class GlowPainting extends GlowHangingEntity implements Painting {
      *     <li>The painting is not inside another entity</li>
      * </ul>
      *
-     * @return true if the painting can survive, false otherwise
+     * @return true if the painting should drop, false otherwise
      */
     public boolean isObstructed() {
         Location current = getTopLeftCorner();


### PR DESCRIPTION
This pull request fixes several bugs and implements some events regarding item frames and paintings.

The following bugs/features are fixed/implemented:
- Call `HangingBreakByEntityEvent` when player breaks the item frame/painting
- Don't drop item frame if player is in creative
- Call `EntityDamageByEntityEvent` when item is removed from item frame (equals spigot behaviour)
- Only drop item frame content if player is in creative
- Don't reset rotation when item is removed or placed (equals vanilla behaviour)
- Remove useless/wrong check for air behind a painting, since the call to `isObstructed()` is executed before that and performs a wider check
