### PR TITLE
Fix pinging the server in proxy mode

### DIFF
--- a/src/main/java/net/glowstone/net/handler/handshake/HandshakeHandler.java
+++ b/src/main/java/net/glowstone/net/handler/handshake/HandshakeHandler.java
@@ -27,7 +27,8 @@ public class HandshakeHandler implements MessageHandler<GlowSession, HandshakeMe
 
         // Proxies modify the hostname in the HandshakeMessage to contain
         // the client's UUID and (optionally) properties
-        if (session.getServer().getProxySupport()) {
+        // Only applicable if ProtocolType is login
+        if (protocol == ProtocolType.LOGIN && session.getServer().getProxySupport()) {
             try {
                 session.setProxyData(new ProxyData(session, message.getAddress()));
             } catch (IllegalArgumentException ex) {


### PR DESCRIPTION
This pull request fixes an issue with pinging a Glowstone server from BungeeCord.

BungeeCord provides a `ServerInfo.ping()` method, which returns the server list information from the given server.

Since there's no need to send additional information (like the uuid of a player), the address field of the handshake message behaves just like a direct packet from a vanilla client. That means the only case where additional bungeecord data has to be parsed, is when the handshake is performed for a login process.

The old version tried to parse the address string, failed when [checking the length](https://github.com/GlowstoneMC/Glowstone/blob/dev/src/main/java/net/glowstone/net/ProxyData.java#L83) of the data and disconnected the session, so BungeeCord never received the correct packet.

A side-effect of this change is that pinging the Glowstone server directly from a Minecraft client is possible even when proxy support is enabled. Connecting without a proxy is still not possible.

PS: If you're wondering where all the issues and pull requests come from, @hibo98 and I are currently trying to migrate the lobby of our server to Glowstone and these are the bugs we encounter.

And thanks for adding me to the team :).