### PR TITLE
Fix library managment for Java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,7 @@
           <forceCreation>true</forceCreation>
           <archive>
             <manifestEntries>
+              <Launcher-Agent-Class>net.glowstone.util.ClassPathAgent</Launcher-Agent-Class>
               <Main-Class>net.glowstone.GlowServer</Main-Class>
               <Implementation-Title>${project.name}</Implementation-Title>
               <Implementation-Version>${project.version}.${describe}</Implementation-Version>

--- a/src/main/java/net/glowstone/util/ClassPathAgent.java
+++ b/src/main/java/net/glowstone/util/ClassPathAgent.java
@@ -1,0 +1,19 @@
+package net.glowstone.util;
+
+import java.lang.instrument.Instrumentation;
+import java.util.jar.JarFile;
+
+public class ClassPathAgent {
+
+    private static Instrumentation inst = null;
+
+    public static void agentmain(String agentArgs, Instrumentation instrumentation) {
+        inst = instrumentation;
+    }
+
+    static void addJarFile(JarFile file) {
+        if (inst != null) {
+            inst.appendToSystemClassLoaderSearch(file);
+        }
+    }
+}

--- a/src/main/java/net/glowstone/util/LibraryManager.java
+++ b/src/main/java/net/glowstone/util/LibraryManager.java
@@ -97,7 +97,7 @@ public final class LibraryManager {
 
             // hack it onto the classpath
             try {
-                String[] javaVersion = System.getProperty("java.version").split("\\.");
+                String[] javaVersion = System.getProperty("java.version").split("-")[0].split("\\.");
                 if (Integer.parseInt(javaVersion[0]) >= 9) {
                     ClassPathAgent.addJarFile(new JarFile(file));
                 } else {


### PR DESCRIPTION
The ClassPathAgent starts before the GlowServer and saves the Instrumentation for future use. (This Works only as of Java 9) The LibraryManager uses as of Java 9 the ClassPathAgent to add jars to the classpath.

Test with Oracle and OpenJDK 8+9
