### PR TITLE
Fix an NPE on player disconnect

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -702,7 +702,7 @@ public abstract class GlowEntity implements Entity {
 
         GlowPlayer player = session.getPlayer();
         if (player == null) {
-            // No update messages are needed
+            // Player disconnected while this task was pending
             return result;
         }
         boolean visible = player.canSeeEntity(this);

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -701,6 +701,10 @@ public abstract class GlowEntity implements Entity {
         List<Message> result = Lists.newArrayList();
 
         GlowPlayer player = session.getPlayer();
+        if (player == null) {
+            // No update messages are needed
+            return result;
+        }
         boolean visible = player.canSeeEntity(this);
         for (GlowEntity leashedEntity : leashedEntities) {
             if (visible && player.canSeeEntity(leashedEntity)) {


### PR DESCRIPTION
```
13:40:09 [SEVERE] Error while executing GlowTask{id=181, plugin=null,
sync=false: net.glowstone.entity.GlowPlayer$$Lambda$177/1192674151@4e453b75}
java.lang.NullPointerException
at
net.glowstone.entity.GlowEntity.createAfterSpawnMessage(GlowEntity.java:704)
at net.glowstone.entity.GlowPlayer.lambda$null$1(GlowPlayer.java:853)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown
Source)
at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
at net.glowstone.scheduler.GlowTask.run(GlowTask.java:168)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown
Source)
at java.base/java.util.concurrent.FutureTask.run(Unknown Source)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown
Source)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown
Source)
at java.base/java.lang.Thread.run(Unknown Source)
```