### PR TITLE
Refactor 4 Message classes to take Location constructor param

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowCreature.java
+++ b/src/main/java/net/glowstone/entity/GlowCreature.java
@@ -48,17 +48,11 @@ public class GlowCreature extends GlowLivingEntity implements Creature {
         List<Message> result = new LinkedList<>();
 
         // spawn mob
-        double x = location.getX();
-        double y = location.getY();
-        double z = location.getZ();
-        int yaw = Position.getIntYaw(location);
-        int pitch = Position.getIntPitch(location);
         result.add(
-            new SpawnMobMessage(id, getUniqueId(), type.getTypeId(), x, y, z, yaw, pitch, pitch, 0,
-                0, 0, metadata.getEntryList()));
+            new SpawnMobMessage(id, getUniqueId(), type.getTypeId(), location, metadata.getEntryList()));
 
         // head facing
-        result.add(new EntityHeadRotationMessage(id, yaw));
+        result.add(new EntityHeadRotationMessage(id, Position.getIntYaw(location)));
 
         // todo: equipment
         //result.add(createEquipmentMessage());

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -644,7 +644,7 @@ public abstract class GlowEntity implements Entity {
 
     /**
      * Creates a list of {@link Message}s which can be sent to a client to spawn this entity.
-     * Implementations in concrete subclasses may return an immutable list.
+     * Implementations in concrete subclasses may return a shallowly immutable list.
      *
      * @return A list of messages which can spawn this entity.
      */

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -643,9 +643,10 @@ public abstract class GlowEntity implements Entity {
     }
 
     /**
-     * Creates a {@link Message} which can be sent to a client to spawn this entity.
+     * Creates a list of {@link Message}s which can be sent to a client to spawn this entity.
+     * Implementations in concrete subclasses may return an immutable list.
      *
-     * @return A message which can spawn this entity.
+     * @return A list of messages which can spawn this entity.
      */
     public abstract List<Message> createSpawnMessage();
 

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -703,18 +703,20 @@ public abstract class GlowEntity implements Entity {
 
         boolean teleport = dx > Short.MAX_VALUE || dy > Short.MAX_VALUE || dz > Short.MAX_VALUE || dx < Short.MIN_VALUE || dy < Short.MIN_VALUE || dz < Short.MIN_VALUE;
 
-        int yaw = Position.getIntYaw(location);
-        int pitch = Position.getIntPitch(location);
-
         List<Message> result = new LinkedList<>();
         if (teleported || moved && teleport) {
-            result.add(new EntityTeleportMessage(id, x, y, z, yaw, pitch));
-        } else if (moved && rotated) {
-            result.add(new RelativeEntityPositionRotationMessage(id, (short) dx, (short) dy, (short) dz, yaw, pitch));
+            result.add(new EntityTeleportMessage(id, location));
+        } else if (rotated) {
+            int yaw = Position.getIntYaw(location);
+            int pitch = Position.getIntPitch(location);
+            if (moved) {
+                result.add(new RelativeEntityPositionRotationMessage(id,
+                        (short) dx, (short) dy, (short) dz, yaw, pitch));
+            } else {
+                result.add(new EntityRotationMessage(id, yaw, pitch));
+            }
         } else if (moved) {
             result.add(new RelativeEntityPositionMessage(id, (short) dx, (short) dy, (short) dz));
-        } else if (rotated) {
-            result.add(new EntityRotationMessage(id, yaw, pitch));
         }
 
         // send changed metadata

--- a/src/main/java/net/glowstone/entity/GlowTNTPrimed.java
+++ b/src/main/java/net/glowstone/entity/GlowTNTPrimed.java
@@ -1,15 +1,12 @@
 package net.glowstone.entity;
 
 import com.flowpowered.network.Message;
-
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import net.glowstone.EventFactory;
 import net.glowstone.Explosion;
 import net.glowstone.net.message.play.entity.SpawnObjectMessage;
-import net.glowstone.util.Position;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;

--- a/src/main/java/net/glowstone/entity/GlowTNTPrimed.java
+++ b/src/main/java/net/glowstone/entity/GlowTNTPrimed.java
@@ -1,6 +1,8 @@
 package net.glowstone.entity;
 
 import com.flowpowered.network.Message;
+
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -74,15 +76,7 @@ public class GlowTNTPrimed extends GlowExplosive implements TNTPrimed {
 
     @Override
     public List<Message> createSpawnMessage() {
-        double x = location.getX();
-        double y = location.getY();
-        double z = location.getZ();
-        int pitch = Position.getIntPitch(location);
-        int yaw = Position.getIntYaw(location);
-
-        LinkedList<Message> result = new LinkedList<>();
-        result.add(new SpawnObjectMessage(id, getUniqueId(), 50, x, y, z, pitch, yaw));
-        return result;
+        return Collections.singletonList(new SpawnObjectMessage(id, getUniqueId(), 50, location));
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
@@ -349,15 +349,9 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
 
     @Override
     public List<Message> createSpawnMessage() {
-        double x = location.getX();
-        double y = location.getY();
-        double z = location.getZ();
-
-        int yaw = Position.getIntYaw(location);
-        int pitch = Position.getIntPitch(location);
 
         return Arrays.asList(
-            new SpawnObjectMessage(id, UUID.randomUUID(), 78, x, y, z, pitch, yaw),
+            new SpawnObjectMessage(id, UUID.randomUUID(), 78, location),
             // TODO: once UUID is documented, actually use the appropriate ID here
             new EntityMetadataMessage(id, metadata.getEntryList()),
             new EntityEquipmentMessage(id, EntityEquipmentMessage.HELD_ITEM, getItemInHand()),

--- a/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
@@ -22,7 +22,6 @@ import net.glowstone.net.message.play.entity.SpawnObjectMessage;
 import net.glowstone.net.message.play.player.InteractEntityMessage;
 import net.glowstone.net.message.play.player.InteractEntityMessage.Action;
 import net.glowstone.util.InventoryUtil;
-import net.glowstone.util.Position;
 import org.bukkit.Effect;
 import org.bukkit.GameMode;
 import org.bukkit.Location;

--- a/src/main/java/net/glowstone/entity/objects/GlowBoat.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowBoat.java
@@ -42,15 +42,8 @@ public class GlowBoat extends GlowEntity implements Boat {
 
     @Override
     public List<Message> createSpawnMessage() {
-        double x = location.getX();
-        double y = location.getY();
-        double z = location.getZ();
-
-        int yaw = Position.getIntYaw(location);
-        int pitch = Position.getIntPitch(location);
-
         return Arrays.asList(
-            new SpawnObjectMessage(id, getUniqueId(), SpawnObjectMessage.BOAT, x, y, z, pitch, yaw),
+            new SpawnObjectMessage(id, getUniqueId(), SpawnObjectMessage.BOAT, location),
             new EntityMetadataMessage(id, metadata.getEntryList())
         );
     }

--- a/src/main/java/net/glowstone/entity/objects/GlowBoat.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowBoat.java
@@ -11,7 +11,6 @@ import net.glowstone.net.message.play.entity.EntityMetadataMessage;
 import net.glowstone.net.message.play.entity.SpawnObjectMessage;
 import net.glowstone.net.message.play.player.InteractEntityMessage;
 import net.glowstone.net.message.play.player.InteractEntityMessage.Action;
-import net.glowstone.util.Position;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/src/main/java/net/glowstone/entity/objects/GlowEnderCrystal.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowEnderCrystal.java
@@ -41,16 +41,8 @@ public class GlowEnderCrystal extends GlowEntity implements EnderCrystal {
 
     @Override
     public List<Message> createSpawnMessage() {
-        double x = location.getX();
-        double y = location.getY();
-        double z = location.getZ();
-
-        int yaw = Position.getIntYaw(location);
-        int pitch = Position.getIntPitch(location);
-
         return Arrays.asList(
-            new SpawnObjectMessage(id, getUniqueId(), SpawnObjectMessage.ENDER_CRYSTAL, x, y, z,
-                pitch, yaw),
+            new SpawnObjectMessage(id, getUniqueId(), SpawnObjectMessage.ENDER_CRYSTAL, location),
             new EntityMetadataMessage(id, metadata.getEntryList())
         );
     }

--- a/src/main/java/net/glowstone/entity/objects/GlowEnderCrystal.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowEnderCrystal.java
@@ -12,7 +12,6 @@ import net.glowstone.net.message.play.entity.EntityMetadataMessage;
 import net.glowstone.net.message.play.entity.SpawnObjectMessage;
 import net.glowstone.net.message.play.player.InteractEntityMessage;
 import net.glowstone.net.message.play.player.InteractEntityMessage.Action;
-import net.glowstone.util.Position;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World.Environment;

--- a/src/main/java/net/glowstone/entity/objects/GlowExperienceOrb.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowExperienceOrb.java
@@ -37,10 +37,8 @@ public class GlowExperienceOrb extends GlowEntity implements ExperienceOrb {
 
     @Override
     public List<Message> createSpawnMessage() {
-        Location location = getLocation();
         return Collections.singletonList(
-            new SpawnXpOrbMessage(getEntityId(), location.getX(), location.getY(), location.getZ(),
-                (short) getExperience()));
+            new SpawnXpOrbMessage(getEntityId(), getLocation(), (short) getExperience()));
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/objects/GlowFallingBlock.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowFallingBlock.java
@@ -1,7 +1,6 @@
 package net.glowstone.entity.objects;
 
 import com.flowpowered.network.Message;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -9,7 +8,6 @@ import net.glowstone.block.GlowBlock;
 import net.glowstone.block.entity.BlockEntity;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.net.message.play.entity.SpawnObjectMessage;
-import net.glowstone.util.Position;
 import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.Location;
 import org.bukkit.Material;

--- a/src/main/java/net/glowstone/entity/objects/GlowFallingBlock.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowFallingBlock.java
@@ -2,6 +2,7 @@ package net.glowstone.entity.objects;
 
 import com.flowpowered.network.Message;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import net.glowstone.block.GlowBlock;
@@ -112,19 +113,13 @@ public class GlowFallingBlock extends GlowEntity implements FallingBlock {
 
     @Override
     public List<Message> createSpawnMessage() {
-        double x = location.getX();
-        double y = location.getY();
-        double z = location.getZ();
-
-        int yaw = Position.getIntYaw(location);
-        int pitch = Position.getIntPitch(location);
 
         // Note the shift amount has changed previously,
         // if block data doesn't appear to work check this value.
         int blockIdData = getBlockId() | getBlockData() << 12;
 
-        return Arrays.asList(
-            new SpawnObjectMessage(id, getUniqueId(), 70, x, y, z, pitch, yaw, blockIdData)
+        return Collections.singletonList(
+            new SpawnObjectMessage(id, getUniqueId(), 70, location, blockIdData)
         );
     }
 

--- a/src/main/java/net/glowstone/entity/objects/GlowItem.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItem.java
@@ -159,10 +159,10 @@ public class GlowItem extends GlowEntity implements Item {
         int pitch = Position.getIntPitch(location);
 
         return Arrays.asList(
-            new SpawnObjectMessage(id, getUniqueId(), SpawnObjectMessage.ITEM, x, y, z, pitch, yaw),
+            new SpawnObjectMessage(id, getUniqueId(), SpawnObjectMessage.ITEM, location),
             new EntityMetadataMessage(id, metadata.getEntryList()),
             // these keep the client from assigning a random velocity
-            new EntityTeleportMessage(id, x, y, z, yaw, pitch),
+            new EntityTeleportMessage(id, location),
             new EntityVelocityMessage(id, getVelocity())
         );
     }

--- a/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
@@ -39,15 +39,8 @@ public abstract class GlowMinecart extends GlowEntity implements Minecart {
 
     @Override
     public List<Message> createSpawnMessage() {
-        double x = location.getX();
-        double y = location.getY();
-        double z = location.getZ();
-
-        int yaw = Position.getIntYaw(location);
-        int pitch = Position.getIntPitch(location);
-
         return Collections.singletonList(
-            new SpawnObjectMessage(id, getUniqueId(), 10, x, y, z, pitch, yaw, type.ordinal()));
+            new SpawnObjectMessage(id, getUniqueId(), 10, location, type.ordinal()));
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
@@ -8,7 +8,6 @@ import net.glowstone.entity.GlowPlayer;
 import net.glowstone.inventory.GlowInventory;
 import net.glowstone.net.message.play.entity.SpawnObjectMessage;
 import net.glowstone.net.message.play.player.InteractEntityMessage;
-import net.glowstone.util.Position;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;

--- a/src/main/java/net/glowstone/entity/passive/GlowBat.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowBat.java
@@ -25,18 +25,11 @@ public class GlowBat extends GlowAmbient implements Bat {
     public List<Message> createSpawnMessage() {
         List<Message> result = new LinkedList<>();
 
-        // spawn mob
-        double x = location.getX();
-        double y = location.getY();
-        double z = location.getZ();
-        int yaw = Position.getIntYaw(location);
-        int pitch = Position.getIntPitch(location);
         result.add(
-            new SpawnMobMessage(id, UUID.randomUUID(), getType().getTypeId(), x, y, z, yaw, pitch,
-                pitch, 0, 0, 0, metadata.getEntryList())); //TODO 1.9 - Real UUID
+            new SpawnMobMessage(id, UUID.randomUUID(), getType().getTypeId(), location, metadata.getEntryList())); //TODO 1.9 - Real UUID
 
         // head facing
-        result.add(new EntityHeadRotationMessage(id, yaw));
+        result.add(new EntityHeadRotationMessage(id, Position.getIntYaw(location)));
         return result;
     }
 

--- a/src/main/java/net/glowstone/net/message/play/entity/EntityTeleportMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/entity/EntityTeleportMessage.java
@@ -3,6 +3,8 @@ package net.glowstone.net.message.play.entity;
 import com.flowpowered.network.Message;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import net.glowstone.util.Position;
+import org.bukkit.Location;
 
 @Data
 @RequiredArgsConstructor
@@ -17,4 +19,8 @@ public final class EntityTeleportMessage implements Message {
         this(id, x, y, z, rotation, pitch, true);
     }
 
+    public EntityTeleportMessage(int id, Location location) {
+        this(id, location.getX(), location.getY(), location.getZ(), Position.getIntYaw(location),
+                Position.getIntPitch(location));
+    }
 }

--- a/src/main/java/net/glowstone/net/message/play/entity/SpawnMobMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/entity/SpawnMobMessage.java
@@ -4,9 +4,13 @@ import com.flowpowered.network.Message;
 import java.util.List;
 import java.util.UUID;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
 import net.glowstone.entity.meta.MetadataMap.Entry;
+import net.glowstone.util.Position;
+import org.bukkit.Location;
 
 @Data
+@RequiredArgsConstructor
 public final class SpawnMobMessage implements Message {
 
     private final int id;
@@ -16,4 +20,20 @@ public final class SpawnMobMessage implements Message {
     private final int rotation, pitch, headPitch, velX, velY, velZ;
     private final List<Entry> metadata;
 
+    /**
+     * Creates an instance based on a {@link Location}, with headPitch equal to pitch and with zero
+     * velocity.
+     * @param id the mob's ID within the world
+     * @param uuid the mob's UUID
+     * @param type the mob's network type ID
+     * @param location the mob's position, pitch and yaw
+     * @param metadata the mob's metadata
+     */
+    public SpawnMobMessage(int id, UUID uuid, int type, Location location, List<Entry> metadata) {
+        this(id, uuid, type,
+                location.getX(), location.getY(), location.getZ(),
+                Position.getIntYaw(location), Position.getIntPitch(location),
+                Position.getIntPitch(location),
+                0, 0, 0, metadata);
+    }
 }

--- a/src/main/java/net/glowstone/net/message/play/entity/SpawnObjectMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/entity/SpawnObjectMessage.java
@@ -4,6 +4,8 @@ import com.flowpowered.network.Message;
 import java.util.UUID;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import net.glowstone.util.Position;
+import org.bukkit.Location;
 
 @Data
 @RequiredArgsConstructor
@@ -30,6 +32,32 @@ public final class SpawnObjectMessage implements Message {
     public SpawnObjectMessage(int id, UUID uuid, int type, double x, double y, double z, int pitch,
         int yaw, int data) {
         this(id, uuid, type, x, y, z, pitch, yaw, data, 0, 0, 0);
+    }
+
+    /**
+     * Create an instance based on a location.
+     *
+     * @param id the entity id
+     * @param uuid the entity UUID
+     * @param type the network ID of the entity type
+     * @param location The location whose x, y, z, pitch and yaw will be used
+     */
+    public SpawnObjectMessage(int id, UUID uuid, int type, Location location) {
+        this(id, uuid, type, location, 0);
+    }
+
+    /**
+     * Create an instance based on a location.
+     *
+     * @param id the entity id
+     * @param uuid the entity UUID
+     * @param type the network ID of the entity type
+     * @param location the location whose x, y, z, pitch and yaw will be used
+     * @param data as defined by the entity type
+     */
+    public SpawnObjectMessage(int id, UUID uuid, int type, Location location, int data) {
+        this(id, uuid, type, location.getX(), location.getY(), location.getZ(),
+                Position.getIntPitch(location), Position.getIntYaw(location), data);
     }
 
     public boolean hasFireball() {

--- a/src/main/java/net/glowstone/net/message/play/entity/SpawnXpOrbMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/entity/SpawnXpOrbMessage.java
@@ -2,12 +2,19 @@ package net.glowstone.net.message.play.entity;
 
 import com.flowpowered.network.Message;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.bukkit.Location;
 
 @Data
+@RequiredArgsConstructor
 public final class SpawnXpOrbMessage implements Message {
 
     private final int id;
     private final double x, y, z;
     private final short count;
+
+    public SpawnXpOrbMessage(int id, Location location, short count) {
+        this(id, location.getX(), location.getY(), location.getZ(), count);
+    }
 
 }


### PR DESCRIPTION
New constructor overloads accept a Location parameter, eliminating lots of duplicate code to extract x,y,z,pitch,yaw. Also, methods returning only one instance of one or both classes now use Collections.singletonList.