### PR TITLE
Allow fields named x, y or z

### DIFF
--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -202,7 +202,7 @@
     </module>
     <module name="MemberName">
       <property name="severity" value="warning"/> <!-- TODO: fix naming capitalization -->
-      <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9]*$"/>
+      <property name="format" value="^([a-z][a-z0-9][a-zA-Z0-9]*|[xyz])$"/>
       <message key="name.invalidPattern" value="Member name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="ParameterName">


### PR DESCRIPTION
Widely used in existing Block*Message classes, but currently raising warnings in CheckStyle.