### PR TITLE
Rename GlowEntity.getDirection to GlowEntity.getCardinalFacing

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockDirectional.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockDirectional.java
@@ -85,6 +85,6 @@ public class BlockDirectional extends BlockType {
                 return DOWN;
             }
         }
-        return player.getDirection().getOppositeFace();
+        return player.getCardinalFacing().getOppositeFace();
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockDoor.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockDoor.java
@@ -66,7 +66,7 @@ public class BlockDoor extends BlockType {
             return;
         }
 
-        BlockFace facing = player.getDirection();
+        BlockFace facing = player.getCardinalFacing();
         ((Door) data).setFacingDirection(facing.getOppositeFace());
 
         // modify facing for double-doors

--- a/src/main/java/net/glowstone/block/blocktype/BlockLever.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLever.java
@@ -53,7 +53,7 @@ public class BlockLever extends BlockAttachable {
         Lever lever = (Lever) data;
         setAttachedFace(state, face.getOppositeFace());
         lever.setFacingDirection(
-            face == BlockFace.UP || face == BlockFace.DOWN ? player.getDirection() : face);
+            face == BlockFace.UP || face == BlockFace.DOWN ? player.getCardinalFacing() : face);
 
     }
 

--- a/src/main/java/net/glowstone/block/blocktype/BlockPumpkinBase.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockPumpkinBase.java
@@ -22,7 +22,7 @@ public class BlockPumpkinBase extends BlockDirectDrops {
         super.placeBlock(player, state, face, holding, clickedLoc);
         MaterialData data = state.getData();
         if (data instanceof Pumpkin) {
-            ((Pumpkin) data).setFacingDirection(player.getDirection());
+            ((Pumpkin) data).setFacingDirection(player.getCardinalFacing());
             state.setData(data);
         } else {
             warnMaterialData(Pumpkin.class, data);

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneComparator.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneComparator.java
@@ -42,7 +42,7 @@ public class BlockRedstoneComparator extends BlockNeedsAttached {
         ItemStack holding, Vector clickedLoc) {
         super.placeBlock(player, state, face, holding, clickedLoc);
         Comparator comparator = (Comparator) state.getData();
-        comparator.setFacingDirection(player.getDirection());
+        comparator.setFacingDirection(player.getCardinalFacing());
         comparator.setSubtractionMode(false);
         state.getBlock().setData(comparator.getData());
         state.getWorld().requestPulse(state.getBlock());

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneRepeater.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneRepeater.java
@@ -44,7 +44,7 @@ public class BlockRedstoneRepeater extends BlockNeedsAttached {
         super.placeBlock(player, state, face, holding, clickedLoc);
         MaterialData data = state.getData();
         if (data instanceof Diode) {
-            ((Diode) data).setFacingDirection(player.getDirection());
+            ((Diode) data).setFacingDirection(player.getCardinalFacing());
             state.setData(data);
         } else {
             warnMaterialData(Diode.class, data);

--- a/src/main/java/net/glowstone/block/blocktype/BlockStairs.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockStairs.java
@@ -22,7 +22,7 @@ public class BlockStairs extends BlockType {
 
         MaterialData data = state.getData();
         if (data instanceof Stairs) {
-            ((Stairs) data).setFacingDirection(player.getDirection());
+            ((Stairs) data).setFacingDirection(player.getCardinalFacing());
 
             if (face == BlockFace.DOWN || face != BlockFace.UP && clickedLoc.getY() >= 0.5) {
                 ((Stairs) data).setInverted(true);

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -343,7 +343,7 @@ public abstract class GlowEntity implements Entity {
      *
      * @return The cardinal BlockFace of this entity.
      */
-    public BlockFace getDirection() {
+    public BlockFace getCardinalFacing() {
         double rot = getLocation().getYaw() % 360;
         if (rot < 0) {
             rot += 360.0;


### PR DESCRIPTION
Necessary to avoid a name collision once a subclass implements Fireball.