### PR TITLE
Implement more methods in GlowPlayer.Spigot

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -373,9 +373,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
         @Override
         public void respawn() {
-            if (isDead()) {
-                GlowPlayer.this.respawn();
-            }
+            GlowPlayer.this.respawn();
         }
 
         @Override
@@ -386,6 +384,36 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         @Override
         public void setCollidesWithEntities(boolean collides) {
             setCollidable(collides);
+        }
+
+        @Override
+        public Set<Player> getHiddenPlayers() {
+            return hiddenEntities.stream().map((uuid) -> Bukkit.getPlayer(uuid)).filter((p) -> p != null).collect(Collectors.toSet());
+        }
+
+        @Override
+        public void sendMessage(ChatMessageType position, BaseComponent... components) {
+            GlowPlayer.this.sendMessage(position, components);
+        }
+
+        @Override
+        public void sendMessage(ChatMessageType position, BaseComponent component) {
+            GlowPlayer.this.sendMessage(position, component);
+        }
+
+        @Override
+        public void sendMessage(BaseComponent... components) {
+            GlowPlayer.this.sendMessage(components);
+        }
+
+        @Override
+        public void sendMessage(BaseComponent component) {
+            GlowPlayer.this.sendMessage(component);
+        }
+
+        @Override
+        public String getLocale() {
+            return GlowPlayer.this.getLocale();
         }
     };
     /**
@@ -995,6 +1023,10 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
      * Respawn the player after they have died.
      */
     public void respawn() {
+        if (!isDead()) {
+            return;
+        }
+
         // restore health
         setHealth(getMaxHealth());
         setFoodLevel(20);


### PR DESCRIPTION
This pull request:
- implements most of the unimplemented methods in `GlowPlayer.Spigot`
- moves the `isDead()` check to the normal `respawn()` method
I thought about a case where you don't need a check for dead when respawning a player but I can't think of a case where you don't want that
- doesn't implement `getPing()`, because I didn't find where it is stored, if already