### PR TITLE
Track Additional Movement Statistics

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -1479,6 +1479,16 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         return false;
     }
 
+    @Override
+    public void setOnGround(boolean onGround) {
+        float fallDistance = getFallDistance();
+        if (onGround && fallDistance > 2.0F) {
+            int fallDistanceStatistic = (int) Math.round(fallDistance * 100.0D);
+            this.incrementStatistic(Statistic.FALL_ONE_CM, fallDistanceStatistic);
+        }
+        super.setOnGround(onGround);
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Player capabilities
 
@@ -3341,6 +3351,11 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
      */
     public boolean isInWater() {
         Material mat = getLocation().getBlock().getType();
+        return mat == Material.WATER || mat == Material.STATIONARY_WATER;
+    }
+
+    public boolean isEyeInWater() {
+        Material mat = getEyeLocation().getBlock().getType();
         return mat == Material.WATER || mat == Material.STATIONARY_WATER;
     }
 

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
@@ -5,6 +5,10 @@ import java.util.Objects;
 import net.glowstone.EventFactory;
 import net.glowstone.GlowServer;
 import net.glowstone.entity.GlowPlayer;
+import net.glowstone.entity.objects.GlowBoat;
+import net.glowstone.entity.objects.GlowMinecart;
+import net.glowstone.entity.passive.GlowHorse;
+import net.glowstone.entity.passive.GlowPig;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.game.PositionRotationMessage;
 import net.glowstone.net.message.play.player.PlayerUpdateMessage;
@@ -119,29 +123,54 @@ public final class PlayerUpdateHandler implements MessageHandler<GlowSession, Pl
         delta.setX(Math.abs(delta.getX()));
         delta.setY(Math.abs(delta.getY()));
         delta.setZ(Math.abs(delta.getZ()));
-        int flatDistance = (int) Math.round(Math.sqrt(
-            NumberConversions.square(delta.getX()) + NumberConversions.square(delta.getZ()))
-            * 100.0);
-        if (message.isOnGround()) {
-            if (flatDistance > 0) {
-                if (player.isSprinting()) {
-                    player.incrementStatistic(Statistic.SPRINT_ONE_CM, flatDistance);
-                } else if (player.isSneaking()) {
-                    player.incrementStatistic(Statistic.CROUCH_ONE_CM, flatDistance);
-                } else {
-                    player.incrementStatistic(Statistic.WALK_ONE_CM, flatDistance);
+        if (player.isInsideVehicle()) {
+            int cubeDistance = (int) Math.round(delta.length() * 100.0);
+            if (cubeDistance > 0) {
+                if (player.getVehicle() instanceof GlowMinecart) {
+                    player.incrementStatistic(Statistic.MINECART_ONE_CM, cubeDistance);
+                } else if (player.getVehicle() instanceof GlowBoat) {
+                    player.incrementStatistic(Statistic.BOAT_ONE_CM, cubeDistance);
+                } else if (player.getVehicle() instanceof GlowPig) {
+                    player.incrementStatistic(Statistic.PIG_ONE_CM, cubeDistance);
+                } else if (player.getVehicle() instanceof GlowHorse) {
+                    player.incrementStatistic(Statistic.HORSE_ONE_CM, cubeDistance);
                 }
             }
-        } else if (player.isFlying()) {
-            if (flatDistance > 0) {
-                player.incrementStatistic(Statistic.FLY_ONE_CM, flatDistance);
+        }
+        if (player.isEyeInWater()) {
+            int cubeDistance = (int) Math.round(delta.length() * 100.0);
+            if (cubeDistance > 0) {
+                player.incrementStatistic(Statistic.DIVE_ONE_CM, cubeDistance);
             }
-        } else if (player.isInWater()) {
-            if (flatDistance > 0) {
-                player.incrementStatistic(Statistic.SWIM_ONE_CM, flatDistance);
+        } else {
+            int flatDistance = (int) Math.round(Math.sqrt(
+                    NumberConversions.square(delta.getX()) + NumberConversions.square(delta.getZ()))
+                    * 100.0);
+            if (player.isInWater()) {
+                if (flatDistance > 0) {
+                    player.incrementStatistic(Statistic.SWIM_ONE_CM, flatDistance);
+                }
+            }
+            if (message.isOnGround()) {
+                if (flatDistance > 0) {
+                    if (player.isSprinting()) {
+                        player.incrementStatistic(Statistic.SPRINT_ONE_CM, flatDistance);
+                    } else if (player.isSneaking()) {
+                        player.incrementStatistic(Statistic.CROUCH_ONE_CM, flatDistance);
+                    } else {
+                        player.incrementStatistic(Statistic.WALK_ONE_CM, flatDistance);
+                    }
+                }
+            } else if (player.isGliding()) {
+                int cubeDistance = (int) Math.round(delta.length() * 100.0);
+                if (cubeDistance > 0) {
+                    player.incrementStatistic(Statistic.AVIATE_ONE_CM, cubeDistance);
+                }
+            } else if (player.isFlying()) {
+                if (flatDistance > 0) {
+                    player.incrementStatistic(Statistic.FLY_ONE_CM, flatDistance);
+                }
             }
         }
-
-
     }
 }


### PR DESCRIPTION
This PR adds the tracking of the movement statistics:
FALL_ONE_CM
MINECART_ONE_CM
BOAT_ONE_CM
AVIATE_ONE_CM (Elytra)
HORSE_ONE_CM
DIVE_ONE_CM
SWIM_ONE_CM
FLY_ONE_CM
Some of the mechanics for these statistics (for example minecart) are not yet implemented, and thus do not work yet, but I added them so that if they would be added in the feature, they would be tracked automatically.
I inspected the NMS code for how exactly these statistics are tracked, and thus they should be tracked the same as in vanilla.