### PR TITLE
Fix implementation of Player.getVirtualHost()/getProtocolVersion()

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -1289,13 +1289,13 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public int getProtocolVersion() {
-        return GlowServer.PROTOCOL_VERSION;
+        return session.getVersion();
     }
 
     @Nullable
     @Override
     public InetSocketAddress getVirtualHost() {
-        return session.getAddress();
+        return session.getVirtualHost();
     }
 
     @Override

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -104,12 +104,11 @@ public class GlowSession extends BasicSession {
     private String verifyUsername;
 
     /**
-     * Set the hostname the player used to connect to the server.
-     *
-     * @param hostname Hostname in "addr:port" format.
+     * The hostname/port the player used to connect to the server.
      */
+    @Getter
     @Setter
-    private String hostname;
+    private InetSocketAddress virtualHost;
 
     /**
      * The version used to connect.
@@ -182,7 +181,8 @@ public class GlowSession extends BasicSession {
     public void setProxyData(ProxyData proxyData) {
         this.proxyData = proxyData;
         address = proxyData.getAddress();
-        hostname = proxyData.getHostname();
+        virtualHost = InetSocketAddress.createUnresolved(
+                proxyData.getHostname(), virtualHost.getPort());
     }
 
     /**
@@ -264,7 +264,7 @@ public class GlowSession extends BasicSession {
         }
 
         // login event
-        PlayerLoginEvent event = EventFactory.onPlayerLogin(player, hostname);
+        PlayerLoginEvent event = EventFactory.onPlayerLogin(player, virtualHost.toString());
         if (event.getResult() != Result.ALLOWED) {
             disconnect(event.getKickMessage(), true);
             return;

--- a/src/main/java/net/glowstone/net/handler/handshake/HandshakeHandler.java
+++ b/src/main/java/net/glowstone/net/handler/handshake/HandshakeHandler.java
@@ -1,6 +1,7 @@
 package net.glowstone.net.handler.handshake;
 
 import com.flowpowered.network.MessageHandler;
+import java.net.InetSocketAddress;
 import java.util.logging.Level;
 import net.glowstone.GlowServer;
 import net.glowstone.net.GlowSession;
@@ -23,7 +24,8 @@ public class HandshakeHandler implements MessageHandler<GlowSession, HandshakeMe
         }
 
         session.setVersion(message.getVersion());
-        session.setHostname(message.getAddress() + ":" + message.getPort());
+        session.setVirtualHost(InetSocketAddress.createUnresolved(
+                message.getAddress(), message.getPort()));
 
         // Proxies modify the hostname in the HandshakeMessage to contain
         // the client's UUID and (optionally) properties


### PR DESCRIPTION
Right now, `Player.getVirtualHost()` returns the client's IP address. However, it is actually supposed to return the hostname/port the player used to connect to the server.

Correct this and also make use of the version information in GlowSession instead of just returning the constant.

For reference: API was added in https://github.com/PaperMC/Paper/pull/914