### PR TITLE
Add a slf4j back-end to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.25</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>net.glowstone</groupId>
       <artifactId>glowkit</artifactId>
       <version>${api.version}</version>


### PR DESCRIPTION
Fixes #606
Used only by a library, not by Glowstone itself.