### PR TITLE
Fine tune ender pearl

### DIFF
--- a/src/main/java/net/glowstone/block/itemtype/ItemEnderPearl.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemEnderPearl.java
@@ -12,6 +12,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
 public class ItemEnderPearl extends ItemType {
+    private static final int ENDER_PEARL_COOLDOWN_TICKS = 20;
 
     @Override
     public void rightClickAir(GlowPlayer player, ItemStack holding) {
@@ -30,10 +31,12 @@ public class ItemEnderPearl extends ItemType {
     }
 
     private void throwEnderPearl(GlowPlayer player, ItemStack holding) {
-        if (!player.getGameMode().equals(GameMode.CREATIVE)) {
-            holding.setAmount(holding.getAmount() - 1);
+        if (player.getEnderPearlCooldown() == 0) {
+            if (!player.getGameMode().equals(GameMode.CREATIVE)) {
+                holding.setAmount(holding.getAmount() - 1);
+            }
+            throwEnderPearl(player);
         }
-        throwEnderPearl(player);
     }
 
     private void throwEnderPearl(GlowPlayer player) {
@@ -41,5 +44,6 @@ public class ItemEnderPearl extends ItemType {
         throwLoc.setY(throwLoc.getY() + 1.5);
         player.launchProjectile(EnderPearl.class);
         player.playSound(player.getLocation(), Sound.ENTITY_ENDERPEARL_THROW, 3, 1);
+        player.setEnderPearlCooldown(ENDER_PEARL_COOLDOWN_TICKS);
     }
 }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -520,6 +520,15 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
     private boolean forceStream = false;
 
     /**
+     * The player's ender pearl cooldown game tick counter.
+     * 1 second, or 20 game ticks by default.
+     * The player can use ender pearl again if equals 0.
+     */
+    @Getter
+    @Setter
+    private int enderPearlCooldown = 0;
+
+    /**
      * Creates a new player and adds it to the world.
      *
      * @param session The player's session.
@@ -847,6 +856,11 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             default: {
                 // Do nothing when there are other game difficulties.
             }
+        }
+
+        // process ender pearl cooldown, decrease by 1 every game tick.
+        if (enderPearlCooldown > 0) {
+            enderPearlCooldown--;
         }
 
         // stream world

--- a/src/main/java/net/glowstone/entity/projectile/GlowEnderPearl.java
+++ b/src/main/java/net/glowstone/entity/projectile/GlowEnderPearl.java
@@ -63,7 +63,7 @@ public class GlowEnderPearl extends GlowProjectile implements EnderPearl {
             Entity entity = (Entity) source;
             Location entityLocation = entity.getLocation();
 
-            // Add 1 to Y value. Otherwise the eneity will get stuck inside a block.
+            // Add 0.3 to Y value. Otherwise the eneity will get stuck inside a block.
             destination.add(0, 0.3, 0);
             // Renew the pitch and yaw value right before teleportation.
             destination.setPitch(entityLocation.getPitch());

--- a/src/main/java/net/glowstone/entity/projectile/GlowEnderPearl.java
+++ b/src/main/java/net/glowstone/entity/projectile/GlowEnderPearl.java
@@ -4,7 +4,6 @@ import com.flowpowered.network.Message;
 import io.netty.util.internal.ThreadLocalRandom;
 import java.util.Arrays;
 import java.util.List;
-
 import net.glowstone.entity.monster.GlowEndermite;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
 import net.glowstone.net.message.play.entity.EntityTeleportMessage;
@@ -22,8 +21,8 @@ import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.util.Vector;
 
 public class GlowEnderPearl extends GlowProjectile implements EnderPearl {
-
     private static final double ENDER_PEARL_DAMAGE = 5.0;
+    private static final double VERTICAL_GRAVITY_ACCEL = -0.03;
 
     /**
      * Creates a thrown ender pearl with default speed.
@@ -45,7 +44,7 @@ public class GlowEnderPearl extends GlowProjectile implements EnderPearl {
         setDrag(0.99, false);
         setDrag(0.99, true);
         setHorizontalAirDrag(1);
-        setGravityAccel(new Vector(0, -0.03, 0));
+        setGravityAccel(new Vector(0, VERTICAL_GRAVITY_ACCEL, 0));
         setVelocity(location.getDirection().multiply(speed));
         setBoundingBox(0.25, 0.25);
     }


### PR DESCRIPTION
This pull request tries to fine tune the details of the ender pearl.

Observed behavior:
1. Ender pearl trajectory is weird, can't travel very far.
2. No endermite spawn after using ender pearl
3. The 1 second cool down is broken
4. Ender pearl does not have a bonding box, causing it never collides with entities.

Expected behavior:
1. Ender pearl should have little friction when traveling in the air
2. Endermite has a 5% chance spawning
3. Player can only use ender pearl once per 1 second
4. Ender pearl does have a 0.25*0.25 bonding box. The data is found in [Entity](https://minecraft.gamepedia.com/Entity), "Types of entities" section, "Width * Height" column.

I previously submitted https://github.com/GlowstoneMC/Glowstone/pull/822, but later I found out the actual code merged is different from the one I submitted. The resulted bug is also fixed in this pull request.
https://github.com/GlowstoneMC/Glowstone/commit/9c3fce2b20a642eddf816b44437e345c5f3e4bbd did not fix the player's orientation problem because https://github.com/GlowstoneMC/Glowstone/blob/9c3fce2b20a642eddf816b44437e345c5f3e4bbd/src/main/java/net/glowstone/entity/projectile/GlowEnderPearl.java#L58
should be
```java
    entity.teleport(location, PlayerTeleportEvent.TeleportCause.ENDER_PEARL);
```

