### PR TITLE
Fix dead bush drops nothing

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockDeadBush.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockDeadBush.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
+
+import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
@@ -28,6 +30,12 @@ public class BlockDeadBush extends BlockNeedsAttached {
 
     @Override
     public Collection<ItemStack> getDrops(GlowBlock me, ItemStack tool) {
+        // If the block below the dead bush is removed,
+        // the bush will simply disappear without dropping anything.
+        if (tool == null) {
+            return BlockDropless.EMPTY_STACK;
+        }
+
         // Dead bush drops it self when broken with shears
         if (tool.getType().equals(Material.SHEARS)) {
             return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.DEAD_BUSH)));

--- a/src/main/java/net/glowstone/block/blocktype/BlockDeadBush.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockDeadBush.java
@@ -4,8 +4,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
-
-import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;

--- a/src/main/java/net/glowstone/block/blocktype/BlockDeadBush.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockDeadBush.java
@@ -1,6 +1,9 @@
 package net.glowstone.block.blocktype;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
 import net.glowstone.block.GlowBlock;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
@@ -25,6 +28,14 @@ public class BlockDeadBush extends BlockNeedsAttached {
 
     @Override
     public Collection<ItemStack> getDrops(GlowBlock me, ItemStack tool) {
-        return BlockDropless.EMPTY_STACK;
+        // Dead bush drops it self when broken with shears
+        if (tool.getType().equals(Material.SHEARS)) {
+            return Collections.unmodifiableList(Arrays.asList(new ItemStack(Material.DEAD_BUSH)));
+        }
+
+        // Dead bush drops 0-2 sticks when broken without shears
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        return Collections.unmodifiableList(Arrays.asList(
+            new ItemStack(Material.STICK,random.nextInt(3))));
     }
 }


### PR DESCRIPTION
This pull request tries to fix the bug that dead bush drops nothing when breaks.

Observed behavior:
Dead bush drops nothing when breaks.

Expected behavior:
> Dead bushes drop 0–2 sticks when broken without shears. When shears are used, a dead bush will drop itself. If the block below the dead bush is removed, the bush will simply disappear without dropping anything. [Dead Bush](https://minecraft.gamepedia.com/Dead_Bush)

Solution:
Rewrite the getDrops() in BlockDeadBush.
Returns nothing when ```tool == null```
Returns the dead bush when tool is a shear, otherwise return 0-2 sticks.