### PR TITLE
Material based ItemTable

### DIFF
--- a/src/main/java/net/glowstone/block/GlowBlock.java
+++ b/src/main/java/net/glowstone/block/GlowBlock.java
@@ -186,6 +186,7 @@ public final class GlowBlock implements Block {
         return getTypeIdNoCache();
     }
 
+    @Deprecated
     private int getTypeIdNoCache() {
         return ((GlowChunk) world.getChunkAt(this)).getType(x & 0xf, z & 0xf, y);
     }
@@ -546,7 +547,7 @@ public final class GlowBlock implements Block {
                     blockFace = null;
                 }
 
-                BlockType notifyType = itemTable.getBlock(notify.getTypeId());
+                BlockType notifyType = itemTable.getBlock(notify.getType());
                 if (notifyType != null) {
                     notifyType.onNearBlockChanged(notify, blockFace, this, oldType, oldData, newType, newData);
                 }

--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -151,7 +151,7 @@ public final class ItemTable {
     }
 
     private final EnumMap<Material, ItemType> materialToType = new EnumMap<>(Material.class);
-    private final Map<String, ItemType> extraTypes = new HashMap<>();
+    private final Map<NamespacedKey, ItemType> extraTypes = new HashMap<>();
     private int nextBlockId;
     private int nextItemId;
 
@@ -526,7 +526,7 @@ public final class ItemTable {
         } else {
             id = nextItemId;
         }
