### PR TITLE
Download runtime library dependencies, resolve conflicts against builtin libs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,17 +90,6 @@
       <artifactId>flow-network</artifactId>
       <version>1.2.3-SNAPSHOT</version>
     </dependency>
-    <!-- Kotlin -->
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-runtime</artifactId>
-      <version>${kotlin.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-reflect</artifactId>
-      <version>${kotlin.version}</version>
-    </dependency>
     <!-- OpenCL -->
     <dependency>
       <groupId>org.jogamp.gluegen</groupId>
@@ -111,6 +100,17 @@
       <groupId>org.jogamp.jocl</groupId>
       <artifactId>jocl-main</artifactId>
       <version>2.3.2</version>
+    </dependency>
+    <!-- Maven stuff -->
+    <dependency>
+      <groupId>com.tobedevoured.naether</groupId>
+      <artifactId>core</artifactId>
+      <version>0.15.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>3.0.3</version>
     </dependency>
     <!-- Tests -->
     <dependency>

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1050,7 +1050,7 @@ public final class GlowServer implements Server {
 
     private Naether createNaetherWithRepository(String repository, String libraryFolder) {
         Naether naether = new NaetherImpl();
-        naether.setLocalRepoPath(new File(libraryFolder).toPath().toAbsolutePath().toString());
+        naether.setLocalRepoPath(new File(libraryFolder).getAbsolutePath());
 
         try {
             // Must overwrite the collection here in order to remove Maven Central from it.

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -3,15 +3,22 @@ package net.glowstone;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.flowpowered.network.Message;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Sets;
 import com.jogamp.opencl.CLDevice;
 import com.jogamp.opencl.CLPlatform;
+import com.tobedevoured.naether.NaetherException;
+import com.tobedevoured.naether.api.Naether;
+import com.tobedevoured.naether.impl.NaetherImpl;
+import com.tobedevoured.naether.util.RepoBuilder;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.kqueue.KQueue;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
@@ -28,6 +35,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
@@ -36,9 +44,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.Getter;
 import net.glowstone.advancement.GlowAdvancement;
 import net.glowstone.advancement.GlowAdvancementDisplay;
@@ -136,6 +146,7 @@ import net.glowstone.util.config.ServerConfig;
 import net.glowstone.util.config.ServerConfig.Key;
 import net.glowstone.util.config.WorldConfig;
 import net.glowstone.util.library.Library;
+import net.glowstone.util.library.LibraryKey;
 import net.glowstone.util.library.LibraryManager;
 import net.glowstone.util.loot.LootingManager;
 import net.md_5.bungee.api.chat.BaseComponent;
@@ -412,6 +423,13 @@ public final class GlowServer implements Server {
      * Whether the macOS/BSD kqueue native transport is available for Netty.
      */
     public static final boolean KQUEUE = KQueue.isAvailable();
+    /**
+     * Libraries that are known to cause problems when loaded up via the server config or plugin
+     * dependencies.
+     */
+    private static final Set<LibraryKey> blacklistedRuntimeLibs = ImmutableSet.of(
+            new LibraryKey("it.unimi.dsi", "fastutil")
+    );
 
     /**
      * Creates a new server.
@@ -776,9 +794,10 @@ public final class GlowServer implements Server {
         }
 
         // Start loading plugins
-        List<Library> libraries = aggregateLibraries();
-        new LibraryManager(config.getString(Key.LIBRARY_REPOSITORY_URL),
-                config.getString(Key.LIBRARIES_FOLDER),
+        String repository = config.getString(Key.LIBRARY_REPOSITORY_URL);
+        String libraryFolder = config.getString(Key.LIBRARIES_FOLDER);
+        Set<Library> libraries = aggregateLibraries(repository, libraryFolder);
+        new LibraryManager(repository, libraryFolder,
                 config.getBoolean(Key.LIBRARY_CHECKSUM_VALIDATION),
                 config.getInt(Key.LIBRARY_DOWNLOAD_ATTEMPTS), libraries).run();
         loadPlugins();
@@ -1019,13 +1038,110 @@ public final class GlowServer implements Server {
         }
     }
 
+    private boolean serverContainsLibrary(Library library) {
+        return this.getClass().getResource(
+                String.format(
+                        "/META-INF/maven/%s/%s/pom.xml",
+                        library.getGroupId(),
+                        library.getArtifactId()
+                )
+        ) != null;
+    }
+
+    private Naether createNaetherWithRepository(String repository, String libraryFolder) {
+        Naether naether = new NaetherImpl();
+        naether.setLocalRepoPath(new File(libraryFolder).toPath().toAbsolutePath().toString());
+
+        try {
+            // Must overwrite the collection here in order to remove Maven Central from it.
+            naether.setRemoteRepositories(Sets.newHashSet(
+                    RepoBuilder.remoteRepositoryFromUrl(repository)
+            ));
+        } catch (MalformedURLException e) {
+            logger.log(Level.WARNING, "Unable to resolve library dependencies. Falling back to "
+                    + "explicitly defined dependencies only.", e);
+            return null;
+        }
+
+        return naether;
+    }
+
     /**
      * Aggregates libraries from all relevant sources together.
      */
-    private List<Library> aggregateLibraries() {
-        return config.getMapList(Key.LIBRARIES).stream()
+    private Set<Library> aggregateLibraries(String repository, String libraryFolder) {
+        Map<String, Naether> clients = new HashMap<>();
+        clients.put(null, createNaetherWithRepository(repository, libraryFolder));
+
+        Map<LibraryKey, Library> libraries = config.getMapList(Key.LIBRARIES).stream()
                 .map(Library::fromConfigMap)
-                .collect(Collectors.toList());
+                .peek(library -> {
+                    Naether naether = clients.computeIfAbsent(
+                        library.getRepository(),
+                        k -> createNaetherWithRepository(k, libraryFolder)
+                    );
+                    if (naether != null) {
+                        naether.addDependency(
+                            String.format(
+                                "%s:%s:jar:%s",
+                                library.getGroupId(),
+                                library.getArtifactId(),
+                                library.getVersion()
+                            )
+                        );
+                    }
+                })
+                .collect(Collectors.toMap(Library::getLibraryKey, Function.identity()));
+
+        Set<String> conflicts = libraries.values().stream()
+                .filter(this::serverContainsLibrary)
+                .map(Object::toString)
+                .collect(Collectors.toSet());
+
+        if (!conflicts.isEmpty()) {
+            String joinedConflicts = conflicts.stream()
+                    .collect(Collectors.joining("', '", "['", "']"));
+            logger.log(Level.SEVERE, String.format(
+                    "Libraries %s conflict with libraries built into this JAR file. Please fix"
+                            + " this issue and restart the server.",
+                    joinedConflicts
+            ));
+            System.exit(1);
+        }
+
+        Set<LibraryKey> seenDependencies = new HashSet<>();
+
+        Map<LibraryKey, Library> dependencies = clients.values().stream()
+                .filter(Objects::nonNull)
+                .flatMap(naether -> {
+                    try {
+                        naether.resolveDependencies(false);
+                        return naether.getDependenciesNotation().stream();
+                    } catch (NaetherException e) {
+                        logger.log(Level.WARNING, "Unable to resolve library dependencies. Falling"
+                                + " back to explicitly defined dependencies only.", e);
+                        return Stream.empty();
+                    }
+                })
+                .map(dependency -> {
+                    // same format as above, {groupId}:{artifactId}:jar:{version}
+                    String[] expanded = dependency.split(":");
+                    // TODO: populate the repository and checksum fields if possible
+                    return new Library(expanded[0], expanded[1], expanded[3]);
+                })
+                .filter(library -> !libraries.containsKey(library.getLibraryKey())
+                        && !serverContainsLibrary(library)
+                        && !blacklistedRuntimeLibs.contains(library.getLibraryKey()))
+                .collect(Collectors.toMap(
+                    Library::getLibraryKey,
+                    Function.identity(),
+                    (library1, library2) -> library1.compareTo(library2) > 0
+                        ? library1 : library2
+                ));
+
+        libraries.putAll(dependencies);
+
+        return new HashSet<>(libraries.values());
     }
 
     /**

--- a/src/main/java/net/glowstone/util/RectangularRegion.java
+++ b/src/main/java/net/glowstone/util/RectangularRegion.java
@@ -3,9 +3,9 @@ package net.glowstone.util;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.AbstractIterator;
 import java.util.Iterator;
+import javax.annotation.Nonnull;
 import lombok.Getter;
 import org.bukkit.Location;
-import org.jetbrains.annotations.NotNull;
 
 @Getter
 public class RectangularRegion {
@@ -88,7 +88,7 @@ public class RectangularRegion {
             this.iterableZ = iterableZ;
         }
 
-        @NotNull
+        @Nonnull
         @Override
         public Iterator<Location> iterator() {
             return new LocationIterator(lowCorner, iterableX, iterableY, iterableZ);
@@ -172,7 +172,7 @@ public class RectangularRegion {
             this.max = max;
         }
 
-        @NotNull
+        @Nonnull
         @Override
         public Iterator<Integer> iterator() {
             return new ForwardsAxisIterator(max);
@@ -208,7 +208,7 @@ public class RectangularRegion {
             this.max = max;
         }
 
-        @NotNull
+        @Nonnull
         @Override
         public Iterator<Integer> iterator() {
             return new BackwardsAxisIterator(max);

--- a/src/main/java/net/glowstone/util/config/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/config/ServerConfig.java
@@ -393,6 +393,12 @@ public final class ServerConfig implements DynamicallyTypedMap<ServerConfig.Key>
                     .add(new Library("org.apache.commons", "commons-lang3", "3.5",
                             HashAlgorithm.SHA1, "6c6c702c89bfff3cd9e80b04d668c5e190d588c6")
                             .toConfigMap())
+                    .add(new Library("org.jetbrains.kotlin", "kotlin-runtime", "1.2.21",
+                            HashAlgorithm.SHA1, "67558262649fc4ab2ade6b6a2999e636019e82a2")
+                            .toConfigMap())
+                    .add(new Library("org.jetbrains.kotlin", "kotlin-reflect", "1.2.21",
+                            HashAlgorithm.SHA1, "3159ff5936aa570a90050d385cb717fbb6c1723a")
+                            .toConfigMap())
                     .build();
 
     /**

--- a/src/main/java/net/glowstone/util/config/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/config/ServerConfig.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -16,12 +17,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.Level;
+import java.util.stream.Stream;
 import lombok.Getter;
 import net.glowstone.GlowServer;
 import net.glowstone.util.DynamicallyTypedMap;
 import net.glowstone.util.library.Library;
+import net.glowstone.util.library.LibraryKey;
 import net.glowstone.util.library.LibraryManager.HashAlgorithm;
 import org.bukkit.Difficulty;
 import org.bukkit.GameMode;
@@ -379,28 +383,30 @@ public final class ServerConfig implements DynamicallyTypedMap<ServerConfig.Key>
     }
 
     public static final String DEFAULT_KOTLIN_VERSION = "1.2.21";
-    private static final List<Map<?, ?>> DEFAULT_LIBRARIES_VALUE =
-            ImmutableList.<Map<?, ?>>builder()
-                    .add(new Library("org.xerial", "sqlite-jdbc", "3.21.0", HashAlgorithm.SHA1,
-                            "347e4d1d3e1dff66d389354af8f0021e62344584").toConfigMap())
-                    .add(new Library("mysql", "mysql-connector-java", "5.1.44", HashAlgorithm.SHA1,
-                            "61b6b998192c85bb581c6be90e03dcd4b9079db4").toConfigMap())
-                    .add(new Library("org.apache.logging.log4j", "log4j-api", "2.8.1",
-                            HashAlgorithm.SHA1, "e801d13612e22cad62a3f4f3fe7fdbe6334a8e72")
-                            .toConfigMap())
-                    .add(new Library("org.apache.logging.log4j", "log4j-core", "2.8.1",
-                            HashAlgorithm.SHA1, "4ac28ff2f1ddf05dae3043a190451e8c46b73c31")
-                            .toConfigMap())
-                    .add(new Library("org.apache.commons", "commons-lang3", "3.5",
-                            HashAlgorithm.SHA1, "6c6c702c89bfff3cd9e80b04d668c5e190d588c6")
-                            .toConfigMap())
-                    .add(new Library("org.jetbrains.kotlin", "kotlin-runtime",
-                            DEFAULT_KOTLIN_VERSION, HashAlgorithm.SHA1,
-                            "67558262649fc4ab2ade6b6a2999e636019e82a2").toConfigMap())
-                    .add(new Library("org.jetbrains.kotlin", "kotlin-reflect",
-                            DEFAULT_KOTLIN_VERSION, HashAlgorithm.SHA1,
-                            "3159ff5936aa570a90050d385cb717fbb6c1723a").toConfigMap())
-                    .build();
+    public static final Map<LibraryKey, Library> DEFAULT_RUNTIME_LIBRARIES = Stream.of(
+            new Library("org.xerial", "sqlite-jdbc", "3.21.0", HashAlgorithm.SHA1,
+                    "347e4d1d3e1dff66d389354af8f0021e62344584"),
+            new Library("mysql", "mysql-connector-java", "5.1.44", HashAlgorithm.SHA1,
+                    "61b6b998192c85bb581c6be90e03dcd4b9079db4"),
+            new Library("org.apache.logging.log4j", "log4j-api", "2.8.1",
+                    HashAlgorithm.SHA1, "e801d13612e22cad62a3f4f3fe7fdbe6334a8e72"),
+            new Library("org.apache.logging.log4j", "log4j-core", "2.8.1",
+                    HashAlgorithm.SHA1, "4ac28ff2f1ddf05dae3043a190451e8c46b73c31"),
+            new Library("org.apache.commons", "commons-lang3", "3.5",
+                    HashAlgorithm.SHA1, "6c6c702c89bfff3cd9e80b04d668c5e190d588c6"),
+            new Library("org.jetbrains.kotlin", "kotlin-runtime",
+                    DEFAULT_KOTLIN_VERSION, HashAlgorithm.SHA1,
+                    "67558262649fc4ab2ade6b6a2999e636019e82a2"),
+            new Library("org.jetbrains.kotlin", "kotlin-reflect",
+                    DEFAULT_KOTLIN_VERSION, HashAlgorithm.SHA1,
+                    "3159ff5936aa570a90050d385cb717fbb6c1723a")
+            )
+            .collect(ImmutableMap.toImmutableMap(Library::getLibraryKey, Function.identity()));
+    private static final List<Map<?, ?>> DEFAULT_LIBRARIES_VALUE = DEFAULT_RUNTIME_LIBRARIES
+            .values()
+            .stream()
+            .map(Library::toConfigMap)
+            .collect(ImmutableList.toImmutableList());
 
     /**
      * An enum containing configuration keys used by the server.

--- a/src/main/java/net/glowstone/util/config/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/config/ServerConfig.java
@@ -378,6 +378,7 @@ public final class ServerConfig implements DynamicallyTypedMap<ServerConfig.Key>
         return migrateStatus;
     }
 
+    public static final String DEFAULT_KOTLIN_VERSION = "1.2.21";
     private static final List<Map<?, ?>> DEFAULT_LIBRARIES_VALUE =
             ImmutableList.<Map<?, ?>>builder()
                     .add(new Library("org.xerial", "sqlite-jdbc", "3.21.0", HashAlgorithm.SHA1,
@@ -393,12 +394,12 @@ public final class ServerConfig implements DynamicallyTypedMap<ServerConfig.Key>
                     .add(new Library("org.apache.commons", "commons-lang3", "3.5",
                             HashAlgorithm.SHA1, "6c6c702c89bfff3cd9e80b04d668c5e190d588c6")
                             .toConfigMap())
-                    .add(new Library("org.jetbrains.kotlin", "kotlin-runtime", "1.2.21",
-                            HashAlgorithm.SHA1, "67558262649fc4ab2ade6b6a2999e636019e82a2")
-                            .toConfigMap())
-                    .add(new Library("org.jetbrains.kotlin", "kotlin-reflect", "1.2.21",
-                            HashAlgorithm.SHA1, "3159ff5936aa570a90050d385cb717fbb6c1723a")
-                            .toConfigMap())
+                    .add(new Library("org.jetbrains.kotlin", "kotlin-runtime",
+                            DEFAULT_KOTLIN_VERSION, HashAlgorithm.SHA1,
+                            "67558262649fc4ab2ade6b6a2999e636019e82a2").toConfigMap())
+                    .add(new Library("org.jetbrains.kotlin", "kotlin-reflect",
+                            DEFAULT_KOTLIN_VERSION, HashAlgorithm.SHA1,
+                            "3159ff5936aa570a90050d385cb717fbb6c1723a").toConfigMap())
                     .build();
 
     /**

--- a/src/main/java/net/glowstone/util/library/LibraryKey.java
+++ b/src/main/java/net/glowstone/util/library/LibraryKey.java
@@ -1,0 +1,43 @@
+package net.glowstone.util.library;
+
+import com.google.common.collect.ComparisonChain;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+/**
+ * Encapsulates the identifying pieces of a library in a Maven repository, its group ID and
+ * artifact ID. Can be safely used as a key in a map or within a set.
+ */
+@EqualsAndHashCode
+public class LibraryKey implements Comparable<LibraryKey> {
+    /**
+     * The group ID of the library in a maven-style repo. Parts of the group ID must be separated
+     * by periods.
+     */
+    @Getter
+    private final String groupId;
+
+    /**
+     * The artifact ID of the library in a maven-style repo.
+     */
+    @Getter
+    private final String artifactId;
+
+    public LibraryKey(String groupId, String artifactId) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+    }
+
+    @Override
+    public String toString() {
+        return groupId + ":" + artifactId;
+    }
+
+    @Override
+    public int compareTo(LibraryKey o) {
+        return ComparisonChain.start()
+                .compare(groupId, o.groupId)
+                .compare(artifactId, o.artifactId)
+                .result();
+    }
+}


### PR DESCRIPTION
This PR adds the ability for Glowstone to download dependencies for libraries specified in the glowstone.yml. It does so using an abstraction on top of Maven's Aether API, Naether, that makes dependency resolution fairly easy. I check the tree that is built up by this plugin against the libraries builtin to the server by searching the classpath for the dependency's POM, which maven-shade-plugin embeds into the JAR. I tried various methods (hence why this change took so long), and this seems to be the most stable way of attempting to do this.

In order to test this out, I downgraded Kotlin from being a builtin dependency to a library in the default glowstone.yml, since we don't actually use Kotlin in our own code. Watching the logs of server startup, you can see it download kotlin-runtime, kotlin-reflect, and kotlin-stdlib, the latter which is a dependency of kotlin-reflect.

Now, there's a few downsides to how I implemented this:
* The way I am checking for what dependencies Glowstone includes relies on an implementation detail from maven-shade-plugin. While not a large piece of code, it will have to be rewritten if we ever decide to move away from this plugin or from Maven in general. I tried exploring other possibilities, such as serializing the depndency tree at build time, but it proved to be a lot more work for not much more benefit.
* This requires embedding portions of Maven itself into Glowstone in order to perform the dependency resolution. While this doesn't tie us to Maven for builds like the dependency checking does, it still ties us to resolving dependencies in a certain way. If we decide to move build systems, it could be awkward to have two different ways of resolving dependencies depending on if they are runtime vs builtin. Currently, we're using Maven, so I think it's fine to use it for our library downloads as well.
* Naether provides the ability to download the dependencies itself, but I am explicitly disabling that since we have our own download manager. We may choose to use this at some point in the future, but I felt it was better to let this functionality bake before trying this out.

Let me know what you think of this change! I think the benefits of this outweigh the downsides listed above, but certainly there's room for improvement here.