### PR TITLE
Fix SLF4J logging for plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-jdk14</artifactId>
       <version>1.7.25</version>
       <scope>runtime</scope>
     </dependency>


### PR DESCRIPTION
SLF4J logging for plugins is a feature introduced in PaperMC/Paper#890. Plugins should be able to use SLF4J as alternative logging API.

All that is necessary to make that work is a proper SLF4J adapter implementation. However, right now Glowstone includes the SLF4J implementation for Log4j 1.x, which isn't used in Glowstone at all. (This was incorrectly added in #612)

Include the correct SLF4J implementation for the java.util.logging API to make SLF4J logging work correctly.