### PR TITLE
Fix Fire Ticks After Death

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -1162,6 +1162,10 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         // restore health
         setHealth(getMaxHealth());
         setFoodLevel(20);
+
+        // reset fire ticks
+        setFireTicks(0);
+
         worldLock.writeLock().lock();
         try {
             // determine spawn destination


### PR DESCRIPTION
This pull request aims to fix the fire ticks persisting after a player has died and respawned.

**Observed Behavior:**  Once a player dies while on fire, they will respawn with the previous fire ticks and continue to take damage.

**Expected Behavior:**  Once the player dies while on fire, they will be cleansed of the amount of prior fire ticks.

This is my first pull request, even though it is rather simple, please let me know if there is any changes that can be made.  Thanks!