### PR TITLE
Refactor GlowMeta*

### DIFF
--- a/src/main/java/net/glowstone/inventory/GlowMetaBanner.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaBanner.java
@@ -6,6 +6,8 @@ import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
 import net.glowstone.block.blocktype.BlockBanner;
 import net.glowstone.util.nbt.CompoundTag;
 import net.glowstone.util.nbt.TagType;
@@ -17,38 +19,36 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 public class GlowMetaBanner extends GlowMetaItem implements BannerMeta {
 
-    private List<Pattern> patterns = new ArrayList<>();
-    private DyeColor baseColor = null;
+    protected List<Pattern> patterns = new ArrayList<>();
+    @Getter
+    @Setter
+    protected DyeColor baseColor = null;
 
-    public GlowMetaBanner(GlowMetaItem meta) {
+    /**
+     * Creates an instance by copying from the given {@link ItemMeta}. If that item is another
+     * {@link BannerMeta}, its patterns are copied; otherwise, the new banner is blank.
+     * @param meta the {@link ItemMeta} to copy
+     */
+    public GlowMetaBanner(ItemMeta meta) {
         super(meta);
-        if (!(meta instanceof GlowMetaBanner)) {
+        if (!(meta instanceof BannerMeta)) {
             return;
         }
-        GlowMetaBanner banner = (GlowMetaBanner) meta;
-        patterns = banner.patterns;
-        baseColor = banner.baseColor;
+        BannerMeta banner = (BannerMeta) meta;
+        patterns = banner.getPatterns();
+        baseColor = banner.getBaseColor();
     }
 
     @Override
     public List<Pattern> getPatterns() {
-        return patterns;
+        return new ArrayList<>(patterns);
     }
 
     @Override
     public void setPatterns(List<Pattern> patterns) {
         checkNotNull(patterns, "Pattern cannot be null!");
-        this.patterns = patterns;
-    }
-
-    @Override
-    public DyeColor getBaseColor() {
-        return baseColor;
-    }
-
-    @Override
-    public void setBaseColor(DyeColor dyeColor) {
-        this.baseColor = dyeColor;
+        this.patterns.clear();
+        this.patterns.addAll(patterns);
     }
 
     @Override

--- a/src/main/java/net/glowstone/inventory/GlowMetaBook.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaBook.java
@@ -9,6 +9,7 @@ import net.glowstone.util.nbt.CompoundTag;
 import net.glowstone.util.nbt.TagType;
 import org.bukkit.Material;
 import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  * The ItemMeta for book and quill and written book items.
@@ -20,16 +21,23 @@ class GlowMetaBook extends GlowMetaItem implements BookMeta {
     private List<String> pages;
     private Integer generation;
 
-    public GlowMetaBook(GlowMetaItem meta) {
+    /**
+     * Creates an instance by copying from the given {@link ItemMeta}. If that item is another
+     * {@link BookMeta}, its title, author, pages and generation are copied; otherwise, the new book
+     * is blank.
+     * @param meta the {@link ItemMeta} to copy
+     */
+    public GlowMetaBook(ItemMeta meta) {
         super(meta);
-        if (!(meta instanceof GlowMetaBook)) {
+        if (!(meta instanceof BookMeta)) {
             return;
         }
-        GlowMetaBook book = (GlowMetaBook) meta;
-        title = book.title;
-        author = book.author;
+        BookMeta book = (BookMeta) meta;
+        title = book.getTitle();
+        author = book.getAuthor();
         if (book.hasPages()) {
-            pages = new ArrayList<>(book.pages);
+            pages = new ArrayList<>(book instanceof GlowMetaBook
+                    ? ((GlowMetaBook) book).pages : book.getPages());
             filterPages();
         }
         if (hasGeneration()) {

--- a/src/main/java/net/glowstone/inventory/GlowMetaEnchantedBook.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaEnchantedBook.java
@@ -7,21 +7,29 @@ import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public class GlowMetaEnchantedBook extends GlowMetaItem implements EnchantmentStorageMeta {
 
     private Map<Enchantment, Integer> storedEnchants;
 
-    public GlowMetaEnchantedBook(GlowMetaItem meta) {
+    /**
+     * Creates an instance by copying from the given {@link ItemMeta}. If that item is another
+     * {@link EnchantmentStorageMeta}, its enchantments are copied; otherwise, the new book has no
+     * enchantments.
+     * @param meta the {@link ItemMeta} to copy
+     */
+    public GlowMetaEnchantedBook(ItemMeta meta) {
         super(meta);
 
-        if (!(meta instanceof GlowMetaEnchantedBook)) {
+        if (!(meta instanceof EnchantmentStorageMeta)) {
             return;
         }
 
-        GlowMetaEnchantedBook book = (GlowMetaEnchantedBook) meta;
+        EnchantmentStorageMeta book = (EnchantmentStorageMeta) meta;
         if (book.hasStoredEnchants()) {
-            storedEnchants = new HashMap<>(book.storedEnchants);
+            storedEnchants = new HashMap<>(book instanceof GlowMetaEnchantedBook
+                    ? ((GlowMetaEnchantedBook) book).storedEnchants : book.getStoredEnchants());
         }
     }
 
@@ -83,7 +91,7 @@ public class GlowMetaEnchantedBook extends GlowMetaItem implements EnchantmentSt
     @Override
     public Map<Enchantment, Integer> getStoredEnchants() {
         return hasStoredEnchants() ? Collections.unmodifiableMap(storedEnchants)
-            : Collections.emptyMap();
+                : Collections.emptyMap();
     }
 
     @Override
@@ -93,7 +101,7 @@ public class GlowMetaEnchantedBook extends GlowMetaItem implements EnchantmentSt
         }
 
         if (ignoreLevelRestriction || level >= ench.getStartLevel() && level <= ench
-            .getMaxLevel()) {
+                .getMaxLevel()) {
             Integer old = storedEnchants.put(ench, level);
             return old == null || old != level;
         }

--- a/src/main/java/net/glowstone/inventory/GlowMetaFirework.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaFirework.java
@@ -14,21 +14,29 @@ import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.FireworkEffect;
 import org.bukkit.Material;
 import org.bukkit.inventory.meta.FireworkMeta;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public class GlowMetaFirework extends GlowMetaItem implements FireworkMeta {
 
     private List<FireworkEffect> effects = new ArrayList<>();
     private int power;
 
-    public GlowMetaFirework(GlowMetaItem meta) {
+    /**
+     * Creates an instance by copying from the given {@link ItemMeta}. If that item is another
+     * {@link FireworkMeta}, its effects and power are copied; otherwise, the new firework has no
+     * effects and zero power.
+     * @param meta the {@link ItemMeta} to copy
+     */
+    public GlowMetaFirework(ItemMeta meta) {
         super(meta);
-        if (!(meta instanceof GlowMetaFirework)) {
+        if (!(meta instanceof FireworkMeta)) {
             return;
         }
 
-        GlowMetaFirework firework = (GlowMetaFirework) meta;
-        effects.addAll(firework.effects);
-        power = firework.power;
+        FireworkMeta firework = (FireworkMeta) meta;
+        effects.addAll(firework instanceof GlowMetaFirework
+                ? ((GlowMetaFirework) firework).effects : firework.getEffects());
+        power = firework.getPower();
     }
 
     @Override

--- a/src/main/java/net/glowstone/inventory/GlowMetaFireworkEffect.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaFireworkEffect.java
@@ -11,20 +11,24 @@ import org.bukkit.FireworkEffect;
 import org.bukkit.FireworkEffect.Type;
 import org.bukkit.Material;
 import org.bukkit.inventory.meta.FireworkEffectMeta;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public class GlowMetaFireworkEffect extends GlowMetaItem implements FireworkEffectMeta {
 
     private FireworkEffect effect;
 
-    public GlowMetaFireworkEffect(GlowMetaItem meta) {
+    /**
+     * Creates an instance by copying from the given {@link ItemMeta}. If that item is another
+     * {@link FireworkEffectMeta}, it is copied fully; otherwise, the {@link FireworkEffect} is
+     * null.
+     * @param meta the {@link ItemMeta} to copy
+     */
+    public GlowMetaFireworkEffect(ItemMeta meta) {
         super(meta);
 
-        if (!(meta instanceof GlowMetaFireworkEffect)) {
-            return;
+        if (meta instanceof FireworkEffectMeta) {
+            effect = ((FireworkEffectMeta) meta).getEffect();
         }
-
-        GlowMetaFireworkEffect effect = (GlowMetaFireworkEffect) meta;
-        this.effect = effect.effect;
     }
 
     static FireworkEffect toEffect(CompoundTag explosion) {

--- a/src/main/java/net/glowstone/inventory/GlowMetaItem.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaItem.java
@@ -33,21 +33,26 @@ public class GlowMetaItem implements ItemMeta {
      *
      * @param meta The meta to copy from, or null.
      */
-    public GlowMetaItem(GlowMetaItem meta) {
+    public GlowMetaItem(ItemMeta meta) {
         if (meta == null) {
             return;
         }
 
-        displayName = meta.displayName;
+        displayName = meta.getDisplayName();
 
         if (meta.hasLore()) {
-            lore = new ArrayList<>(meta.lore);
+            lore = new ArrayList<>(meta.getLore());
         }
         if (meta.hasEnchants()) {
-            enchants = new HashMap<>(meta.enchants);
+            enchants = new HashMap<>(meta.getEnchants());
         }
-
-        hideFlag = meta.hideFlag;
+        if (meta instanceof GlowMetaItem) {
+            hideFlag = ((GlowMetaItem) meta).hideFlag;
+        } else {
+            for (ItemFlag flag : meta.getItemFlags()) {
+                addItemFlags(flag);
+            }
+        }
     }
 
     protected static void serializeEnchants(String name, Map<String, Object> map,

--- a/src/main/java/net/glowstone/inventory/GlowMetaKnowledgeBook.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaKnowledgeBook.java
@@ -1,42 +1,55 @@
 package net.glowstone.inventory;
 
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.KnowledgeBookMeta;
 
 public class GlowMetaKnowledgeBook extends GlowMetaItem implements KnowledgeBookMeta {
 
-    public GlowMetaKnowledgeBook(GlowMetaItem meta) {
+    private final List<NamespacedKey> recipes = new ArrayList<>();
+
+    /**
+     * Creates an instance by copying from the given {@link ItemMeta}. If that item is another
+     * {@link KnowledgeBookMeta}, its recipes are copied; otherwise, the new book is empty.
+     * @param meta the {@link ItemMeta} to copy
+     */
+    public GlowMetaKnowledgeBook(ItemMeta meta) {
         super(meta);
 
-        if (!(meta instanceof GlowMetaKnowledgeBook)) {
+        if (!(meta instanceof KnowledgeBookMeta)) {
             return;
         }
 
-        GlowMetaKnowledgeBook book = (GlowMetaKnowledgeBook) meta;
+        KnowledgeBookMeta book = (KnowledgeBookMeta) meta;
         if (book.hasRecipes()) {
-            // add recipes
+            recipes.addAll(book instanceof GlowMetaKnowledgeBook
+                    ? ((GlowMetaKnowledgeBook) book).recipes : book.getRecipes());
         }
     }
 
     @Override
     public boolean hasRecipes() {
-        return false;
+        return !recipes.isEmpty();
     }
 
     @Override
     public List<NamespacedKey> getRecipes() {
-        return null;
+        return ImmutableList.copyOf(recipes);
     }
 
     @Override
     public void setRecipes(List<NamespacedKey> recipes) {
-
+        this.recipes.clear();
+        this.recipes.addAll(recipes);
     }
 
     @Override
     public void addRecipe(NamespacedKey... recipes) {
-
+        this.recipes.addAll(Arrays.asList(recipes));
     }
 
     @Override

--- a/src/main/java/net/glowstone/inventory/GlowMetaLeatherArmor.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaLeatherArmor.java
@@ -3,27 +3,30 @@ package net.glowstone.inventory;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
+import lombok.Getter;
 import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.Color;
 import org.bukkit.Material;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 
 public class GlowMetaLeatherArmor extends GlowMetaItem implements LeatherArmorMeta {
 
+    private static final Color DEFAULT_LEATHER_COLOR
+            = GlowItemFactory.instance().getDefaultLeatherColor();
+    @Getter
     private Color color = GlowItemFactory.instance().getDefaultLeatherColor();
 
-    public GlowMetaLeatherArmor(GlowMetaItem meta) {
+    /**
+     * Creates an instance by copying from the given {@link ItemMeta}. If that item is another
+     * {@link LeatherArmorMeta}, its color is copied; otherwise, the new item is undyed.
+     * @param meta the {@link ItemMeta} to copy
+     */
+    public GlowMetaLeatherArmor(ItemMeta meta) {
         super(meta);
-        if (!(meta instanceof GlowMetaLeatherArmor)) {
-            return;
+        if (meta instanceof LeatherArmorMeta) {
+            color = ((LeatherArmorMeta) meta).getColor();
         }
-        GlowMetaLeatherArmor armor = (GlowMetaLeatherArmor) meta;
-        color = armor.color;
-    }
-
-    @Override
-    public Color getColor() {
-        return color;
     }
 
     @Override
@@ -84,6 +87,6 @@ public class GlowMetaLeatherArmor extends GlowMetaItem implements LeatherArmorMe
     }
 
     private boolean hasColor() {
-        return !color.equals(GlowItemFactory.instance().getDefaultLeatherColor());
+        return !color.equals(DEFAULT_LEATHER_COLOR);
     }
 }

--- a/src/main/java/net/glowstone/inventory/GlowMetaShield.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaShield.java
@@ -2,10 +2,13 @@ package net.glowstone.inventory;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
 import net.glowstone.block.blocktype.BlockBanner;
 import net.glowstone.util.nbt.CompoundTag;
 import net.glowstone.util.nbt.TagType;
@@ -15,65 +18,15 @@ import org.bukkit.block.banner.Pattern;
 import org.bukkit.inventory.meta.BannerMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 
-public class GlowMetaShield extends GlowMetaItem implements BannerMeta {
+public class GlowMetaShield extends GlowMetaBanner {
 
-    private List<Pattern> patterns = new ArrayList<>();
-    private DyeColor baseColor = null;
-
-    public GlowMetaShield(GlowMetaItem meta) {
+    /**
+     * Creates an instance by copying from the given {@link ItemMeta}. If that item is another
+     * {@link BannerMeta}, the banner is copied; otherwise, the new shield has no banner.
+     * @param meta the {@link ItemMeta} to copy
+     */
+    public GlowMetaShield(ItemMeta meta) {
         super(meta);
-        if (!(meta instanceof GlowMetaShield)) {
-            return;
-        }
-        GlowMetaShield banner = (GlowMetaShield) meta;
-        patterns = banner.patterns;
-        baseColor = banner.baseColor;
-    }
-
-    @Override
-    public List<Pattern> getPatterns() {
-        return patterns;
-    }
-
-    @Override
-    public void setPatterns(List<Pattern> patterns) {
-        checkNotNull(patterns, "Pattern cannot be null!");
-        this.patterns = patterns;
-    }
-
-    @Override
-    public DyeColor getBaseColor() {
-        return baseColor;
-    }
-
-    @Override
-    public void setBaseColor(DyeColor dyeColor) {
-        this.baseColor = dyeColor;
-    }
-
-    @Override
-    public void addPattern(Pattern pattern) {
-        patterns.add(pattern);
-    }
-
-    @Override
-    public Pattern getPattern(int i) {
-        return patterns.get(i);
-    }
-
-    @Override
-    public Pattern removePattern(int i) {
-        return patterns.remove(i);
-    }
-
-    @Override
-    public void setPattern(int i, Pattern pattern) {
-        patterns.set(i, pattern);
-    }
-
-    @Override
-    public int numberOfPatterns() {
-        return patterns.size();
     }
 
     @Override

--- a/src/main/java/net/glowstone/inventory/GlowMetaShield.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaShield.java
@@ -1,14 +1,9 @@
 package net.glowstone.inventory;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import lombok.Getter;
-import lombok.Setter;
 import net.glowstone.block.blocktype.BlockBanner;
 import net.glowstone.util.nbt.CompoundTag;
 import net.glowstone.util.nbt.TagType;

--- a/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
@@ -43,6 +43,13 @@ public class GlowMetaSkull extends GlowMetaItem implements SkullMeta {
     ////////////////////////////////////////////////////////////////////////////
     // Internal stuff
 
+    /**
+     * Deserializes an instance as specified in {@link
+     * org.bukkit.configuration.serialization.ConfigurationSerializable}.
+     *
+     * @param data a serialized instance
+     * @return the instance as a GlowMetaSkull
+     */
     public static GlowMetaSkull deserialize(Map<String, Object> data) {
         GlowMetaSkull result = new GlowMetaSkull(null);
         if (data.containsKey("owner")) {

--- a/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import net.glowstone.GlowOfflinePlayer;
 import net.glowstone.GlowServer;
+import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.meta.profile.PlayerProfile;
 import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.Bukkit;
@@ -147,6 +148,8 @@ public class GlowMetaSkull extends GlowMetaItem implements SkullMeta {
             GlowOfflinePlayer impl = (GlowOfflinePlayer) owningPlayer;
             this.owner.set(impl.getProfile());
             return true;
+        } else if (owningPlayer instanceof GlowPlayer) {
+            this.owner.set(((GlowPlayer) owningPlayer).getProfile());
         } else {
             CompletableFuture<PlayerProfile> profileFuture = PlayerProfile
                     .getProfile(owningPlayer.getName());

--- a/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
@@ -5,7 +5,6 @@ import java.util.UUID;
 import net.glowstone.GlowOfflinePlayer;
 import net.glowstone.GlowServer;
 import net.glowstone.entity.meta.profile.PlayerProfile;
-import net.glowstone.util.UuidUtils;
 import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;

--- a/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
@@ -150,6 +150,7 @@ public class GlowMetaSkull extends GlowMetaItem implements SkullMeta {
             return true;
         } else if (owningPlayer instanceof GlowPlayer) {
             this.owner.set(((GlowPlayer) owningPlayer).getProfile());
+            return true;
         } else {
             CompletableFuture<PlayerProfile> profileFuture = PlayerProfile
                     .getProfile(owningPlayer.getName());

--- a/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
@@ -19,7 +19,7 @@ public class GlowMetaSkull extends GlowMetaItem implements SkullMeta {
     private static final PlayerProfile UNKNOWN_PLAYER = new PlayerProfile("MHF_Steve",
             new UUID(0xc06f89064c8a4911L, 0x9c29ea1dbd1aab82L));
 
-    final AtomicReference<PlayerProfile> owner = new AtomicReference<PlayerProfile>();
+    final AtomicReference<PlayerProfile> owner = new AtomicReference<>();
 
     /**
      * Creates an instance by copying from the given {@link ItemMeta}. If that item is another
@@ -34,7 +34,7 @@ public class GlowMetaSkull extends GlowMetaItem implements SkullMeta {
         SkullMeta skull = (SkullMeta) meta;
         if (skull.hasOwner()) {
             if (skull instanceof GlowMetaSkull) {
-                owner = ((GlowMetaSkull) skull).owner;
+                owner.set(((GlowMetaSkull) skull).owner.get());
             } else {
                 if (!setOwningPlayerInternal(skull.getOwningPlayer())) {
                     owner.set(UNKNOWN_PLAYER); // necessary to preserve the return value of hasOwner()

--- a/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
@@ -129,6 +129,11 @@ public class GlowMetaSkull extends GlowMetaItem implements SkullMeta {
         return ((GlowServer) Bukkit.getServer()).getOfflinePlayer(owner.get());
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * When this returns false, it may still succeed asynchronously.
+     */
     @Override
     public boolean setOwningPlayer(OfflinePlayer owningPlayer) {
         if (hasOwner()) {

--- a/src/main/java/net/glowstone/inventory/GlowMetaSpawn.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaSpawn.java
@@ -1,29 +1,37 @@
 package net.glowstone.inventory;
 
 import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
 import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SpawnEggMeta;
 
 public class GlowMetaSpawn extends GlowMetaItem implements SpawnEggMeta {
 
-    private EntityType type;
+    @Getter
+    @Setter
+    private EntityType spawnedType;
+    @Getter
+    @Setter
     private CompoundTag entityTag;
 
-    public GlowMetaSpawn(GlowMetaItem meta) {
+    /**
+     * Creates an instance by copying from the given {@link ItemMeta}. If that item is another
+     * {@link SpawnEggMeta}, the creature type is copied; if it's a {@link GlowMetaSpawn}, any
+     * custom NBT for the spawned entity is also copied.
+     * @param meta the {@link ItemMeta} to copy
+     */
+    public GlowMetaSpawn(ItemMeta meta) {
         super(meta);
 
-        if (!(meta instanceof GlowMetaSpawn)) {
-            return;
-        }
-
-        GlowMetaSpawn spawn = (GlowMetaSpawn) meta;
-        if (spawn.hasSpawnedType()) {
-            this.type = spawn.getSpawnedType();
-        }
-        if (spawn.getEntityTag() != null) {
-            this.entityTag = spawn.getEntityTag();
+        if (meta instanceof SpawnEggMeta) {
+            this.spawnedType = ((SpawnEggMeta) meta).getSpawnedType();
+            if (meta instanceof GlowMetaSpawn) {
+                entityTag = ((GlowMetaSpawn) meta).entityTag;
+            }
         }
     }
 
@@ -57,18 +65,10 @@ public class GlowMetaSpawn extends GlowMetaItem implements SpawnEggMeta {
                 if (id.startsWith("minecraft:")) {
                     id = id.substring("minecraft:".length());
                 }
-                type = EntityType.fromName(id);
+                spawnedType = EntityType.fromName(id);
             }
             this.entityTag = entity;
         }
-    }
-
-    public CompoundTag getEntityTag() {
-        return entityTag;
-    }
-
-    public void setEntityTag(CompoundTag tag) {
-        this.entityTag = tag;
     }
 
     @Override
@@ -77,17 +77,7 @@ public class GlowMetaSpawn extends GlowMetaItem implements SpawnEggMeta {
     }
 
     public boolean hasSpawnedType() {
-        return this.type != null;
-    }
-
-    @Override
-    public EntityType getSpawnedType() {
-        return this.type;
-    }
-
-    @Override
-    public void setSpawnedType(EntityType type) {
-        this.type = type;
+        return this.spawnedType != null;
     }
 
     @Override


### PR DESCRIPTION
List getters and setters now consistently make defensive copies.
Non-list getters and setters are lombokified (including a few that were stubs). Copy constructors now
handle *any* implementations of their respective interfaces, improving
plugin-friendliness. GlowMetaShield now extends GlowMetaBanner.
GlowMetaSkull.setOwningPlayer now checks the ProfileCache but still
doesn't wait for a profile to be downloaded. Missing Javadocs are added.