### PR TITLE
Clean up and fix several issues regarding player profiles

### DIFF
--- a/src/main/java/net/glowstone/GlowOfflinePlayer.java
+++ b/src/main/java/net/glowstone/GlowOfflinePlayer.java
@@ -22,7 +22,7 @@ import org.bukkit.entity.Player;
 public final class GlowOfflinePlayer implements OfflinePlayer {
 
     private final GlowServer server;
-    private PlayerProfile profile;
+    private final PlayerProfile profile;
 
     private boolean hasPlayed;
     private long firstPlayed;
@@ -31,7 +31,7 @@ public final class GlowOfflinePlayer implements OfflinePlayer {
     private Location bedSpawn;
 
     /**
-     * Create a new offline player for the given name. If possible, the player's UUID will be found and then their data.
+     * Create a new offline player for the given name. If possible, the player's data will be loaded.
      *
      * @param server The server of the offline player. Must not be null.
      * @param profile The profile associated with the player. Must not be null.
@@ -41,20 +41,6 @@ public final class GlowOfflinePlayer implements OfflinePlayer {
         checkNotNull(profile, "profile must not be null");
         this.server = server;
         this.profile = profile;
-        loadData();
-    }
-
-    /**
-     * Create a new offline player for the given UUID. If possible, the player's data (including name) will be loaded based on the UUID.
-     *
-     * @param server The server of the offline player. Must not be null.
-     * @param name The name of the player. Must not be null.
-     */
-    public GlowOfflinePlayer(GlowServer server, String name) {
-        checkNotNull(server, "server must not be null");
-        checkNotNull(name, "name cannot be null");
-        this.server = server;
-        profile = PlayerProfile.getProfile(name);
         loadData();
     }
 
@@ -132,11 +118,7 @@ public final class GlowOfflinePlayer implements OfflinePlayer {
 
     @Override
     public Player getPlayer() {
-        if (getUniqueId() != null) {
-            return server.getPlayer(getUniqueId());
-        } else {
-            return server.getPlayerExact(getName());
-        }
+        return server.getPlayer(getUniqueId());
     }
 
     @Override

--- a/src/main/java/net/glowstone/GlowOfflinePlayer.java
+++ b/src/main/java/net/glowstone/GlowOfflinePlayer.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import net.glowstone.entity.meta.profile.PlayerProfile;
 import net.glowstone.entity.meta.profile.ProfileCache;
 import net.glowstone.io.PlayerDataService.PlayerReader;
@@ -45,17 +46,16 @@ public final class GlowOfflinePlayer implements OfflinePlayer {
     }
 
     /**
-     * Create a new offline player for the given UUID. If possible, the player's data (including name) will be loaded based on the UUID.
+     * Returns a Future for a GlowOfflinePlayer by UUID. If possible, the player's data (including name) will be loaded based on the UUID.
      *
      * @param server The server of the offline player. Must not be null.
      * @param uuid The UUID of the player. Must not be null.
+     * @return A {@link GlowOfflinePlayer} future.
      */
-    public GlowOfflinePlayer(GlowServer server, UUID uuid) {
+    public static CompletableFuture<GlowOfflinePlayer> getOfflinePlayer(GlowServer server, UUID uuid) {
         checkNotNull(server, "server must not be null");
         checkNotNull(uuid, "UUID must not be null");
-        this.server = server;
-        profile = ProfileCache.getProfile(uuid);
-        loadData();
+        return ProfileCache.getProfile(uuid).thenApplyAsync((profile) -> new GlowOfflinePlayer(server, profile));
     }
 
     @SuppressWarnings("UnusedDeclaration")

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1687,8 +1687,12 @@ public final class GlowServer implements Server {
     @Deprecated
     public OfflinePlayer getOfflinePlayer(String name) {
         try {
-            // probably blocking, limited to five seconds
-            return getOfflinePlayerAsync(name).get(5, TimeUnit.SECONDS);
+            // probably blocking, timeout depending on config setting
+            if (config.getInt(Key.PROFILE_LOOKUP_TIMEOUT) <= 0) {
+                return getOfflinePlayerAsync(name).get();
+            } else {
+                return getOfflinePlayerAsync(name).get(config.getInt(Key.PROFILE_LOOKUP_TIMEOUT), TimeUnit.SECONDS);
+            }
         } catch (InterruptedException | ExecutionException ex) {
             GlowServer.logger.log(Level.SEVERE, "UUID lookup interrupted: ", ex);
         } catch (TimeoutException ex) {
@@ -1701,7 +1705,12 @@ public final class GlowServer implements Server {
     @Override
     public OfflinePlayer getOfflinePlayer(UUID uuid) {
         try {
-            return getOfflinePlayerAsync(uuid).get(5, TimeUnit.SECONDS); // todo: should we timeout? If yes, how long?
+            // probably blocking, timeout depending on config setting
+            if (config.getInt(Key.PROFILE_LOOKUP_TIMEOUT) <= 0) {
+                return getOfflinePlayerAsync(uuid).get();
+            } else {
+                return getOfflinePlayerAsync(uuid).get(config.getInt(Key.PROFILE_LOOKUP_TIMEOUT), TimeUnit.SECONDS);
+            }
         } catch (InterruptedException | ExecutionException ex) {
             GlowServer.logger.log(Level.SEVERE, "Profile lookup interrupted: ", ex);
         } catch (TimeoutException ex) {

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1566,7 +1566,7 @@ public final class GlowServer implements Server {
 
     @Override
     public Set<OfflinePlayer> getOperators() {
-        return opsList.getUUIDs().stream().map(this::getOfflinePlayer).collect(Collectors.toSet());
+        return opsList.getProfiles().stream().map(this::getOfflinePlayer).collect(Collectors.toSet());
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -1675,21 +1675,13 @@ public final class GlowServer implements Server {
     @Override
     @Deprecated
     public OfflinePlayer getOfflinePlayer(String name) {
-        Player onlinePlayer = getPlayerExact(name);
-        if (onlinePlayer != null) {
-            return onlinePlayer;
+        // probably blocking
+        PlayerProfile profile = PlayerProfile.getProfile(name);
+        if (profile == null) {
+            return getOfflinePlayer(new PlayerProfile(name, UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes())));
+        } else {
+            return getOfflinePlayer(profile);
         }
-        OfflinePlayer result = getPlayerExact(name);
-        if (result == null) {
-            //probably blocking (same player once per minute)
-            PlayerProfile profile = PlayerProfile.getProfile(name);
-            if (profile == null) {
-                result = getOfflinePlayer(new PlayerProfile(name, UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes())));
-            } else {
-                result = getOfflinePlayer(profile);
-            }
-        }
-        return result;
     }
 
     @Override
@@ -1697,12 +1689,9 @@ public final class GlowServer implements Server {
         Player onlinePlayer = getPlayer(uuid);
         if (onlinePlayer != null) {
             return onlinePlayer;
+        } else {
+            return new GlowOfflinePlayer(this, uuid);
         }
-        OfflinePlayer result = getPlayer(uuid);
-        if (result == null) {
-            result = new GlowOfflinePlayer(this, uuid);
-        }
-        return result;
     }
 
     @Override

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1717,6 +1717,11 @@ public final class GlowServer implements Server {
      * @return a {@link GlowOfflinePlayer} future for the given name.
      */
     public CompletableFuture<OfflinePlayer> getOfflinePlayerAsync(String name) {
+        Player onlinePlayer = getPlayerExact(name);
+        if (onlinePlayer != null) {
+            return CompletableFuture.completedFuture(onlinePlayer);
+        }
+
         return PlayerProfile.getProfile(name).thenApplyAsync((profile) -> {
             if (profile == null) {
                 return getOfflinePlayerFallback(name);

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1690,9 +1690,9 @@ public final class GlowServer implements Server {
             // probably blocking, limited to five seconds
             return getOfflinePlayerAsync(name).get(5, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException ex) {
-            Logger.getLogger(GlowServer.class.getName()).log(Level.SEVERE, "UUID lookup interrupted: ", ex);
+            GlowServer.logger.log(Level.SEVERE, "UUID lookup interrupted: ", ex);
         } catch (TimeoutException ex) {
-            Logger.getLogger(GlowServer.class.getName()).log(Level.WARNING, "UUID lookup timeout: ", ex);
+            GlowServer.logger.log(Level.WARNING, "UUID lookup timeout: ", ex);
         }
 
         return getOfflinePlayerFallback(name);
@@ -1703,9 +1703,9 @@ public final class GlowServer implements Server {
         try {
             return getOfflinePlayerAsync(uuid).get(5, TimeUnit.SECONDS); // todo: should we timeout? If yes, how long?
         } catch (InterruptedException | ExecutionException ex) {
-            Logger.getLogger(GlowServer.class.getName()).log(Level.SEVERE, "Profile lookup interrupted: ", ex);
+            GlowServer.logger.log(Level.SEVERE, "Profile lookup interrupted: ", ex);
         } catch (TimeoutException ex) {
-            Logger.getLogger(GlowServer.class.getName()).log(Level.WARNING, "Profile lookup timeout: ", ex);
+            GlowServer.logger.log(Level.WARNING, "Profile lookup timeout: ", ex);
         }
         return new GlowOfflinePlayer(this, new PlayerProfile(null, uuid));
     }

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1384,6 +1384,15 @@ public final class GlowServer implements Server {
         return config.getBoolean(Key.ANNOUNCE_ACHIEVEMENTS);
     }
 
+    /**
+     * Get the time after a profile lookup should be cancelled.
+     *
+     * @return The maximum lookup time in seconds or zero to never cancel the lookup.
+     */
+    public int getProfileLookupTimeout() {
+        return config.getInt(Key.PROFILE_LOOKUP_TIMEOUT);
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Static server properties
 
@@ -1688,10 +1697,10 @@ public final class GlowServer implements Server {
     public OfflinePlayer getOfflinePlayer(String name) {
         try {
             // probably blocking, timeout depending on config setting
-            if (config.getInt(Key.PROFILE_LOOKUP_TIMEOUT) <= 0) {
+            if (getProfileLookupTimeout() <= 0) {
                 return getOfflinePlayerAsync(name).get();
             } else {
-                return getOfflinePlayerAsync(name).get(config.getInt(Key.PROFILE_LOOKUP_TIMEOUT), TimeUnit.SECONDS);
+                return getOfflinePlayerAsync(name).get(getProfileLookupTimeout(), TimeUnit.SECONDS);
             }
         } catch (InterruptedException | ExecutionException ex) {
             GlowServer.logger.log(Level.SEVERE, "UUID lookup interrupted: ", ex);
@@ -1706,10 +1715,10 @@ public final class GlowServer implements Server {
     public OfflinePlayer getOfflinePlayer(UUID uuid) {
         try {
             // probably blocking, timeout depending on config setting
-            if (config.getInt(Key.PROFILE_LOOKUP_TIMEOUT) <= 0) {
+            if (getProfileLookupTimeout() <= 0) {
                 return getOfflinePlayerAsync(uuid).get();
             } else {
-                return getOfflinePlayerAsync(uuid).get(config.getInt(Key.PROFILE_LOOKUP_TIMEOUT), TimeUnit.SECONDS);
+                return getOfflinePlayerAsync(uuid).get(getProfileLookupTimeout(), TimeUnit.SECONDS);
             }
         } catch (InterruptedException | ExecutionException ex) {
             GlowServer.logger.log(Level.SEVERE, "Profile lookup interrupted: ", ex);

--- a/src/main/java/net/glowstone/block/entity/SkullEntity.java
+++ b/src/main/java/net/glowstone/block/entity/SkullEntity.java
@@ -32,12 +32,12 @@ public class SkullEntity extends BlockEntity {
         }
         if (tag.containsKey("Owner")) {
             CompoundTag ownerTag = tag.getCompound("Owner");
-            owner = PlayerProfile.fromNBT(ownerTag);
+            owner = PlayerProfile.fromNBT(ownerTag).join();
         } else if (tag.containsKey("ExtraType")) {
             // Pre-1.8 uses just a name, instead of a profile object
             String name = tag.getString("ExtraType");
             if (name != null && !name.isEmpty()) {
-                owner = PlayerProfile.getProfile(name);
+                owner = PlayerProfile.getProfile(name).join();
             }
         }
     }

--- a/src/main/java/net/glowstone/block/entity/state/GlowSkull.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowSkull.java
@@ -58,7 +58,7 @@ public class GlowSkull extends GlowBlockState implements Skull {
 
     @Override
     public boolean setOwner(String name) {
-        PlayerProfile owner = PlayerProfile.getProfile(name);
+        PlayerProfile owner = PlayerProfile.getProfile(name).join();
         if (owner == null) {
             return false;
         }

--- a/src/main/java/net/glowstone/command/minecraft/BanCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/BanCommand.java
@@ -23,7 +23,7 @@ public class BanCommand extends VanillaCommand {
             return false;
         }
         if (args.length > 0) {
-            if (PlayerProfile.getProfile(args[0]) == null) {
+            if (PlayerProfile.getProfile(args[0]).join() == null) {
                 sender.sendMessage(ChatColor.RED + "Could not ban player " + args[0]);
                 return false;
             }

--- a/src/main/java/net/glowstone/command/minecraft/DeopCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/DeopCommand.java
@@ -3,6 +3,7 @@ package net.glowstone.command.minecraft;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
@@ -29,8 +30,12 @@ public class DeopCommand extends VanillaCommand {
         }
         String name = args[0];
         OfflinePlayer player = Bukkit.getOfflinePlayer(name);
-        player.setOp(false);
-        sender.sendMessage("Deopped " + player.getName());
+        if (player.isOp()) {
+            player.setOp(false);
+            sender.sendMessage("Deopped " + player.getName());
+        } else {
+            sender.sendMessage("Could not deop " + player.getName());
+        }
         return true;
     }
 
@@ -39,11 +44,10 @@ public class DeopCommand extends VanillaCommand {
         throws IllegalArgumentException {
         if (args.length == 1) {
             List<String> operators = new ArrayList<>();
-            Bukkit.getOperators().stream().filter(OfflinePlayer::isOp)
-                .filter(player -> player.getName() != null)
-                .forEach(player -> operators.add(player.getName()));
-            return (List) StringUtil
-                .copyPartialMatches(args[0], operators, new ArrayList(operators.size()));
+            Bukkit.getOperators().stream().map(OfflinePlayer::getName)
+                    .filter(Objects::nonNull)
+                    .forEach(player -> operators.add(player));
+            return StringUtil.copyPartialMatches(args[0], operators, new ArrayList<>(operators.size()));
         } else if (args.length > 1) {
             return Collections.emptyList();
         }

--- a/src/main/java/net/glowstone/entity/meta/profile/PlayerDataFetcher.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/PlayerDataFetcher.java
@@ -45,7 +45,7 @@ class PlayerDataFetcher {
             is = conn.getInputStream();
         } catch (IOException e) {
             GlowServer.logger.log(Level.WARNING, "Failed to look up profile");
-            return null;
+            return new PlayerProfile(null, uuid);
         }
 
         JSONObject json;
@@ -57,10 +57,10 @@ class PlayerDataFetcher {
             }
         } catch (ParseException e) {
             GlowServer.logger.log(Level.WARNING, "Failed to parse profile response", e);
-            return null;
+            return new PlayerProfile(null, uuid);
         } catch (IOException e) {
             GlowServer.logger.log(Level.WARNING, "Failed to look up profile", e);
-            return null;
+            return new PlayerProfile(null, uuid);
         }
         return PlayerProfile.fromJson(json);
     }

--- a/src/main/java/net/glowstone/entity/meta/profile/PlayerDataFetcher.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/PlayerDataFetcher.java
@@ -34,7 +34,7 @@ class PlayerDataFetcher {
      * Look up the PlayerProfile for a given UUID.
      *
      * @param uuid The UUID to look up.
-     * @return The resulting PlayerProfile, or null on failure.
+     * @return The resulting PlayerProfile, contains a null name on failure.
      */
     public static PlayerProfile getProfile(UUID uuid) {
         InputStream is;

--- a/src/main/java/net/glowstone/entity/meta/profile/PlayerProfile.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/PlayerProfile.java
@@ -11,11 +11,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import lombok.Data;
 import net.glowstone.GlowServer;
-import net.glowstone.entity.GlowPlayer;
 import net.glowstone.util.UuidUtils;
 import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
@@ -71,11 +69,6 @@ public class PlayerProfile {
     public static CompletableFuture<PlayerProfile> getProfile(String name) {
         if (name == null || name.length() > MAX_USERNAME_LENGTH || name.isEmpty()) {
             return CompletableFuture.completedFuture(null);
-        }
-
-        Player player = Bukkit.getServer().getPlayerExact(name);
-        if (player != null) {
-            return CompletableFuture.completedFuture(((GlowPlayer) player).getProfile());
         }
 
         if (Bukkit.getServer().getOnlineMode() || ((GlowServer) Bukkit.getServer()).getProxySupport()) {

--- a/src/main/java/net/glowstone/entity/meta/profile/PlayerProfile.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/PlayerProfile.java
@@ -87,7 +87,6 @@ public class PlayerProfile {
                 }
             });
         }
-        GlowServer.logger.warning("Unable to get UUID for username: " + name);
         return CompletableFuture.completedFuture(null);
     }
 

--- a/src/main/java/net/glowstone/entity/meta/profile/ProfileCache.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/ProfileCache.java
@@ -4,55 +4,44 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.logging.Level;
-import net.glowstone.GlowServer;
 
 /**
  * Cached methods for accessing Mojang servers to find UUIDs and player profiles.
  */
 public class ProfileCache {
 
-    private static Map<String, UUID> uuidCache = new HashMap<>();
-    private static Map<UUID, PlayerProfile> profileCache = new HashMap<>();
+    private static final Map<String, UUID> uuidCache = new HashMap<>();
+    private static final Map<UUID, PlayerProfile> profileCache = new HashMap<>();
 
     /**
      * Look up the PlayerProfile for a given UUID.
      *
      * @param uuid The UUID to look up.
-     * @return The resulting PlayerProfile, or null on failure.
+     * @return A PlayerProfile future, contains a null name if the lookup failed.
      */
-    public static PlayerProfile getProfile(UUID uuid) {
+    public static CompletableFuture<PlayerProfile> getProfile(UUID uuid) {
         if (profileCache.containsKey(uuid)) {
-            return profileCache.get(uuid);
+            return CompletableFuture.completedFuture(profileCache.get(uuid));
         }
-        profileCache.put(uuid, PlayerDataFetcher.getProfile(uuid));
-        return profileCache.get(uuid);
+        CompletableFuture<PlayerProfile> profileFuture = CompletableFuture
+                .supplyAsync(() -> PlayerDataFetcher.getProfile(uuid));
+        profileFuture.thenAccept(profile -> profileCache.put(uuid, profile));
+        return profileFuture;
     }
 
     /**
      * Look up the UUID for a given username.
      *
      * @param playerName The name to look up.
-     * @return The UUID, or null on failure.
+     * @return A UUID future, UUID may be null on failure.
      */
-    public static UUID getUUID(String playerName) {
+    public static CompletableFuture<UUID> getUUID(String playerName) {
         if (uuidCache.containsKey(playerName)) {
-            return uuidCache.get(playerName);
+            return CompletableFuture.completedFuture(uuidCache.get(playerName));
         }
-        UUID uuid = null;
         CompletableFuture<UUID> uuidFuture = CompletableFuture
-            .supplyAsync(() -> PlayerDataFetcher.getUUID(playerName));
-        uuidFuture.thenAcceptAsync(uid -> uuidCache.put(playerName, uid));
-        try {
-            uuid = uuidFuture.get(5, TimeUnit.SECONDS);
-        } catch (InterruptedException | ExecutionException e) {
-            GlowServer.logger.log(Level.SEVERE, "UUID Cache interrupted: ", e);
-        } catch (TimeoutException e) {
-            GlowServer.logger.log(Level.SEVERE, "UUID Cache lookup timed out: ", e);
-        }
-        return uuid;
+                .supplyAsync(() -> PlayerDataFetcher.getUUID(playerName));
+        uuidFuture.thenAccept(uid -> uuidCache.put(playerName, uid));
+        return uuidFuture;
     }
 }

--- a/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
@@ -67,9 +67,9 @@ public class GlowMetaSkull extends GlowMetaItem implements SkullMeta {
         super.readNbt(tag);
         if (tag.containsKey("SkullOwner")) {
             if (tag.isString("SkullOwner")) {
-                owner = PlayerProfile.getProfile(tag.getString("SkullOwner"));
+                owner = PlayerProfile.getProfile(tag.getString("SkullOwner")).join();
             } else if (tag.isCompound("SkullOwner")) {
-                owner = PlayerProfile.fromNBT(tag.getCompound("SkullOwner"));
+                owner = PlayerProfile.fromNBT(tag.getCompound("SkullOwner")).join();
             }
         }
     }
@@ -89,7 +89,7 @@ public class GlowMetaSkull extends GlowMetaItem implements SkullMeta {
 
     @Override
     public boolean setOwner(String name) {
-        PlayerProfile owner = PlayerProfile.getProfile(name);
+        PlayerProfile owner = PlayerProfile.getProfile(name).join();
         if (owner == null) {
             return false;
         }

--- a/src/main/java/net/glowstone/io/PlayerDataService.java
+++ b/src/main/java/net/glowstone/io/PlayerDataService.java
@@ -47,16 +47,6 @@ public interface PlayerDataService {
     Collection<OfflinePlayer> getOfflinePlayers();
 
     /**
-     * Locally look up the UUID of an offline player based on their name.
-     *
-     * <p>If no local player with the name was found, an offline-mode UUID is returned.
-     *
-     * @param name The name to look up.
-     * @return The UUID of the player.
-     */
-    UUID lookupUUID(String name);
-
-    /**
      * A piecewise reader for initializing new players. See {@link PlayerDataService#beginReadingData}.
      */
     interface PlayerReader extends AutoCloseable {

--- a/src/main/java/net/glowstone/io/PlayerDataService.java
+++ b/src/main/java/net/glowstone/io/PlayerDataService.java
@@ -2,6 +2,7 @@ package net.glowstone.io;
 
 import java.util.Collection;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
@@ -44,7 +45,7 @@ public interface PlayerDataService {
      *
      * @return All known offline players.
      */
-    Collection<OfflinePlayer> getOfflinePlayers();
+    CompletableFuture<Collection<OfflinePlayer>> getOfflinePlayers();
 
     /**
      * A piecewise reader for initializing new players. See {@link PlayerDataService#beginReadingData}.

--- a/src/main/java/net/glowstone/io/nbt/NbtPlayerDataService.java
+++ b/src/main/java/net/glowstone/io/nbt/NbtPlayerDataService.java
@@ -4,24 +4,19 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Level;
 import net.glowstone.GlowOfflinePlayer;
 import net.glowstone.GlowServer;
 import net.glowstone.entity.GlowPlayer;
-import net.glowstone.entity.meta.profile.ProfileCache;
 import net.glowstone.io.PlayerDataService;
 import net.glowstone.io.entity.EntityStorage;
 import net.glowstone.util.nbt.CompoundTag;
 import net.glowstone.util.nbt.NBTInputStream;
 import net.glowstone.util.nbt.NBTOutputStream;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
@@ -33,7 +28,6 @@ public class NbtPlayerDataService implements PlayerDataService {
 
     private final GlowServer server;
     private final File playerDir;
-    private Map<String, UUID> uuidCache = new HashMap<>();
 
     public NbtPlayerDataService(GlowServer server, File playerDir) {
         this.server = server;
@@ -80,32 +74,6 @@ public class NbtPlayerDataService implements PlayerDataService {
         }
 
         return result;
-    }
-
-    @Override
-    public UUID lookupUUID(String name) {
-        if (uuidCache.containsKey(name)) {
-            return uuidCache.get(name);
-        }
-
-        for (OfflinePlayer player : getOfflinePlayers()) {
-            if (name.equalsIgnoreCase(player.getName())) {
-                uuidCache.put(name, player.getUniqueId());
-                return player.getUniqueId();
-            }
-        }
-
-        // In online mode, find the Mojang UUID if possible
-        if (Bukkit.getServer().getOnlineMode() || ((GlowServer) Bukkit.getServer())
-            .getProxySupport()) {
-            UUID uuid = ProfileCache.getUUID(name);
-            if (uuid != null) {
-                return uuid;
-            }
-        }
-
-        // Fall back to the offline-mode UUID
-        return UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/src/main/java/net/glowstone/scoreboard/GlowTeam.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowTeam.java
@@ -9,8 +9,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import net.glowstone.GlowOfflinePlayer;
-import net.glowstone.GlowServer;
 import net.glowstone.net.message.play.scoreboard.ScoreboardTeamMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -208,8 +206,7 @@ public final class GlowTeam implements Team {
     public Set<OfflinePlayer> getPlayers() throws IllegalStateException {
         Set<OfflinePlayer> playerObjectSet = new HashSet<>(players.size());
         playerObjectSet.addAll(
-            players.stream().map(s -> new GlowOfflinePlayer((GlowServer) Bukkit.getServer(), s))
-                .collect(Collectors.toList()));
+            players.stream().map(Bukkit::getOfflinePlayer).collect(Collectors.toList()));
         return playerObjectSet;
     }
 

--- a/src/main/java/net/glowstone/util/bans/UuidListFile.java
+++ b/src/main/java/net/glowstone/util/bans/UuidListFile.java
@@ -7,7 +7,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import net.glowstone.entity.meta.profile.PlayerProfile;
 import net.glowstone.entity.meta.profile.ProfileCache;
 import org.bukkit.OfflinePlayer;
@@ -21,19 +20,12 @@ public final class UuidListFile extends JsonListFile {
         super(file);
     }
 
-    public List<UUID> getUUIDs() {
-        List<UUID> result = new ArrayList<>(entries.size());
-        result.addAll(entries.stream().map(baseEntry -> ((Entry) baseEntry).uuid)
-            .collect(Collectors.toList()));
-        return result;
-    }
-
     public List<PlayerProfile> getProfiles() {
         List<PlayerProfile> result = new ArrayList<>(entries.size());
         for (BaseEntry baseEntry : entries) {
             Entry entry = (Entry) baseEntry;
             PlayerProfile profile = ProfileCache.getProfile(entry.uuid);
-            if (profile == null) {
+            if (profile.getName() == null) {
                 profile = new PlayerProfile(entry.fallbackName, entry.uuid);
             }
             result.add(profile);
@@ -98,9 +90,7 @@ public final class UuidListFile extends JsonListFile {
         @Override
         public Map<String, String> write() {
             PlayerProfile profile = ProfileCache.getProfile(uuid);
-            String name =
-                profile != null ? profile.getName() != null ? profile.getName() : fallbackName
-                    : fallbackName;
+            String name = profile.getName() != null ? profile.getName() : fallbackName;
             Map<String, String> result = new HashMap<>(2);
             result.put("uuid", uuid.toString());
             result.put("name", name);

--- a/src/main/java/net/glowstone/util/bans/UuidListFile.java
+++ b/src/main/java/net/glowstone/util/bans/UuidListFile.java
@@ -24,7 +24,7 @@ public final class UuidListFile extends JsonListFile {
         List<PlayerProfile> result = new ArrayList<>(entries.size());
         for (BaseEntry baseEntry : entries) {
             Entry entry = (Entry) baseEntry;
-            PlayerProfile profile = ProfileCache.getProfile(entry.uuid);
+            PlayerProfile profile = ProfileCache.getProfile(entry.uuid).join();
             if (profile.getName() == null) {
                 profile = new PlayerProfile(entry.fallbackName, entry.uuid);
             }
@@ -89,7 +89,7 @@ public final class UuidListFile extends JsonListFile {
 
         @Override
         public Map<String, String> write() {
-            PlayerProfile profile = ProfileCache.getProfile(uuid);
+            PlayerProfile profile = ProfileCache.getProfile(uuid).join();
             String name = profile.getName() != null ? profile.getName() : fallbackName;
             Map<String, String> result = new HashMap<>(2);
             result.put("uuid", uuid.toString());

--- a/src/main/java/net/glowstone/util/config/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/config/ServerConfig.java
@@ -117,7 +117,7 @@ public final class ServerConfig {
         }
         int integer = config.getInt(key.path, (Integer) key.def);
         parameters.put(key, integer);
-        return config.getInt(key.path, (Integer) key.def);
+        return integer;
     }
 
     public boolean getBoolean(Key key) {

--- a/src/main/java/net/glowstone/util/config/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/config/ServerConfig.java
@@ -411,6 +411,7 @@ public final class ServerConfig {
         GRAPHICS_COMPUTE_ANY_DEVICE("advanced.graphics-compute.use-any-device", false),
         REGION_CACHE_SIZE("advanced.region-file.cache-size", 256),
         REGION_COMPRESSION("advanced.region-file.compression", true),
+        PROFILE_LOOKUP_TIMEOUT("advanced.profile-lookup-timeout", 5),
 
         // query rcon etc
         QUERY_ENABLED("extras.query-enabled", false, Migrate.PROPS, "enable-query"),


### PR DESCRIPTION
This fixes several problems and inconsistencies with player profiles, offline players and player data fetcher.

#### Removed name constructor in `GlowOfflinePlayer`
Calling `PlayerProfile.getProfile(name)` may return null, which initializes the `GlowOfflinePlayer` with a null profile. This is not allowed as many methods would throw a `NullPointerException` (including the loadData method called in constructor).
To get an `OfflinePlayer` by name `GlowServer.getOfflinePlayer(name)` should be used instead, as this method assigns the correct offline player uuid if no online uuid could be retrieved.

#### Simplified `GlowOfflinePlayer.getPlayer()`
UUID can never be null and getting player by name would cause a loop as `getName()` calls `getPlayer()`.

#### Simplified `GlowServer.getOfflinePlayer(name)` and `GlowServer.getOfflinePlayer(uuid)`
Calling getPlayer() two times is unnecessary

#### `PlayerDataFetcher.getProfile(uuid)` now returns a `PlayerProfile` with a null name in case of an error
Returning null in case of an error can cause `NullPointerExceptions` at several places (e.g. the profile in `GlowOfflinePlayer` could again be null)

#### Removed name lookup in `PlayerProfile` constructor
This could cause a loop in case of a lookup error: `ProfileCache.getProfile()` -> `PlayerDataFetcher.getProfile()` -> creates `PlayerProfile` with null name -> Lookup process starts again

#### Changes in `PlayerProfile.getProfile(name)`
At first, the name is looked up with `getPlayerExact()` instead of `getPlayer()` for obvious reasons.
Then, a uuid is only requested from Mojang when the server is in online mode.

#### Removed `PlayerDataService.lookupUUID()`
This method was not used anywhere and introduced another uuid cache like the one in `ProfileCache`. Further it performed the same actions as `GlowServer.getOfflinePlayer(name)` if the uuid was not found, but iterated over all OfflinePlayers before that, which is very inefficient.

#### Removed `UuidListFiles.getUUIDs()`
The use of this function can and should be replaced by `getProfiles()` as that method fills the name with a fallback version from the corresponding list file, if the uuid lookup failed (e.g. it allows to autocomplete in deop command if the uuid of an opped player does not exist)

I did my best to fix all uses of these functions wherever the change would break something, but please review the changes as I might have missed some cases.