### PR TITLE
Fix wrong fall damage when switching gamemodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ dependency-reduced-pom.xml
 .settings
 .db
 .DS_Store
+.vscode

--- a/src/main/java/net/glowstone/command/minecraft/GameModeCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/GameModeCommand.java
@@ -22,7 +22,8 @@ public class GameModeCommand extends VanillaCommand {
      * Creates the instance for this command.
      */
     public GameModeCommand() {
-        super("gamemode", "Change the game mode of a player.", "/gamemode <mode> [player]", Collections.emptyList());
+        super("gamemode", "Change the game mode of a player.", "/gamemode <mode> [player]",
+            Collections.emptyList());
         setPermission("minecraft.command.gamemode");
     }
 
@@ -73,18 +74,21 @@ public class GameModeCommand extends VanillaCommand {
         String gameModeName = GameModeUtils.prettyPrint(gameMode);
         who.setGameMode(gameMode);
         if (!sender.equals(who)) {
-            sender.sendMessage(who.getDisplayName() + "'s game mode has been updated to " + ChatColor.GRAY + ""
+            sender.sendMessage(
+                who.getDisplayName() + "'s game mode has been updated to " + ChatColor.GRAY + ""
                     + ChatColor.ITALIC + gameModeName + " Mode" + ChatColor.RESET);
         }
-        who.sendMessage("Your game mode has been updated to " + ChatColor.GRAY + "" + ChatColor.ITALIC + gameModeName
-                + " Mode" + ChatColor.RESET);
+        who.sendMessage(
+            "Your game mode has been updated to " + ChatColor.GRAY + "" + ChatColor.ITALIC
+                + gameModeName + " Mode" + ChatColor.RESET);
     }
 
     @Override
-    public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args)
+        throws IllegalArgumentException {
         if (args.length == 1) {
             return (List) StringUtil.copyPartialMatches(args[0], GameModeUtils.GAMEMODE_NAMES,
-                    new ArrayList(GameModeUtils.GAMEMODE_NAMES.size()));
+                new ArrayList(GameModeUtils.GAMEMODE_NAMES.size()));
         }
         return super.tabComplete(sender, alias, args);
     }

--- a/src/main/java/net/glowstone/command/minecraft/GameModeCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/GameModeCommand.java
@@ -22,8 +22,7 @@ public class GameModeCommand extends VanillaCommand {
      * Creates the instance for this command.
      */
     public GameModeCommand() {
-        super("gamemode", "Change the game mode of a player.", "/gamemode <mode> [player]",
-            Collections.emptyList());
+        super("gamemode", "Change the game mode of a player.", "/gamemode <mode> [player]", Collections.emptyList());
         setPermission("minecraft.command.gamemode");
     }
 
@@ -73,22 +72,20 @@ public class GameModeCommand extends VanillaCommand {
     private void updateGameMode(CommandSender sender, Player who, GameMode gameMode) {
         String gameModeName = GameModeUtils.prettyPrint(gameMode);
         who.setGameMode(gameMode);
+        who.setFallDistance(0);
         if (!sender.equals(who)) {
-            sender.sendMessage(
-                who.getDisplayName() + "'s game mode has been updated to " + ChatColor.GRAY + ""
+            sender.sendMessage(who.getDisplayName() + "'s game mode has been updated to " + ChatColor.GRAY + ""
                     + ChatColor.ITALIC + gameModeName + " Mode" + ChatColor.RESET);
         }
-        who.sendMessage(
-            "Your game mode has been updated to " + ChatColor.GRAY + "" + ChatColor.ITALIC
-                + gameModeName + " Mode" + ChatColor.RESET);
+        who.sendMessage("Your game mode has been updated to " + ChatColor.GRAY + "" + ChatColor.ITALIC + gameModeName
+                + " Mode" + ChatColor.RESET);
     }
 
     @Override
-    public List<String> tabComplete(CommandSender sender, String alias, String[] args)
-        throws IllegalArgumentException {
+    public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
         if (args.length == 1) {
             return (List) StringUtil.copyPartialMatches(args[0], GameModeUtils.GAMEMODE_NAMES,
-                new ArrayList(GameModeUtils.GAMEMODE_NAMES.size()));
+                    new ArrayList(GameModeUtils.GAMEMODE_NAMES.size()));
         }
         return super.tabComplete(sender, alias, args);
     }

--- a/src/main/java/net/glowstone/command/minecraft/GameModeCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/GameModeCommand.java
@@ -72,7 +72,6 @@ public class GameModeCommand extends VanillaCommand {
     private void updateGameMode(CommandSender sender, Player who, GameMode gameMode) {
         String gameModeName = GameModeUtils.prettyPrint(gameMode);
         who.setGameMode(gameMode);
-        who.setFallDistance(0);
         if (!sender.equals(who)) {
             sender.sendMessage(who.getDisplayName() + "'s game mode has been updated to " + ChatColor.GRAY + ""
                     + ChatColor.ITALIC + gameModeName + " Mode" + ChatColor.RESET);

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -1481,6 +1481,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             }
 
             super.setGameMode(mode);
+            super.setFallDistance(0);
             updateUserListEntries(UserListItemMessage.gameModeOne(getUniqueId(), mode.getValue()));
             session.send(new StateChangeMessage(Reason.GAMEMODE, mode.getValue()));
         }


### PR DESCRIPTION
```This is my first ever pull request, please have mercy if I did something wrong😄```

This pull request tries to fix bug that when switching to game mode 0 from game mode 1, the player receives incorrect fall damage.

Steps to recreate:
1. In game mode 0, land on floor
2. Switch to game mode 1 and fly to a certain height
3. Lower the height to barely touching the floor (not actually standing on the floor)
4. Switch back to game mode 0 and the player receives fall damage. The damage can sometimes kill the player. 

Observed behavior:
The player receives fall damage calculated from the maximum height during game mode 1

Expected behavior:
The player receives fall damage calculated from the location where the player's game mode changes. For example, the player should not receive damage when he/she's only 2 blocks above the floor when the game mode switches. 

Solution:
I have added an extra statement to reset the player's fall distance when switching game mode. At line 75 of file ```GameModeCommand.java```