### PR TITLE
Fix NullPointerException in ConsoleManager

### DIFF
--- a/src/main/java/net/glowstone/ConsoleManager.java
+++ b/src/main/java/net/glowstone/ConsoleManager.java
@@ -194,7 +194,7 @@ public final class ConsoleManager {
     }
 
     private String colorize(String string) {
-        if (string.indexOf(ChatColor.COLOR_CHAR) < 0) {
+        if (string == null || string.indexOf(ChatColor.COLOR_CHAR) < 0) {
             return string;  // no colors in the message
         } else if (!jline || !reader.getTerminal().isAnsiSupported()) {
             return ChatColor.stripColor(string);  // color not supported


### PR DESCRIPTION
When a null message is passed to the the logger, then a NPE was thrown.
Now 'null' is printed to the console.