-        if (extraTypes.putIfAbsent(key.toString(), type) == null) {
+        if (extraTypes.putIfAbsent(key, type) == null) {
             type.setId(id);
             if (block) {
                 nextBlockId++;

--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -134,6 +134,7 @@ import net.glowstone.block.itemtype.ItemWrittenBook;
 import net.glowstone.entity.objects.GlowMinecart;
 import net.glowstone.inventory.ToolType;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Sound;
 import org.bukkit.TreeSpecies;
 
@@ -148,8 +149,10 @@ public final class ItemTable {
         INSTANCE.registerBuiltins();
     }
 
-    private final Map<Integer, ItemType> idToType = new HashMap<>(512);
-    private int nextBlockId, nextItemId;
+    private final Map<Material, ItemType> materialToType = new HashMap<>(512);
+    private final Map<String, ItemType> extraTypes = new HashMap<>();
+    private int nextBlockId;
+    private int nextItemId;
 
     ////////////////////////////////////////////////////////////////////////////
     // Data
@@ -468,12 +471,13 @@ public final class ItemTable {
             throw new IllegalArgumentException("Cannot mismatch item and block: " + material + ", " + type);
         }
 
-        if (idToType.containsKey(material.getId())) {
-            throw new IllegalArgumentException("Cannot use " + type + " for " + material + ", is already " + idToType.get(material.getId()));
+        if (materialToType.containsKey(material)) {
+            throw new IllegalArgumentException("Cannot use " + type + " for " + material + ", is already " + materialToType
+                .get(material));
         }
 
-        idToType.put(material.getId(), type);
-        type.setId(material.getId());
+        materialToType.put(material, type);
+        type.setMaterial(material);
 
         if (material.isBlock()) {
             nextBlockId = Math.max(nextBlockId, material.getId() + 1);
@@ -490,12 +494,13 @@ public final class ItemTable {
             throw new IllegalArgumentException("Cannot mismatch item and block: " + material + ", " + type);
         }
 
-        if (idToType.containsKey(material.getId())) {
-            throw new IllegalArgumentException("Cannot use " + type + " for " + material + ", is already " + idToType.get(material.getId()));
+        if (materialToType.containsKey(material)) {
+            throw new IllegalArgumentException("Cannot use " + type + " for " + material + ", is already " + materialToType
+                .get(material));
         }
 
-        idToType.put(material.getId(), type);
-        type.setId(material.getId());
+        materialToType.put(material, type);
+        type.setMaterial(material);
 
         if (material.isBlock()) {
             nextBlockId = Math.max(nextBlockId, material.getId() + 1);
@@ -508,33 +513,38 @@ public final class ItemTable {
     /**
      * Register a new, non-Vanilla ItemType. It will be assigned an ID automatically.
      *
+     * @param key the namespaced key of the ItemType
      * @param type the ItemType to register.
+     * @return if the registration was successful
      */
-    public void register(ItemType type) {
+    public boolean register(NamespacedKey key, ItemType type) {
         int id;
-        if (type instanceof BlockType) {
+        boolean block = type instanceof BlockType;
+        if (block) {
             id = nextBlockId;
         } else {
             id = nextItemId;
         }
-
-        while (idToType.containsKey(id)) {
-            ++id;
-        }
-
-        idToType.put(id, type);
-        type.setId(id);
-
-        if (type instanceof BlockType) {
-            nextBlockId = id + 1;
+        if (extraTypes.putIfAbsent(key.toString(), type) == null) {
+            type.setId(id);
+            if (block) {
+                nextBlockId++;
+            } else {
+                nextItemId++;
+            }
+            return true;
         } else {
-            nextItemId = id + 1;
+            return false;
         }
     }
 
+    @Deprecated
     private ItemType createDefault(int id) {
-        Material material = Material.getMaterial(id);
-        if (material == null || id == 0) {
+        return createDefault(Material.getMaterial(id));
+    }
+
+    private ItemType createDefault(Material material) {
+        if (material == null || material == Material.AIR) {
             return null;
         }
 
@@ -551,28 +561,30 @@ public final class ItemTable {
     ////////////////////////////////////////////////////////////////////////////
     // Type access
 
+    @Deprecated
     public ItemType getItem(int id) {
-        ItemType type = idToType.get(id);
+        return getItem(Material.getMaterial(id));
+    }
+
+    public ItemType getItem(Material mat) {
+        ItemType type = materialToType.get(mat);
         if (type == null) {
-            type = createDefault(id);
+            type = createDefault(mat);
         }
         return type;
     }
 
-    public ItemType getItem(Material mat) {
-        return getItem(mat.getId());
+    @Deprecated
+    public BlockType getBlock(int id) {
+        return getBlock(Material.getMaterial(id));
     }
 
-    public BlockType getBlock(int id) {
-        ItemType itemType = getItem(id);
+    public BlockType getBlock(Material mat) {
+        ItemType itemType = getItem(mat);
         if (itemType instanceof BlockType) {
             return (BlockType) itemType;
         }
         return null;
-    }
-
-    public BlockType getBlock(Material mat) {
-        return getBlock(mat.getId());
     }
 
 }

--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -538,11 +538,6 @@ public final class ItemTable {
         }
     }
 
-    @Deprecated
-    private ItemType createDefault(int id) {
-        return createDefault(Material.getMaterial(id));
-    }
-
     private ItemType createDefault(Material material) {
         if (material == null || material == Material.AIR) {
             return null;

--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -1,5 +1,6 @@
 package net.glowstone.block;
 
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import net.glowstone.block.blocktype.BlockAnvil;
@@ -149,7 +150,7 @@ public final class ItemTable {
         INSTANCE.registerBuiltins();
     }
 
-    private final Map<Material, ItemType> materialToType = new HashMap<>(512);
+    private final EnumMap<Material, ItemType> materialToType = new EnumMap<>(Material.class);
     private final Map<String, ItemType> extraTypes = new HashMap<>();
     private int nextBlockId;
     private int nextItemId;

--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -538,6 +538,11 @@ public final class ItemTable {
         }
     }
 
+    @Deprecated
+    private ItemType createDefault(int id) {
+        return createDefault(Material.getMaterial(id));
+    }
+
     private ItemType createDefault(Material material) {
         if (material == null || material == Material.AIR) {
             return null;

--- a/src/main/java/net/glowstone/block/blocktype/BlockButton.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockButton.java
@@ -66,7 +66,7 @@ public class BlockButton extends BlockAttachable {
         if (target.getType().isSolid()) {
             for (BlockFace face2 : ADJACENT) {
                 GlowBlock target2 = target.getRelative(face2);
-                BlockType notifyType = itemTable.getBlock(target2.getTypeId());
+                BlockType notifyType = itemTable.getBlock(target2.getType());
                 if (notifyType != null) {
                     if (target2.getFace(block) == null) {
                         notifyType

--- a/src/main/java/net/glowstone/block/blocktype/BlockLever.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLever.java
@@ -64,7 +64,7 @@ public class BlockLever extends BlockAttachable {
         if (target.getType().isSolid()) {
             for (BlockFace face2 : ADJACENT) {
                 GlowBlock target2 = target.getRelative(face2);
-                BlockType notifyType = itemTable.getBlock(target2.getTypeId());
+                BlockType notifyType = itemTable.getBlock(target2.getType());
                 if (notifyType != null) {
                     if (target2.getFace(block) == null) {
                         notifyType

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstone.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstone.java
@@ -266,7 +266,7 @@ public class BlockRedstone extends BlockNeedsAttached {
             if (target.getType().isSolid()) {
                 for (BlockFace face2 : ADJACENT) {
                     GlowBlock target2 = target.getRelative(face2);
-                    BlockType notifyType = itemTable.getBlock(target2.getTypeId());
+                    BlockType notifyType = itemTable.getBlock(target2.getType());
                     if (notifyType != null) {
                         if (target2.getFace(block) == null) {
                             notifyType

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneRepeater.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneRepeater.java
@@ -78,7 +78,7 @@ public class BlockRedstoneRepeater extends BlockNeedsAttached {
         if (target.getType().isSolid()) {
             for (BlockFace face2 : ADJACENT) {
                 GlowBlock target2 = target.getRelative(face2);
-                BlockType notifyType = itemTable.getBlock(target2.getTypeId());
+                BlockType notifyType = itemTable.getBlock(target2.getType());
                 if (notifyType != null) {
                     if (target2.getFace(block) == null) {
                         notifyType

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneTorch.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneTorch.java
@@ -97,7 +97,7 @@ public class BlockRedstoneTorch extends BlockNeedsAttached {
         if (target.getType().isSolid()) {
             for (BlockFace face2 : ADJACENT) {
                 GlowBlock target2 = target.getRelative(face2);
-                BlockType notifyType = itemTable.getBlock(target2.getTypeId());
+                BlockType notifyType = itemTable.getBlock(target2.getType());
                 if (notifyType != null) {
                     if (target2.getFace(block) == null) {
                         notifyType

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -320,13 +320,13 @@ public class BlockType extends ItemType {
         }
 
         // check whether the block clicked against should absorb the placement
-        BlockType againstType = ItemTable.instance().getBlock(against.getTypeId());
+        BlockType againstType = ItemTable.instance().getBlock(against.getType());
         if (againstType != null) {
             if (againstType.canAbsorb(against, face, holding)) {
                 target = against;
             } else if (!target.isEmpty()) {
                 // air can always be overridden
-                BlockType targetType = ItemTable.instance().getBlock(target.getTypeId());
+                BlockType targetType = ItemTable.instance().getBlock(target.getType());
                 if (targetType != null && !targetType.canOverride(target, face, holding)) {
                     return;
                 }

--- a/src/main/java/net/glowstone/block/itemtype/ItemFilledBucket.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFilledBucket.java
@@ -37,7 +37,7 @@ public class ItemFilledBucket extends ItemType {
         if (againstBlockType.canAbsorb(target, face, holding)) {
             target = against;
         } else if (!target.isEmpty()) {
-            BlockType targetType = ItemTable.instance().getBlock(target.getTypeId());
+            BlockType targetType = ItemTable.instance().getBlock(target.getType());
             if (!targetType.canOverride(target, face, holding)) {
                 return;
             }

--- a/src/main/java/net/glowstone/block/itemtype/ItemType.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemType.java
@@ -46,13 +46,14 @@ public class ItemType {
     @Deprecated
     public final void setId(int id) {
         if (material != null && this.id != -1) {
-            throw new IllegalStateException("Material is already set in " + this);
+            throw new IllegalStateException("ID is already set in " + this);
         }
-        this.id = id;
         material = Material.getMaterial(id);
 
-        if (material != null) {
-            maxStackSize = material.getMaxStackSize();
+        if (material == null) {
+            this.id = id;
+        } else {
+            setMaterial(material);
         }
     }
 

--- a/src/main/java/net/glowstone/block/itemtype/ItemType.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemType.java
@@ -48,12 +48,12 @@ public class ItemType {
         if (material != null && this.id != -1) {
             throw new IllegalStateException("ID is already set in " + this);
         }
-        material = Material.getMaterial(id);
+        Material mat = Material.getMaterial(id);
 
-        if (material == null) {
+        if (mat == null) {
             this.id = id;
         } else {
-            setMaterial(material);
+            setMaterial(mat);
         }
     }
 

--- a/src/main/java/net/glowstone/block/itemtype/ItemType.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemType.java
@@ -1,5 +1,6 @@
 package net.glowstone.block.itemtype;
 
+import com.google.common.base.Preconditions;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.ItemTable;
 import net.glowstone.block.blocktype.BlockType;
@@ -16,6 +17,7 @@ import org.bukkit.util.Vector;
 public class ItemType {
 
     private int id = -1;
+    private Material material;
 
     private BlockType placeAs;
 
@@ -28,26 +30,29 @@ public class ItemType {
      * Get the id assigned to this ItemType.
      *
      * @return The corresponding id.
+     * @deprecated Magic value
      */
+    @Deprecated
     public final int getId() {
-        return id;
+        return material == null ? id : material.getId();
     }
 
     /**
      * Assign an id number to this ItemType (for internal use only).
      *
      * @param id The internal item id for this item.
+     * @deprecated Magic value
      */
+    @Deprecated
     public final void setId(int id) {
-        if (this.id != -1) {
-            throw new IllegalStateException("Id is already set in " + this);
+        if (material != null && this.id != -1) {
+            throw new IllegalStateException("Material is already set in " + this);
         }
         this.id = id;
+        material = Material.getMaterial(id);
 
-        // pull a few defaults from Material if possible
-        Material mat = getMaterial();
-        if (mat != null) {
-            maxStackSize = mat.getMaxStackSize();
+        if (material != null) {
+            maxStackSize = material.getMaxStackSize();
         }
     }
 
@@ -57,7 +62,22 @@ public class ItemType {
      * @return The corresponding Material.
      */
     public final Material getMaterial() {
-        return Material.getMaterial(getId());
+        return material;
+    }
+
+    /**
+     * Assign an material to this ItemType (for internal use only).
+     *
+     * @param material The internal material for this item.
+     */
+    public final void setMaterial(Material material) {
+        if (this.material != null && id != -1) {
+            throw new IllegalStateException("Material is already set in " + this);
+        }
+        Preconditions.checkNotNull(material);
+        this.material = material;
+        id = material.getId();
+        maxStackSize = material.getMaxStackSize();
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/block/itemtype/ItemType.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemType.java
@@ -38,7 +38,7 @@ public class ItemType {
     }
 
     /**
-     * Assign an id number to this ItemType (for internal use only).
+     * Assign an item ID to this ItemType (for internal use only).
      *
      * @param id The internal item id for this item.
      * @deprecated Magic value
@@ -46,13 +46,14 @@ public class ItemType {
     @Deprecated
     public final void setId(int id) {
         if (material != null && this.id != -1) {
-            throw new IllegalStateException("Material is already set in " + this);
+            throw new IllegalStateException("ID is already set in " + this);
         }
-        this.id = id;
         material = Material.getMaterial(id);
 
-        if (material != null) {
-            maxStackSize = material.getMaxStackSize();
+        if (material == null) {
+            this.id = id;
+        } else {
+            setMaterial(material);
         }
     }
 

--- a/src/main/java/net/glowstone/block/itemtype/ItemType.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemType.java
@@ -66,7 +66,7 @@ public class ItemType {
     }
 
     /**
-     * Assign an material to this ItemType (for internal use only).
+     * Assign a Material to this ItemType (for internal use only).
      *
      * @param material The internal material for this item.
      */

--- a/src/main/java/net/glowstone/block/itemtype/ItemType.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemType.java
@@ -46,14 +46,13 @@ public class ItemType {
     @Deprecated
     public final void setId(int id) {
         if (material != null && this.id != -1) {
-            throw new IllegalStateException("ID is already set in " + this);
+            throw new IllegalStateException("Material is already set in " + this);
         }
-        Material mat = Material.getMaterial(id);
+        this.id = id;
+        material = Material.getMaterial(id);
 
-        if (mat == null) {
-            this.id = id;
-        } else {
-            setMaterial(mat);
+        if (material != null) {
+            maxStackSize = material.getMaxStackSize();
         }
     }
 
@@ -67,7 +66,7 @@ public class ItemType {
     }
 
     /**
-     * Assign a Material to this ItemType (for internal use only).
+     * Assign an material to this ItemType (for internal use only).
      *
      * @param material The internal material for this item.
      */

--- a/src/main/java/net/glowstone/block/itemtype/ItemType.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemType.java
@@ -182,7 +182,7 @@ public class ItemType {
 
     @Override
     public final String toString() {
-        return getClass().getSimpleName() + "{" + getId() + " -> " + getMaterial() + "}";
+        return getClass().getSimpleName() + "{" + (getMaterial() == null ? getId() : getMaterial())  + "}";
     }
 
     /**

--- a/src/main/java/net/glowstone/chunk/GlowChunk.java
+++ b/src/main/java/net/glowstone/chunk/GlowChunk.java
@@ -334,7 +334,7 @@ public final class GlowChunk implements Chunk {
             case DAYLIGHT_DETECTOR_INVERTED:
             case REDSTONE_COMPARATOR_OFF:
             case REDSTONE_COMPARATOR_ON:
-                BlockType blockType = ItemTable.instance().getBlock(type);
+                BlockType blockType = ItemTable.instance().getBlock(material);
                 if (blockType == null) {
                     return null;
                 }

--- a/src/main/java/net/glowstone/dispenser/BucketDispenseBehavior.java
+++ b/src/main/java/net/glowstone/dispenser/BucketDispenseBehavior.java
@@ -33,7 +33,7 @@ public class BucketDispenseBehavior extends DefaultDispenseBehavior {
 
     private boolean canPlace(GlowBlock target, BlockFace facing, ItemStack stack) {
         if (!target.isEmpty()) {
-            BlockType targetType = ItemTable.instance().getBlock(target.getTypeId());
+            BlockType targetType = ItemTable.instance().getBlock(target.getType());
             //noinspection ConstantConditions
             if (!targetType.canOverride(target, facing.getOppositeFace(), stack)) {
                 return false;


### PR DESCRIPTION
This converts the `ItemTable` and its usage to be based on `Material` types, rather than item IDs. This partially future proofs Glowstone and also prevents autoboxing `Integer`s in the type map.

To support custom materials, a new mapping from namespaced keys to `ItemType`s has been added.