### PR TITLE
Fix OOM kills on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
 version: 2
+machine:
+    environment:
+      _JAVA_OPTIONS: "-Xms1024m -Xmx1024m"
 jobs:
     build:
         docker:
@@ -7,7 +10,7 @@ jobs:
         working_directory: ~/glowstone
 
         environment:
-            MAVEN_OPTS: -Xmx3200m
+            MAVEN_OPTS: -Xmx1024m
 
         steps:
             - run: mvn --version


### PR DESCRIPTION
Maven forks a second VM to run the tests, so the heaps need to be small enough to leave room for both. Should make the build more reliable.