### PR TITLE
Revert JDK 9 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ machine:
 jobs:
     build:
         docker:
-            - image: circleci/openjdk:9-jdk
+            - image: circleci/openjdk:8-jdk
 
         working_directory: ~/glowstone
 
@@ -43,7 +43,7 @@ jobs:
 
     build-deploy:
         docker:
-            - image: circleci/openjdk:9-jdk
+            - image: circleci/openjdk:8-jdk
 
         working_directory: ~/glowstone
 


### PR DESCRIPTION
This reverts the change of the Java version used in CircleCI, from 1.9 back to 1.8.

See #866 