### PR TITLE
Fix player interact issues

### DIFF
--- a/src/main/java/net/glowstone/EventFactory.java
+++ b/src/main/java/net/glowstone/EventFactory.java
@@ -200,9 +200,7 @@ public final class EventFactory {
      */
     public static PlayerInteractEvent onPlayerInteract(Player player, Action action,
             EquipmentSlot hand) {
-        return callEvent(new PlayerInteractEvent(player, action,
-                hand == EquipmentSlot.OFF_HAND ? player.getInventory().getItemInOffHand()
-                        : player.getInventory().getItemInMainHand(), null, null, hand));
+        return onPlayerInteract(player, action, hand, null, BlockFace.SELF);
     }
 
     /**

--- a/src/main/java/net/glowstone/block/ItemTable.java
+++ b/src/main/java/net/glowstone/block/ItemTable.java
@@ -118,6 +118,7 @@ import net.glowstone.block.itemtype.ItemFoodSeeds;
 import net.glowstone.block.itemtype.ItemGoldenApple;
 import net.glowstone.block.itemtype.ItemHoe;
 import net.glowstone.block.itemtype.ItemItemFrame;
+import net.glowstone.block.itemtype.ItemKnowledgeBook;
 import net.glowstone.block.itemtype.ItemMilk;
 import net.glowstone.block.itemtype.ItemMinecart;
 import net.glowstone.block.itemtype.ItemPainting;
@@ -467,6 +468,7 @@ public final class ItemTable {
         reg(Material.PAINTING, new ItemPainting());
         reg(Material.FIREWORK, new ItemFirework());
         reg(Material.ENDER_PEARL, new ItemEnderPearl());
+        reg(Material.KNOWLEDGE_BOOK, new ItemKnowledgeBook());
     }
 
     private void reg(Material material, ItemType type) {

--- a/src/main/java/net/glowstone/block/itemtype/ItemBoat.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemBoat.java
@@ -1,8 +1,7 @@
 package net.glowstone.block.itemtype;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
+import java.util.Set;
+import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -10,7 +9,9 @@ import org.bukkit.TreeSpecies;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Boat;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
 
 public class ItemBoat extends ItemType {
 
@@ -22,24 +23,31 @@ public class ItemBoat extends ItemType {
 
     @Override
     public void rightClickAir(GlowPlayer player, ItemStack holding) {
-        List<Block> lastTwoTargetBlocks = player
-            .getLastTwoTargetBlocks((HashSet<Material>) null, 5);
-        Optional<Block> first = lastTwoTargetBlocks.stream()
-            .filter(b -> b.getType() != Material.AIR).findFirst();
+        // Executed when the player clicks on water that doesn't have a block beneath
+        placeBoat(player);
+    }
 
-        if (first.isPresent()) {
-            Block block = first.get();
-            Location location = block.getRelative(BlockFace.UP).getLocation();
+    @Override
+    public void rightClickBlock(GlowPlayer player, GlowBlock target, BlockFace face, ItemStack holding, Vector clickedLoc, EquipmentSlot hand) {
+        // Two cases are handled here: Either the player clicked on a block on the land or beneath water
+        placeBoat(player);
+    }
+
+    private void placeBoat(GlowPlayer player) {
+        Block targetBlock = player.getTargetBlock((Set<Material>) null, 5);
+
+        if (targetBlock != null && !targetBlock.isEmpty()) {
+            Location location = targetBlock.getRelative(BlockFace.UP).getLocation();
             // center boat on cursor location
             location.add(0.6875f, 0, 0.6875f);
             location.setYaw(player.getLocation().getYaw());
-            Boat boat = block.getWorld().spawn(location, Boat.class);
+            Boat boat = targetBlock.getWorld().spawn(location, Boat.class);
             boat.setWoodType(woodType);
         }
     }
 
     @Override
     public Context getContext() {
-        return Context.AIR;
+        return Context.ANY;
     }
 }

--- a/src/main/java/net/glowstone/block/itemtype/ItemBoat.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemBoat.java
@@ -36,7 +36,7 @@ public class ItemBoat extends ItemType {
     private void placeBoat(GlowPlayer player) {
         Block targetBlock = player.getTargetBlock((Set<Material>) null, 5);
 
-        if (targetBlock != null && !targetBlock.isEmpty()) {
+        if (targetBlock != null && !targetBlock.isEmpty() && targetBlock.getRelative(BlockFace.UP).isEmpty()) {
             Location location = targetBlock.getRelative(BlockFace.UP).getLocation();
             // center boat on cursor location
             location.add(0.6875f, 0, 0.6875f);

--- a/src/main/java/net/glowstone/block/itemtype/ItemBucket.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemBucket.java
@@ -2,6 +2,7 @@ package net.glowstone.block.itemtype;
 
 import java.util.Iterator;
 import net.glowstone.EventFactory;
+import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.ItemTable;
 import net.glowstone.block.blocktype.BlockLiquid;
@@ -12,8 +13,10 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.player.PlayerBucketFillEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.BlockIterator;
+import org.bukkit.util.Vector;
 
 public class ItemBucket extends ItemType {
 
@@ -23,11 +26,20 @@ public class ItemBucket extends ItemType {
 
     @Override
     public Context getContext() {
-        return Context.AIR;
+        return Context.ANY;
     }
 
     @Override
     public void rightClickAir(GlowPlayer player, ItemStack holding) {
+        clickBucket(player, holding);
+    }
+
+    @Override
+    public void rightClickBlock(GlowPlayer player, GlowBlock target, BlockFace face, ItemStack holding, Vector clickedLoc, EquipmentSlot hand) {
+        clickBucket(player, holding);
+    }
+
+    private void clickBucket(GlowPlayer player, ItemStack holding) {
         Iterator<Block> itr = new BlockIterator(player, 5);
         Block target = null;
         // Used to determine the side the block was clicked on:
@@ -46,6 +58,8 @@ public class ItemBucket extends ItemType {
                     validTarget = true;
                     break;
                 }
+            } else if (!target.isEmpty()) {
+                break;
             }
         }
 

--- a/src/main/java/net/glowstone/block/itemtype/ItemFilledBucket.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFilledBucket.java
@@ -6,6 +6,7 @@ import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.ItemTable;
 import net.glowstone.block.blocktype.BlockType;
 import net.glowstone.entity.GlowPlayer;
+import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.player.PlayerBucketEmptyEvent;
@@ -55,5 +56,9 @@ public class ItemFilledBucket extends ItemType {
 
         // perform the block change
         newState.update(true);
+
+        if (player.getGameMode() != GameMode.CREATIVE) {
+            holding.setType(Material.BUCKET);
+        }
     }
 }

--- a/src/main/java/net/glowstone/block/itemtype/ItemFood.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFood.java
@@ -22,11 +22,6 @@ public class ItemFood extends ItemTimedUsage {
         saturation = 0;
     }
 
-    @Override
-    public Context getContext() {
-        return Context.AIR;
-    }
-
     protected int getFoodLevel(ItemStack stack) {
         return foodLevel;
     }

--- a/src/main/java/net/glowstone/block/itemtype/ItemKnowledgeBook.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemKnowledgeBook.java
@@ -1,16 +1,38 @@
 package net.glowstone.block.itemtype;
 
 import net.glowstone.GlowServer;
+import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
+import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.KnowledgeBookMeta;
+import org.bukkit.util.Vector;
 
 public class ItemKnowledgeBook extends ItemType {
 
+    public ItemKnowledgeBook() {
+        setMaxStackSize(1);
+    }
+
+    @Override
+    public Context getContext() {
+        return Context.ANY;
+    }
+
+    @Override
+    public void rightClickBlock(GlowPlayer player, GlowBlock target, BlockFace face, ItemStack holding, Vector clickedLoc, EquipmentSlot hand) {
+        rightClickBook(player, holding);
+    }
+
     @Override
     public void rightClickAir(GlowPlayer player, ItemStack holding) {
+        rightClickBook(player, holding);
+    }
+
+    private void rightClickBook(GlowPlayer player, ItemStack holding) {
         if (holding.getItemMeta() instanceof KnowledgeBookMeta) {
             KnowledgeBookMeta recipes = (KnowledgeBookMeta) holding.getItemMeta();
             if (recipes.hasRecipes()) {
@@ -19,6 +41,8 @@ public class ItemKnowledgeBook extends ItemType {
                         .getRecipeByKey(recipe), true);
                 }
             }
+
+            holding.setAmount(0);
         }
     }
 }

--- a/src/main/java/net/glowstone/block/itemtype/ItemKnowledgeBook.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemKnowledgeBook.java
@@ -4,6 +4,7 @@ import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.BlockFace;
 import org.bukkit.inventory.EquipmentSlot;
@@ -42,7 +43,9 @@ public class ItemKnowledgeBook extends ItemType {
                 }
             }
 
-            holding.setAmount(0);
+            if (player.getGameMode() != GameMode.CREATIVE) {
+                holding.setAmount(0);
+            }
         }
     }
 }

--- a/src/main/java/net/glowstone/block/itemtype/ItemTimedUsage.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemTimedUsage.java
@@ -10,6 +10,11 @@ import org.bukkit.util.Vector;
 public class ItemTimedUsage extends ItemType {
 
     @Override
+    public Context getContext() {
+        return Context.ANY;
+    }
+
+    @Override
     public void rightClickAir(GlowPlayer player, ItemStack holding) {
         startUse(player, holding);
     }

--- a/src/main/java/net/glowstone/block/itemtype/ItemType.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemType.java
@@ -143,7 +143,7 @@ public class ItemType {
     // Actions
 
     /**
-     * Called when a player right-clicks in midair while holding this item. Also called by default if rightClickBlock is not overridden.
+     * Called when a player right-clicks in midair while holding this item.
      *
      * @param player The player
      * @param holding The ItemStack the player was holding
@@ -172,7 +172,7 @@ public class ItemType {
      */
     public void rightClickBlock(GlowPlayer player, GlowBlock target, BlockFace face,
         ItemStack holding, Vector clickedLoc, EquipmentSlot hand) {
-        if (placeAs != null) {
+        if (placeAs != null && (placeAs.getContext() == Context.ANY || placeAs.getContext() == Context.BLOCK)) {
             placeAs.rightClickBlock(player, target, face, holding, clickedLoc, hand);
         }
     }

--- a/src/main/java/net/glowstone/block/itemtype/ItemWrittenBook.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemWrittenBook.java
@@ -1,8 +1,12 @@
 package net.glowstone.block.itemtype;
 
+import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.message.play.game.PluginMessage;
+import org.bukkit.block.BlockFace;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
 
 public class ItemWrittenBook extends ItemType {
 
@@ -10,11 +14,16 @@ public class ItemWrittenBook extends ItemType {
 
     @Override
     public Context getContext() {
-        return Context.AIR;
+        return Context.ANY;
     }
 
     @Override
     public void rightClickAir(GlowPlayer player, ItemStack holding) {
+        openBook(player);
+    }
+
+    @Override
+    public void rightClickBlock(GlowPlayer player, GlowBlock target, BlockFace face, ItemStack holding, Vector clickedLoc, EquipmentSlot hand) {
         openBook(player);
     }
 

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -653,12 +653,12 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
     @Deprecated
     public Block getTargetBlock(HashSet<Byte> transparent, int maxDistance) {
-        return getLineOfSight(transparent, maxDistance, 0).get(0);
+        return getLineOfSight(transparent, maxDistance, 1).get(0);
     }
 
     @Override
     public Block getTargetBlock(Set<Material> materials, int maxDistance) {
-        return getLineOfSight(materials, maxDistance).get(0);
+        return getLineOfSight(materials, maxDistance, 1).get(0);
     }
 
     @Deprecated

--- a/src/main/java/net/glowstone/inventory/GlowItemFactory.java
+++ b/src/main/java/net/glowstone/inventory/GlowItemFactory.java
@@ -154,6 +154,8 @@ public final class GlowItemFactory implements ItemFactory {
                 return new GlowMetaSpawn(meta);
             case SHIELD:
                 return new GlowMetaShield(meta);
+            case KNOWLEDGE_BOOK:
+                return new GlowMetaKnowledgeBook(meta);
             default:
                 return new GlowMetaItem(meta);
         }

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -33,7 +33,6 @@ import net.glowstone.net.message.play.game.PingMessage;
 import net.glowstone.net.message.play.game.UserListItemMessage;
 import net.glowstone.net.message.play.game.UserListItemMessage.Action;
 import net.glowstone.net.message.play.game.UserListItemMessage.Entry;
-import net.glowstone.net.message.play.player.BlockPlacementMessage;
 import net.glowstone.net.pipeline.CodecsHandler;
 import net.glowstone.net.pipeline.CompressionHandler;
 import net.glowstone.net.pipeline.EncryptionHandler;
@@ -118,11 +117,6 @@ public class GlowSession extends BasicSession {
      * The ID of the last ping message sent, used to ensure the client responded correctly.
      */
     private long pingMessageId;
-
-    /**
-     * Stores the last block placement message sent, see BlockPlacementHandler.
-     */
-    private BlockPlacementMessage previousPlacement;
 
     /**
      * The number of ticks until previousPlacement must be cleared.
@@ -258,25 +252,6 @@ public class GlowSession extends BasicSession {
         if (pingId == pingMessageId) {
             pingMessageId = 0;
         }
-    }
-
-    /**
-     * Get the saved previous BlockPlacementMessage for this session.
-     *
-     * @return The message.
-     */
-    public BlockPlacementMessage getPreviousPlacement() {
-        return previousPlacement;
-    }
-
-    /**
-     * Set the previous BlockPlacementMessage for this session.
-     *
-     * @param message The message.
-     */
-    public void setPreviousPlacement(BlockPlacementMessage message) {
-        previousPlacement = message;
-        previousPlacementTicks = 2;
     }
 
     @Override
@@ -450,10 +425,6 @@ public class GlowSession extends BasicSession {
      * Pulse this session, performing any updates needed.
      */
     void pulse() {
-        // drop the previous placement if needed
-        if (previousPlacementTicks > 0 && --previousPlacementTicks == 0) {
-            previousPlacement = null;
-        }
 
         // process messages
         Message message;

--- a/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
@@ -18,6 +18,7 @@ import org.bukkit.block.BlockFace;
 import org.bukkit.event.Event.Result;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
@@ -49,58 +50,32 @@ public final class BlockPlacementHandler implements
         }
     }
 
+    private static boolean bothHandsEmpty(GlowPlayer player) {
+        return InventoryUtil.isEmpty(player.getInventory().getItem(EquipmentSlot.HAND))
+                && InventoryUtil.isEmpty(player.getInventory().getItem(EquipmentSlot.OFF_HAND));
+    }
+
     @Override
     public void handle(GlowSession session, BlockPlacementMessage message) {
         GlowPlayer player = session.getPlayer();
         if (player == null) {
             return;
         }
-
-        //GlowServer.logger.info(session + ": " + message);
-
         /*
-         * The client sends this packet for the following cases:
-         * Right click air:
-         * - Send direction=-1 packet for any non-null item
-         * Right click block:
-         * - Send packet with all values filled
-         * - If client DOES NOT expect a block placement to result:
-         *   - Send direction=-1 packet (unless item is null)
+         * The client sends this packet when
+         * - it expects a block place to happen
+         * - the player clicks on a block with an empty hand
+         *
+         * When the client doesn't expect the block place to be successful,
+         * it sends a Use item packet instead (See UseItemHandler).
          *
          * Client will expect a block placement to result from blocks and from
          * certain items (e.g. sugarcane, sign). We *could* opt to trust the
          * client on this, but the server's view of events (particularly under
          * the Bukkit API, or custom ItemTypes) may differ from the client's.
-         *
-         * In order to avoid firing two events for one interact, the two
-         * packet case must be handled here. Care must also be taken that a
-         * right-click air of an expected-place item immediately after is
-         * not considered part of the same action.
          */
-
-        Action action = Action.RIGHT_CLICK_BLOCK;
         GlowBlock clicked = player.getWorld()
             .getBlockAt(message.getX(), message.getY(), message.getZ());
-
-        /*
-         * Check if the message is a -1. If we *just* got a message with the
-         * values filled, discard it, otherwise perform right-click-air.
-         */
-        if (message.getDirection() == -1) {
-            BlockPlacementMessage previous = session.getPreviousPlacement();
-            //if (previous == null || !previous.getHeldItem().equals(message.getHeldItem())) {
-            // perform normal right-click-air actions
-            //   action = Action.RIGHT_CLICK_AIR;
-            //   clicked = null;
-            //} else {
-            // terminate processing of this event
-            //   session.setPreviousPlacement(null);
-            return;
-            // }
-        }
-
-        // Set previous placement message
-        session.setPreviousPlacement(message);
 
         // Get values from the message
         Vector clickedLoc = new Vector(message.getCursorX(), message.getCursorY(),
@@ -109,31 +84,32 @@ public final class BlockPlacementHandler implements
         ItemStack holding = InventoryUtil
             .itemOrEmpty(player.getInventory().getItem(message.getHandSlot()));
 
-        boolean rightClickedAir = false;
         // check that a block-click wasn't against air
         if (clicked.getType() == Material.AIR) {
-            action = Action.RIGHT_CLICK_AIR;
             if (holding.getType().isBlock()) {
                 // inform the player their perception of reality is wrong
-                player.sendBlockChange(clicked.getLocation(), Material.AIR, (byte) 0);
+                revert(player, clicked);
                 // revert newly placed block
                 revert(player, clicked.getRelative(face));
-                return;
             } else {
-                rightClickedAir = true;
+                // There may be a block behind, if there isn't we perform a right click air
+                UseItemHandler.handleRightClick(player, holding, message.getHandSlot());
             }
+            return;
         }
 
+        handleRightClickBlock(player, holding, message.getHandSlot(), clicked, face, clickedLoc);
+    }
+
+    static void handleRightClickBlock(GlowPlayer player, ItemStack holding, EquipmentSlot slot, GlowBlock clicked, BlockFace face, Vector clickedLoc) {
         // call interact event
         PlayerInteractEvent event = EventFactory.onPlayerInteract(
-                player, action, message.getHandSlot(), rightClickedAir ? null : clicked, face);
-        //GlowServer.logger.info("Interact: " + action + " " + clicked + " " + face);
+                player, Action.RIGHT_CLICK_BLOCK, slot, clicked, face);
 
         // attempt to use interacted block
         // DEFAULT is treated as ALLOW, and sneaking is always considered
         boolean useInteractedBlock = event.useInteractedBlock() != Result.DENY;
-        if (useInteractedBlock && !rightClickedAir && (!player.isSneaking() || InventoryUtil
-            .isEmpty(holding))) {
+        if (useInteractedBlock && (!player.isSneaking() || bothHandsEmpty(player))) {
             BlockType blockType = ItemTable.instance().getBlock(clicked.getType());
             if (blockType != null) {
                 useInteractedBlock = blockType.blockInteract(player, clicked, face, clickedLoc);
@@ -148,19 +124,16 @@ public final class BlockPlacementHandler implements
         // follows ALLOW/DENY: default to if no block was interacted with
         if (selectResult(event.useItemInHand(), !useInteractedBlock) && holding != null) {
             ItemType type = ItemTable.instance().getItem(holding.getType());
-            if (!rightClickedAir && holding.getType() != Material.AIR && (
+            if (holding.getType() != Material.AIR && (
                 type.getContext() == Context.BLOCK || type.getContext() == Context.ANY)) {
-                type.rightClickBlock(player, clicked, face, holding, clickedLoc,
-                    message.getHandSlot());
+                type.rightClickBlock(player, clicked, face, holding, clickedLoc, slot);
             }
         }
 
-        // if anything was actually clicked, make sure the player's up to date
+        // make sure the player's up to date
         // in case something is unimplemented or otherwise screwy on our side
-        if (!rightClickedAir) {
-            revert(player, clicked);
-            revert(player, clicked.getRelative(face));
-        }
+        revert(player, clicked);
+        revert(player, clicked.getRelative(face));
 
         // if there's been a change in the held item, make it valid again
         if (!InventoryUtil.isEmpty(holding)) {
@@ -173,6 +146,6 @@ public final class BlockPlacementHandler implements
                 holding = InventoryUtil.createEmptyStack();
             }
         }
-        player.getInventory().setItem(message.getHandSlot(), holding);
+        player.getInventory().setItem(slot, holding);
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
@@ -122,7 +122,7 @@ public final class BlockPlacementHandler implements
 
         // attempt to use item in hand
         // follows ALLOW/DENY: default to if no block was interacted with
-        if (selectResult(event.useItemInHand(), !useInteractedBlock) && holding != null) {
+        if (selectResult(event.useItemInHand(), !useInteractedBlock)) {
             ItemType type = ItemTable.instance().getItem(holding.getType());
             if (holding.getType() != Material.AIR && (
                 type.getContext() == Context.BLOCK || type.getContext() == Context.ANY)) {
@@ -136,16 +136,16 @@ public final class BlockPlacementHandler implements
         revert(player, clicked.getRelative(face));
 
         // if there's been a change in the held item, make it valid again
-        if (!InventoryUtil.isEmpty(holding)) {
-            if (holding.getType().getMaxDurability() > 0 && holding.getDurability() > holding
-                .getType().getMaxDurability()) {
-                holding.setAmount(holding.getAmount() - 1);
-                holding.setDurability((short) 0);
-            }
-            if (holding.getAmount() <= 0) {
-                holding = InventoryUtil.createEmptyStack();
-            }
+        if (!InventoryUtil.isEmpty(holding) && holding.getType().getMaxDurability() > 0
+            && holding.getDurability() > holding.getType().getMaxDurability()) {
+            holding.setAmount(holding.getAmount() - 1);
+            holding.setDurability((short) 0);
         }
+
+        if (holding.getAmount() <= 0) {
+            holding = InventoryUtil.createEmptyStack();
+        }
+
         player.getInventory().setItem(slot, holding);
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -36,8 +36,6 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
 
     @Override
     public void handle(GlowSession session, DiggingMessage message) {
-        //Todo: Implement SHOOT_ARROW_FINISH_EATING
-        //Todo: Implement SWAP_ITEM_IN_HAND
         GlowPlayer player = session.getPlayer();
         GlowWorld world = player.getWorld();
         GlowBlock block = world.getBlockAt(message.getX(), message.getY(), message.getZ());

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
@@ -20,13 +20,7 @@ public final class PlayerSwingArmHandler implements
     public void handle(GlowSession session, PlayerSwingArmMessage message) {
         GlowPlayer player = session.getPlayer();
 
-        Block block;
-        try {
-            block = player.getTargetBlock((Set<Material>) null, 6);
-        } catch (IllegalStateException ex) {
-            // getTargetBlock failed to find any block at all
-            block = null;
-        }
+        Block block = player.getTargetBlock((Set<Material>) null, 6);
 
         if (block == null || block.isEmpty()) {
             if (EventFactory.onPlayerInteract(player, Action.LEFT_CLICK_AIR, message.getHandSlot()).useItemInHand()

--- a/src/main/java/net/glowstone/net/handler/play/player/UseItemHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/UseItemHandler.java
@@ -1,7 +1,11 @@
 package net.glowstone.net.handler.play.player;
 
 import com.flowpowered.network.MessageHandler;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import net.glowstone.EventFactory;
+import net.glowstone.block.GlowBlock;
 import net.glowstone.block.ItemTable;
 import net.glowstone.block.itemtype.ItemType;
 import net.glowstone.block.itemtype.ItemType.Context;
@@ -10,14 +14,21 @@ import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.UseItemMessage;
 import net.glowstone.util.InventoryUtil;
 
-import org.bukkit.GameMode;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.event.Event;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
 
 public class UseItemHandler implements MessageHandler<GlowSession, UseItemMessage> {
+
+    private static final HashSet<Material> IGNORE_MATS = new HashSet<>(Arrays.asList(
+                Material.AIR, Material.WATER, Material.LAVA, Material.STATIONARY_LAVA, Material.STATIONARY_WATER
+                ));
 
     @Override
     public void handle(GlowSession session, UseItemMessage message) {
@@ -25,8 +36,51 @@ public class UseItemHandler implements MessageHandler<GlowSession, UseItemMessag
         ItemStack holding = InventoryUtil
                 .itemOrEmpty(player.getInventory().getItem(message.getEquipmentSlot()));
 
-        PlayerInteractEvent event = EventFactory
-                .onPlayerInteract(player, Action.RIGHT_CLICK_AIR, message.getEquipmentSlot());
+        handleRightClick(player, holding, message.getEquipmentSlot());
+    }
+
+    static void handleRightClick(GlowPlayer player, ItemStack holding, EquipmentSlot slot) {
+        Action action = Action.RIGHT_CLICK_AIR;
+
+        GlowBlock block = null;
+        BlockFace face = BlockFace.SELF;
+
+        List<Block> targetBlocks = player.getLastTwoTargetBlocks(IGNORE_MATS, 5);
+        if (targetBlocks != null && targetBlocks.size() > 0) {
+            block = (GlowBlock) targetBlocks.get(targetBlocks.size() - 1);
+            if (targetBlocks.size() > 1) {
+                face = block.getFace(targetBlocks.get(0));
+            }
+        }
+
+        Vector clickedAt = null;
+
+        if (block != null && !IGNORE_MATS.contains(block.getType())) {
+            /* There are two special cases on right click:
+             * - When the client doesn't expect a block place to be successful this is sent
+             *   instead of a block place packet
+             * - When the block is not placeable (e.g. a nether star) this packet is sent
+             *   in addition to a block place packet (no need to throw the event twice)
+             */
+            action = Action.RIGHT_CLICK_BLOCK;
+            if (!holding.getType().isBlock()) {
+                return; // Action was already handled by BlockPlacementHandler
+            } else {
+                clickedAt = new Vector(0, 0, 0);
+                // TODO: Implement proper raytrace and determine exact click location
+            }
+        }
+
+        if (action == Action.RIGHT_CLICK_AIR) {
+            handleRightClickAir(player, holding, slot);
+        } else {
+            BlockPlacementHandler.handleRightClickBlock(player, holding, slot, block, face, clickedAt);
+        }
+    }
+
+    static void handleRightClickAir(GlowPlayer player, ItemStack holding, EquipmentSlot slot) {
+        PlayerInteractEvent event = EventFactory.onPlayerInteract(player, Action.RIGHT_CLICK_AIR, slot);
+
         if (event.useItemInHand() == null || event.useItemInHand() == Event.Result.DENY) {
             return;
         }
@@ -34,14 +88,8 @@ public class UseItemHandler implements MessageHandler<GlowSession, UseItemMessag
         if (!InventoryUtil.isEmpty(holding)) {
             ItemType type = ItemTable.instance().getItem(holding.getType());
             if (type != null) {
-                if (type.getContext() == Context.AIR || type.getContext() == Context.ANY) {
+                if (type.getContext() == Context.ANY || type.getContext() == Context.AIR) {
                     type.rightClickAir(player, holding);
-                } else {
-                    if ((holding.getType() == Material.WATER_BUCKET
-                        || holding.getType() == Material.LAVA_BUCKET) 
-                            && player.getGameMode() != GameMode.CREATIVE) {
-                        holding.setType(Material.BUCKET);
-                    }
                 }
             }
 
@@ -49,7 +97,7 @@ public class UseItemHandler implements MessageHandler<GlowSession, UseItemMessag
             if (holding.getAmount() <= 0) {
                 holding = InventoryUtil.createEmptyStack();
             }
-            player.getInventory().setItem(message.getEquipmentSlot(), holding);
+            player.getInventory().setItem(slot, holding);
         }
     }
 }


### PR DESCRIPTION
This PR fixes several issues with the `PlayerInteractEvent` and the `rightClickBlock()` and `rightClickAir()` methods of `ItemType`.

The following bugs are fixed:
- Block clicks fired an additional interact event with left click air (this was checked in `PlayerSwingArmHandler` and failed because `GlowLivingEntity#getTargetBlock` returned wrong values)
- Right clicking on a block with an unplaceable item (e.g. a nether star) fired an additional right click air event because the client sends the place block and use item packets in this case
- When trying to place a placeable block and it fails (e.g. tall grass on stone), the client only sends a use item packet, which only fired a right click air interact. There's a right click block now fired instead (The block and block face values are computed by the `UseItemHandler`). This includes handling all internal right click actions.
- Water behind a wall could be pickup up with a bucket
- In some cases, interacting with blocks was possible even when sneaking and a block in the hand. (Solved by requiring both hands to be empty)

Other changes:
- Emptying a bucket in survival mode now changes the item type to `BUCKET`
- Implemented rightClickBlock handlers for all ItemTypes which previously depended on rightClickAir even if a block was clicked
- Cleaned up boat placement

There still is an issue with this implementation:
When clicking next to an interactable block (e.g. a lever), the lever is still flipped because the current raytrace (BlockIterator) ignores the size of the blocks. Also, the `clickedAt` vector in the `ItemType#rightClickBlock` method doesn't have correct values in it because of this problem.
So a proper raytracing method has to be implemented in the future, which would be useful also for other things (like filling a bucket).

Everything regarding the `PlayerInteractEvent` has been tested in comparison to Spigot behaviour. The results were not equal in all cases, but that's because Spigot isn't handling everything correctly itself ;) (Some interacts even seem quite random).

One difference I noticed was that for right and left click air events, Spigot always used `BlockFace.SOUTH` whereas we are setting the value to null. So there may be plugins that don't expect a null value here. Should we also set the face to `SOUTH` (which doesn't really make sense), should we use something more general like `BlockFace.SELF` or should we still use null?