### PR TITLE
Switch to machine executor rather than Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ machine:
       _JAVA_OPTIONS: "-Xms1024m -Xmx1024m"
 defaults: &defaults
     machine:
-        # Do not update this such that build-deploy would run on JDK9, until we drop support for JDK8
+        # If updating to a JDK9 image, ensure that build-deploy still tests against JDK8 until we drop support for it
         image: circleci/classic:201711-01
 
     working_directory: ~/glowstone

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ machine:
 jobs:
     build:
         machine:
+            # Do not update this such that build-deploy would run on JDK9, until we drop support for JDK8
             image: circleci/classic:201711-01
 
         working_directory: ~/glowstone

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,17 +2,18 @@ version: 2
 machine:
     environment:
       _JAVA_OPTIONS: "-Xms1024m -Xmx1024m"
+defaults: &defaults
+    machine:
+        # Do not update this such that build-deploy would run on JDK9, until we drop support for JDK8
+        image: circleci/classic:201711-01
+
+    working_directory: ~/glowstone
+
+    environment:
+        MAVEN_OPTS: -Xmx1024m
 jobs:
     build:
-        machine:
-            # Do not update this such that build-deploy would run on JDK9, until we drop support for JDK8
-            image: circleci/classic:201711-01
-
-        working_directory: ~/glowstone
-
-        environment:
-            MAVEN_OPTS: -Xmx1024m
-
+        <<: *defaults
         steps:
             - run: mvn --version
             - run: java -version
@@ -43,14 +44,7 @@ jobs:
                 destination: glowstone.jar
 
     build-deploy:
-        docker:
-            - image: circleci/openjdk:8-jdk
-
-        working_directory: ~/glowstone
-
-        environment:
-            MAVEN_OPTS: -Xmx1024m
-
+        <<: *defaults
         steps:
             - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ machine:
 jobs:
     build:
         machine:
-            image: circleci/openjdk:8-jdk
+            image: circleci/classic:201711-01
 
         working_directory: ~/glowstone
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ machine:
 jobs:
     build:
         machine:
-            - image: circleci/openjdk:8-jdk
+            image: circleci/openjdk:8-jdk
 
         working_directory: ~/glowstone
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ machine:
       _JAVA_OPTIONS: "-Xms1024m -Xmx1024m"
 jobs:
     build:
-        docker:
+        machine:
             - image: circleci/openjdk:9-jdk
 
         working_directory: ~/glowstone


### PR DESCRIPTION
May be the only way to stop OOM kills while still using CircleCI and properly supporting JDK8.

Relevant: #866