### PR TITLE
Fix snow slab stacking

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockSnow.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSnow.java
@@ -3,6 +3,7 @@ package net.glowstone.block.blocktype;
 import java.util.Arrays;
 import java.util.Collection;
 import net.glowstone.EventFactory;
+import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.entity.GlowPlayer;
@@ -35,10 +36,15 @@ public class BlockSnow extends BlockNeedsAttached {
         // such as placing snow an extra block away from where it should
 
         if (state.getType() == Material.SNOW) {
-            // add another snow layer if possible
             byte data = state.getRawData();
-            if (data < 7) {
+
+            // add another snow layer if possible
+            if (data < 6) {
                 state.setRawData((byte) (data + 1));
+
+            // set to snow block if high enough
+            } else {
+                state.setType(Material.SNOW_BLOCK);
             }
         } else {
             // place first snow layer

--- a/src/main/java/net/glowstone/block/blocktype/BlockSnow.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSnow.java
@@ -3,7 +3,6 @@ package net.glowstone.block.blocktype;
 import java.util.Arrays;
 import java.util.Collection;
 import net.glowstone.EventFactory;
-import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.entity.GlowPlayer;


### PR DESCRIPTION
This pull request tries to fix the problem of a player being unable to continually stack snow. 

Observed:
When a player is stacking snow, they cannot stack another layer of snow if a block is filled.

Expected:
A player should be able to stack unlimited layers of snow on top of each other. 