### PR TITLE
Implement difficulties for starvation damage 

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -845,7 +845,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                 break;
             }
             default: {
-                // Do nothing when there're other game difficulties.
+                // Do nothing when there are other game difficulties.
             }
         }
 

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -818,8 +818,26 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             }
         }
 
-        if (foodLevel == 0 && getHealth() > 1 && ticksLived % 80 == 0) {
-            damage(1, DamageCause.STARVATION);
+        // Process food level and starvation based on difficulty.
+        if (world.getDifficulty().equals(Difficulty.PEACEFUL)) {
+            if (foodLevel < 20 && ticksLived % 20 == 0) {
+                foodLevel++;
+            }
+        }
+        if (world.getDifficulty().equals(Difficulty.EASY)) {
+            if (foodLevel == 0 && getHealth() > 10 && ticksLived % 80 == 0) {
+                damage(1, DamageCause.STARVATION);
+            }
+        }
+        if (world.getDifficulty().equals(Difficulty.NORMAL)) {
+            if (foodLevel == 0 && getHealth() > 1 && ticksLived % 80 == 0) {
+                damage(1, DamageCause.STARVATION);
+            }
+        }
+        if (world.getDifficulty().equals(Difficulty.HARD)) {
+            if (foodLevel == 0 && ticksLived % 80 == 0) {
+                damage(1, DamageCause.STARVATION);
+            }
         }
 
         // stream world

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -819,24 +819,33 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         }
 
         // Process food level and starvation based on difficulty.
-        if (world.getDifficulty().equals(Difficulty.PEACEFUL)) {
-            if (foodLevel < 20 && ticksLived % 20 == 0) {
-                foodLevel++;
+        switch (world.getDifficulty()) {
+            case PEACEFUL: {
+                if (foodLevel < 20 && ticksLived % 20 == 0) {
+                    foodLevel++;
+                }
+                break;
             }
-        }
-        if (world.getDifficulty().equals(Difficulty.EASY)) {
-            if (foodLevel == 0 && getHealth() > 10 && ticksLived % 80 == 0) {
-                damage(1, DamageCause.STARVATION);
+            case EASY: {
+                if (foodLevel == 0 && getHealth() > 10 && ticksLived % 80 == 0) {
+                    damage(1, DamageCause.STARVATION);
+                }
+                break;
             }
-        }
-        if (world.getDifficulty().equals(Difficulty.NORMAL)) {
-            if (foodLevel == 0 && getHealth() > 1 && ticksLived % 80 == 0) {
-                damage(1, DamageCause.STARVATION);
+            case NORMAL: {
+                if (foodLevel == 0 && getHealth() > 1 && ticksLived % 80 == 0) {
+                    damage(1, DamageCause.STARVATION);
+                }
+                break;
             }
-        }
-        if (world.getDifficulty().equals(Difficulty.HARD)) {
-            if (foodLevel == 0 && ticksLived % 80 == 0) {
-                damage(1, DamageCause.STARVATION);
+            case HARD: {
+                if (foodLevel == 0 && ticksLived % 80 == 0) {
+                    damage(1, DamageCause.STARVATION);
+                }
+                break;
+            }
+            default: {
+                // Do nothing when there're other game difficulties.
             }
         }
 


### PR DESCRIPTION
This pull request tries to fix the bug that starvation damage was not calculated based on world difficulty.

Observed behavior:
Starvation damage is the same across all difficulty level.

Expected behavior:

> When the hunger bar is at 0, the player's health will deplete at a rate of 1 every 4 seconds (this makes sleeping impossible). On Easy difficulty, the player's health stops dropping at 10, on Normal it stops at 1, and on Hard it keeps draining until either the player eats something or starves to death. [Hunger](https://minecraft.gamepedia.com/Hunger)

>  The hunger bar never depletes and players cannot eat anything except golden apples and chorus fruits, unless the player has switched to Peaceful when their hunger bar was below the maximum. Additionally, If the hunger bar is below the maximum, it quickly regenerates. [Difficulty](https://minecraft.gamepedia.com/Difficulty)