### PR TITLE
Anvil sound fix on several blocks

### DIFF
--- a/src/main/java/net/glowstone/entity/objects/GlowFallingBlock.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowFallingBlock.java
@@ -146,11 +146,6 @@ public class GlowFallingBlock extends GlowEntity implements FallingBlock {
                 remove();
             } else {
                 placeFallingBlock();
-                if (material == Material.ANVIL) {
-                    ThreadLocalRandom random = ThreadLocalRandom.current();
-                    world.playSound(location, Sound.BLOCK_ANVIL_FALL, 4, (1.0F
-                            + (random.nextFloat() - random.nextFloat()) * 0.2F) * 0.7F);
-                }
                 remove();
             }
         }
@@ -168,6 +163,11 @@ public class GlowFallingBlock extends GlowEntity implements FallingBlock {
                     blockEntity.loadNbt(getBlockEntityCompoundTag());
                 }
             }
+        }
+        if (material == Material.ANVIL) {
+            ThreadLocalRandom random = ThreadLocalRandom.current();
+            world.playSound(location, Sound.BLOCK_ANVIL_FALL, 4, (1.0F
+                    + (random.nextFloat() - random.nextFloat()) * 0.2F) * 0.7F);
         }
     }
 


### PR DESCRIPTION
This PR fixes the sound when an anvil lands on several blocks:

DEAD_BUSH:
LONG_GRASS:
DOUBLE_PLANT:

I moved the code that produces the sound to the place block function, so that it would called everytime an anvil is placed when it lands.