### PR TITLE
Update JUnit and PowerMock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.0.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <version>1.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <kotlin.version>1.2.20</kotlin.version>
+    <powermockVersion>2.0.0-beta.5</powermockVersion>
   </properties>
 
   <repositories>
@@ -106,9 +107,9 @@
     </dependency>
     <!-- Tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>4.12.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -119,14 +120,20 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>1.6.6</version>
+      <artifactId>powermock-core</artifactId>
+      <version>${powermockVersion}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-      <version>1.6.6</version>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermockVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>${powermockVersion}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/net/glowstone/command/minecraft/TestForBlocksCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/TestForBlocksCommandTest.java
@@ -36,10 +36,8 @@ public class TestForBlocksCommandTest {
 
         when(opPlayer.hasPermission("minecraft.command.testforblocks")).thenReturn(true);
         when(opPlayer.getWorld()).thenReturn(world);
-        when(world.getBlockAt(any(Location.class))).then((invocation) -> {
-            Location location = invocation.getArgument(0);
-            return blockStorage.getBlockAt(location);
-        });
+        when(world.getBlockAt(any(Location.class))).then(
+                (invocation) -> blockStorage.getBlockAt(invocation.getArgument(0)));
     }
 
     public void createCubeAt(int x, int y, int z) {

--- a/src/test/java/net/glowstone/command/minecraft/TestForBlocksCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/TestForBlocksCommandTest.java
@@ -37,7 +37,7 @@ public class TestForBlocksCommandTest {
         when(opPlayer.hasPermission("minecraft.command.testforblocks")).thenReturn(true);
         when(opPlayer.getWorld()).thenReturn(world);
         when(world.getBlockAt(any(Location.class))).then((invocation) -> {
-            Location location = invocation.getArgumentAt(0, Location.class);
+            Location location = invocation.getArgument(0);
             return blockStorage.getBlockAt(location);
         });
     }

--- a/src/test/java/net/glowstone/net/QueryTest.java
+++ b/src/test/java/net/glowstone/net/QueryTest.java
@@ -27,8 +27,6 @@ import net.glowstone.util.Convert;
 import org.bukkit.World;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/net/glowstone/net/QueryTest.java
+++ b/src/test/java/net/glowstone/net/QueryTest.java
@@ -33,6 +33,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -182,7 +183,7 @@ public class QueryTest {
     /**
      * Matches the content (nothing else) of two {@link DatagramPacket}s.
      */
-    private static class DatagramPacketMatcher extends BaseMatcher<DatagramPacket> {
+    private static class DatagramPacketMatcher implements ArgumentMatcher<DatagramPacket> {
 
         private final byte[] content;
 
@@ -191,18 +192,12 @@ public class QueryTest {
         }
 
         @Override
-        public boolean matches(Object obj) {
+        public boolean matches(DatagramPacket obj) {
             ByteBuf buf = ((DatagramPacket) obj).content();
             byte[] array = new byte[buf.readableBytes()];
             buf.readBytes(array);
             buf.readerIndex(buf.readerIndex() - array.length);
             return Arrays.equals(array, content);
-        }
-
-        @Override
-        public void describeTo(Description description) {
-            description.appendText(
-                "DatagramPacket(" + ByteBufUtil.hexDump(Unpooled.wrappedBuffer(content)) + ")");
         }
     }
 }


### PR DESCRIPTION
This allows our unit tests to run on JDK 9, if the following JVM command-line options are added:

```
--add-opens java.base/java.lang=ALL-UNNAMED \
--add-opens java.base/java.lang.reflect=ALL-UNNAMED \
--add-opens java.base/java.util=ALL-UNNAMED \
--add-opens java.base/java.util.concurrent=ALL-UNNAMED \
--add-opens java.base/java.net=ALL-UNNAMED \
--add-opens java.logging/java.util.logging=ALL-UNNAMED
```

Although this PR uses the JUnit Vintage API, which is almost entirely compatible with the JUnit 4 API (hence only 2 test classes need code changes), it also adds a dependency on the JUnit Jupiter API for new and migrated tests. Both APIs can be used side-by-side. Migrating to Jupiter will probably eventually let us eliminate the `--add-opens`; but https://github.com/powermock/powermock/issues/830 means a full migration may not be possible right away.