### PR TITLE
Fix cactus dropping invalid item

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockCactus.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCactus.java
@@ -128,16 +128,9 @@ public class BlockCactus extends BlockType {
         }
     }
 
-    /**
-     * Get the items that will be dropped by digging the block.
-     * Specially overriten for cactus to remove data from the dropped item.
-     *
-     * @param me The cactus block it self.
-     * @param tool The tool used or {@code null} if fists or no tool was used.
-     * @return The drops that should be returned.
-     */
     @Override
     public Collection<ItemStack> getDrops(GlowBlock me, ItemStack tool) {
+        // Overridden for cactus to remove data from the dropped item
         return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.CACTUS)));
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockCactus.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCactus.java
@@ -1,5 +1,8 @@
 package net.glowstone.block.blocktype;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import net.glowstone.EventFactory;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
@@ -7,6 +10,7 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.block.BlockGrowEvent;
+import org.bukkit.inventory.ItemStack;
 
 public class BlockCactus extends BlockType {
 
@@ -122,5 +126,18 @@ public class BlockCactus extends BlockType {
             default:
                 return true;
         }
+    }
+
+    /**
+     * Get the items that will be dropped by digging the block.
+     * Specially overriten for cactus to remove data from the dropped item.
+     *
+     * @param me The cactus block it self.
+     * @param tool The tool used or {@code null} if fists or no tool was used.
+     * @return The drops that should be returned.
+     */
+    @Override
+    public Collection<ItemStack> getDrops(GlowBlock me, ItemStack tool) {
+        return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.CACTUS)));
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockSugarCane.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSugarCane.java
@@ -96,16 +96,9 @@ public class BlockSugarCane extends BlockNeedsAttached {
         return false;
     }
 
-    /**
-     * Get the items that will be dropped by digging the block.
-     * Specially overriten for sugar cane to remove data from the dropped item.
-     *
-     * @param me The sugar cane block it self.
-     * @param tool The tool used or {@code null} if fists or no tool was used.
-     * @return The drops that should be returned.
-     */
     @Override
     public Collection<ItemStack> getDrops(GlowBlock me, ItemStack tool) {
+        // Overridden for sugar cane to remove data from the dropped item
         return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.SUGAR_CANE)));
     }
 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockSugarCane.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSugarCane.java
@@ -49,7 +49,7 @@ public class BlockSugarCane extends BlockNeedsAttached {
         }
 
         GlowBlock blockAbove = block.getRelative(BlockFace.UP);
-        // check it's the highest block of cactus
+        // check it's the highest block of sugar cane
         if (blockAbove.isEmpty()) {
             // check the current cane height
             Block blockBelow = block.getRelative(BlockFace.DOWN);
@@ -96,6 +96,14 @@ public class BlockSugarCane extends BlockNeedsAttached {
         return false;
     }
 
+    /**
+     * Get the items that will be dropped by digging the block.
+     * Specially overriten for sugar cane to remove data from the dropped item.
+     *
+     * @param me The sugar cane block it self.
+     * @param tool The tool used or {@code null} if fists or no tool was used.
+     * @return The drops that should be returned.
+     */
     @Override
     public Collection<ItemStack> getDrops(GlowBlock me, ItemStack tool) {
         return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.SUGAR_CANE)));


### PR DESCRIPTION
This pull request mainly tries to fix a bug that the cactus will drop purple block when the internal data is not 0. It also fixes a typo and improves Javadoc.

Observed behavior:
Cactus drops purple block randomly when break, as seen in the screen shot below.
The purple blocks also groups together based on the data value.
This bug occurs more often when the cactus block is on top of a growing cactus.
![2018-01-30_10 21 37](https://user-images.githubusercontent.com/7459295/35576037-08b1a186-05ac-11e8-8671-b193f61a2b7a.png)

Expected behavior:
Cactus should always drop cactus item when break.

Other known issues:
1. The check style seems to fail on codes related to arrow?
1. When breaking a 3-blocks tall cactus or sugar cane, the items will drop but disappears right after they touch the floor. 