### PR TITLE
Reduce usage of PowerMock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.binarytweed</groupId>
+      <artifactId>quarantining-test-runner</artifactId>
+      <version>0.0.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <version>1.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -126,12 +126,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.binarytweed</groupId>
-      <artifactId>quarantining-test-runner</artifactId>
-      <version>0.0.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <version>1.3</version>

--- a/src/main/java/net/glowstone/ConsoleManager.java
+++ b/src/main/java/net/glowstone/ConsoleManager.java
@@ -350,7 +350,7 @@ public final class ConsoleManager {
 
         @Override
         public void run() {
-            ServerCommandEvent event = server.getEventFactory()
+            ServerCommandEvent event = EventFactory.getInstance()
                     .callEvent(new ServerCommandEvent(sender, command));
             if (!event.isCancelled()) {
                 server.dispatchCommand(sender, event.getCommand());

--- a/src/main/java/net/glowstone/ConsoleManager.java
+++ b/src/main/java/net/glowstone/ConsoleManager.java
@@ -350,7 +350,7 @@ public final class ConsoleManager {
 
         @Override
         public void run() {
-            ServerCommandEvent event = EventFactory
+            ServerCommandEvent event = server.getEventFactory()
                     .callEvent(new ServerCommandEvent(sender, command));
             if (!event.isCancelled()) {
                 server.dispatchCommand(sender, event.getCommand());

--- a/src/main/java/net/glowstone/EventFactory.java
+++ b/src/main/java/net/glowstone/EventFactory.java
@@ -39,9 +39,9 @@ import org.bukkit.scheduler.BukkitScheduler;
 /**
  * Central class for the calling of events.
  */
-public final class EventFactory {
+public class EventFactory {
 
-    private EventFactory() {
+    public EventFactory() {
     }
 
     /**
@@ -51,7 +51,7 @@ public final class EventFactory {
      * @param <T> The type of the event.
      * @return the called event
      */
-    public static <T extends Event> T callEvent(T event) {
+    public <T extends Event> T callEvent(T event) {
         Server server = Bukkit.getServer();
 
         if (event.isAsynchronous()) {
@@ -91,7 +91,7 @@ public final class EventFactory {
      * @return an AsyncPlayerPreLoginEvent
      */
     @SuppressWarnings("deprecation")
-    public static AsyncPlayerPreLoginEvent onPlayerPreLogin(String name, InetSocketAddress address,
+    public AsyncPlayerPreLoginEvent onPlayerPreLogin(String name, InetSocketAddress address,
             UUID uuid) {
         // call async event
         AsyncPlayerPreLoginEvent event = new AsyncPlayerPreLoginEvent(name, address
@@ -123,7 +123,7 @@ public final class EventFactory {
      * @param hostname the hostname that was used to connect to the server
      * @return the completed event
      */
-    public static PlayerLoginEvent onPlayerLogin(GlowPlayer player, String hostname) {
+    public PlayerLoginEvent onPlayerLogin(GlowPlayer player, String hostname) {
         Server server = player.getServer();
         InetAddress address = player.getAddress().getAddress();
         String addressString = address.getHostAddress();
@@ -157,7 +157,7 @@ public final class EventFactory {
      * @return the completed event
      */
     @SuppressWarnings("deprecation")
-    public static AsyncPlayerChatEvent onPlayerChat(boolean async, Player player, String message) {
+    public AsyncPlayerChatEvent onPlayerChat(boolean async, Player player, String message) {
         // call async event
         Set<Player> recipients = new HashSet<>(player.getServer().getOnlinePlayers());
         AsyncPlayerChatEvent event = new AsyncPlayerChatEvent(async, player, message, recipients);
@@ -180,16 +180,16 @@ public final class EventFactory {
         return event;
     }
 
-    public static PlayerJoinEvent onPlayerJoin(Player player) {
+    public PlayerJoinEvent onPlayerJoin(Player player) {
         return callEvent(new PlayerJoinEvent(player,
                 ChatColor.YELLOW + player.getName() + " joined the game"));
     }
 
-    public static PlayerKickEvent onPlayerKick(Player player, String reason) {
+    public PlayerKickEvent onPlayerKick(Player player, String reason) {
         return callEvent(new PlayerKickEvent(player, reason, null));
     }
 
-    public static PlayerQuitEvent onPlayerQuit(Player player) {
+    public PlayerQuitEvent onPlayerQuit(Player player) {
         return callEvent(new PlayerQuitEvent(player,
                 ChatColor.YELLOW + player.getName() + " left the game"));
     }
@@ -202,7 +202,7 @@ public final class EventFactory {
      * @param hand the active hand
      * @return the completed event
      */
-    public static PlayerInteractEvent onPlayerInteract(Player player, Action action,
+    public PlayerInteractEvent onPlayerInteract(Player player, Action action,
             EquipmentSlot hand) {
         return onPlayerInteract(player, action, hand, null, BlockFace.SELF);
     }
@@ -217,7 +217,7 @@ public final class EventFactory {
      * @param face the side of the block clicked
      * @return the completed event
      */
-    public static PlayerInteractEvent onPlayerInteract(Player player, Action action,
+    public PlayerInteractEvent onPlayerInteract(Player player, Action action,
             EquipmentSlot hand, Block clicked, BlockFace face) {
         return callEvent(new PlayerInteractEvent(player, action,
                 hand == EquipmentSlot.OFF_HAND ? player.getInventory().getItemInOffHand()
@@ -232,7 +232,7 @@ public final class EventFactory {
      * @param <T> the event's type
      * @return the completed event
      */
-    public static <T extends EntityDamageEvent> T onEntityDamage(T event) {
+    public <T extends EntityDamageEvent> T onEntityDamage(T event) {
         T result = callEvent(event);
         if (!result.isCancelled()) {
             result.getEntity().setLastDamageCause(result);

--- a/src/main/java/net/glowstone/EventFactory.java
+++ b/src/main/java/net/glowstone/EventFactory.java
@@ -50,7 +50,7 @@ public class EventFactory {
     @Setter
     private static EventFactory instance = new EventFactory();
 
-    public EventFactory() {
+    private EventFactory() {
     }
 
     /**

--- a/src/main/java/net/glowstone/EventFactory.java
+++ b/src/main/java/net/glowstone/EventFactory.java
@@ -9,6 +9,8 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.logging.Level;
+import lombok.Getter;
+import lombok.Setter;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.scheduler.GlowScheduler;
 import org.bukkit.BanList;
@@ -40,6 +42,13 @@ import org.bukkit.scheduler.BukkitScheduler;
  * Central class for the calling of events.
  */
 public class EventFactory {
+
+    /**
+     * The instance of this class. Setter should only be called in tests when mocking.
+     */
+    @Getter
+    @Setter
+    private static EventFactory instance = new EventFactory();
 
     public EventFactory() {
     }

--- a/src/main/java/net/glowstone/Explosion.java
+++ b/src/main/java/net/glowstone/Explosion.java
@@ -14,6 +14,7 @@ import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.message.play.game.ExplosionMessage;
 import net.glowstone.net.message.play.game.ExplosionMessage.Record;
 import net.glowstone.util.RayUtil;
+import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -73,6 +74,7 @@ public final class Explosion {
     private final boolean incendiary;
     private final boolean breakBlocks;
     private final GlowWorld world;
+    private final EventFactory eventFactory;
     private float power;
     private float yield = 0.3f;
 
@@ -114,6 +116,7 @@ public final class Explosion {
         this.incendiary = incendiary;
         this.breakBlocks = breakBlocks;
         world = (GlowWorld) location.getWorld();
+        eventFactory = world.getServer().getEventFactory();
     }
 
     /**
@@ -128,7 +131,7 @@ public final class Explosion {
         Set<BlockVector> droppedBlocks = calculateBlocks();
 
         List<Block> blocks = toBlockList(droppedBlocks);
-        EntityExplodeEvent event = EventFactory.callEvent(
+        EntityExplodeEvent event = eventFactory.callEvent(
                 new EntityExplodeEvent(source, location, blocks, yield));
         if (event.isCancelled()) {
             return false;
@@ -239,7 +242,7 @@ public final class Explosion {
         if (belowType == Material.AIR || belowType == Material.FIRE || !belowType.isFlammable()) {
             return;
         }
-        BlockIgniteEvent event = EventFactory.callEvent(
+        BlockIgniteEvent event = eventFactory.callEvent(
                 new BlockIgniteEvent(block, IgniteCause.EXPLOSION, source));
         if (event.isCancelled()) {
             return;

--- a/src/main/java/net/glowstone/Explosion.java
+++ b/src/main/java/net/glowstone/Explosion.java
@@ -73,7 +73,6 @@ public final class Explosion {
     private final boolean incendiary;
     private final boolean breakBlocks;
     private final GlowWorld world;
-    private final EventFactory eventFactory;
     private float power;
     private float yield = 0.3f;
 
@@ -115,7 +114,6 @@ public final class Explosion {
         this.incendiary = incendiary;
         this.breakBlocks = breakBlocks;
         world = (GlowWorld) location.getWorld();
-        eventFactory = EventFactory.getInstance();
     }
 
     /**
@@ -130,7 +128,7 @@ public final class Explosion {
         Set<BlockVector> droppedBlocks = calculateBlocks();
 
         List<Block> blocks = toBlockList(droppedBlocks);
-        EntityExplodeEvent event = eventFactory.callEvent(
+        EntityExplodeEvent event = EventFactory.getInstance().callEvent(
                 new EntityExplodeEvent(source, location, blocks, yield));
         if (event.isCancelled()) {
             return false;
@@ -241,7 +239,7 @@ public final class Explosion {
         if (belowType == Material.AIR || belowType == Material.FIRE || !belowType.isFlammable()) {
             return;
         }
-        BlockIgniteEvent event = eventFactory.callEvent(
+        BlockIgniteEvent event = EventFactory.getInstance().callEvent(
                 new BlockIgniteEvent(block, IgniteCause.EXPLOSION, source));
         if (event.isCancelled()) {
             return;

--- a/src/main/java/net/glowstone/Explosion.java
+++ b/src/main/java/net/glowstone/Explosion.java
@@ -14,7 +14,6 @@ import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.message.play.game.ExplosionMessage;
 import net.glowstone.net.message.play.game.ExplosionMessage.Record;
 import net.glowstone.util.RayUtil;
-import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -116,7 +115,7 @@ public final class Explosion {
         this.incendiary = incendiary;
         this.breakBlocks = breakBlocks;
         world = (GlowWorld) location.getWorld();
-        eventFactory = world.getServer().getEventFactory();
+        eventFactory = EventFactory.getInstance();
     }
 
     /**

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -202,7 +202,7 @@ import org.bukkit.util.permissions.DefaultPermissions;
  *
  * @author Graham Edgecombe
  */
-public final class GlowServer implements Server {
+public class GlowServer implements Server {
 
     /**
      * The logger for this class.
@@ -412,6 +412,11 @@ public final class GlowServer implements Server {
      * Whether the macOS/BSD kqueue native transport is available for Netty.
      */
     public static final boolean KQUEUE = KQueue.isAvailable();
+    /**
+     * The event factory.
+     */
+    @Getter
+    private final EventFactory eventFactory = new EventFactory();
 
     /**
      * Creates a new server.

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -412,11 +412,6 @@ public class GlowServer implements Server {
      * Whether the macOS/BSD kqueue native transport is available for Netty.
      */
     public static final boolean KQUEUE = KQueue.isAvailable();
-    /**
-     * The event factory.
-     */
-    @Getter
-    private final EventFactory eventFactory = new EventFactory();
 
     /**
      * Creates a new server.

--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -432,18 +432,18 @@ public class GlowWorld implements World {
                 .collect(Collectors.toMap(CommandFunction::getFullName, function -> function));
         server.addWorld(this);
         server.getLogger().info("Preparing spawn for " + name + "...");
-        server.getEventFactory().callEvent(new WorldInitEvent(this));
+        EventFactory.getInstance().callEvent(new WorldInitEvent(this));
 
         spawnChunkLock = keepSpawnLoaded ? newChunkLock("spawn") : null;
 
         setKeepSpawnInMemory(keepSpawnLoaded);
 
         server.getLogger().info("Preparing spawn for " + name + ": done");
-        server.getEventFactory().callEvent(new WorldLoadEvent(this));
+        EventFactory.getInstance().callEvent(new WorldLoadEvent(this));
 
         // pulse AI tasks
         //aiTaskService = Executors.newScheduledThreadPool(1);
-        eventFactory = server.getEventFactory();
+        eventFactory = EventFactory.getInstance();
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -240,7 +240,6 @@ public class GlowWorld implements World {
      * The functions for this world.
      */
     private final Map<String, CommandFunction> functions;
-    private final EventFactory eventFactory;
     /**
      * A lock kept on the spawn chunkManager.
      */
@@ -443,7 +442,6 @@ public class GlowWorld implements World {
 
         // pulse AI tasks
         //aiTaskService = Executors.newScheduledThreadPool(1);
-        eventFactory = EventFactory.getInstance();
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -851,7 +849,7 @@ public class GlowWorld implements World {
         if (anchor) {
             setKeepSpawnInMemory(keepSpawnLoaded);
         }
-        eventFactory.callEvent(new SpawnChangeEvent(this, oldSpawn));
+        EventFactory.getInstance().callEvent(new SpawnChangeEvent(this, oldSpawn));
         return true;
     }
 
@@ -1031,7 +1029,7 @@ public class GlowWorld implements World {
      * @param async if true, save asynchronously
      */
     public void save(boolean async) {
-        eventFactory.callEvent(new WorldSaveEvent(this));
+        EventFactory.getInstance().callEvent(new WorldSaveEvent(this));
 
         // save metadata
         writeWorldData(async);
@@ -1075,7 +1073,7 @@ public class GlowWorld implements World {
             List<BlockState> blockStates = new ArrayList<>(blockStateDelegate.getBlockStates());
             StructureGrowEvent growEvent
                     = new StructureGrowEvent(loc, type, false, null, blockStates);
-            eventFactory.callEvent(growEvent);
+            EventFactory.getInstance().callEvent(growEvent);
             if (!growEvent.isCancelled()) {
                 for (BlockState state : blockStates) {
                     state.update(true);
@@ -1422,10 +1420,10 @@ public class GlowWorld implements World {
             // function.accept(entity); TODO: work on type mismatches
             EntitySpawnEvent spawnEvent = null;
             if (entity instanceof LivingEntity) {
-                spawnEvent = eventFactory
+                spawnEvent = EventFactory.getInstance()
                         .callEvent(new CreatureSpawnEvent((LivingEntity) entity, reason));
             } else if (!(entity instanceof Item)) { // ItemSpawnEvent is called elsewhere
-                spawnEvent = eventFactory.callEvent(new EntitySpawnEvent(entity));
+                spawnEvent = EventFactory.getInstance().callEvent(new EntitySpawnEvent(entity));
             }
             if (spawnEvent != null && spawnEvent.isCancelled()) {
                 // TODO: separate spawning and construction for better event cancellation
@@ -1487,7 +1485,7 @@ public class GlowWorld implements World {
     @Override
     public GlowItem dropItem(Location location, ItemStack item) {
         GlowItem entity = new GlowItem(location, item);
-        ItemSpawnEvent event = eventFactory.callEvent(new ItemSpawnEvent(entity));
+        ItemSpawnEvent event = EventFactory.getInstance().callEvent(new ItemSpawnEvent(entity));
         if (event.isCancelled()) {
             entity.remove();
         }
@@ -1561,7 +1559,7 @@ public class GlowWorld implements World {
             boolean isSilent) {
         GlowLightningStrike strike = new GlowLightningStrike(loc, effect, isSilent);
         LightningStrikeEvent event = new LightningStrikeEvent(this, strike);
-        if (eventFactory.callEvent(event).isCancelled()) {
+        if (EventFactory.getInstance().callEvent(event).isCancelled()) {
             return null;
         }
         return strike;
@@ -1599,7 +1597,7 @@ public class GlowWorld implements World {
     public void setStorm(boolean hasStorm) {
         // call event
         WeatherChangeEvent event = new WeatherChangeEvent(this, hasStorm);
-        if (eventFactory.callEvent(event).isCancelled()) {
+        if (EventFactory.getInstance().callEvent(event).isCancelled()) {
             return;
         }
 
@@ -1626,7 +1624,7 @@ public class GlowWorld implements World {
     public void setThundering(boolean thundering) {
         // call event
         ThunderChangeEvent event = new ThunderChangeEvent(this, thundering);
-        if (eventFactory.callEvent(event).isCancelled()) {
+        if (EventFactory.getInstance().callEvent(event).isCancelled()) {
             return;
         }
 
@@ -1885,7 +1883,7 @@ public class GlowWorld implements World {
     public boolean unload() {
         // terminate task service
         //aiTaskService.shutdown();
-        if (eventFactory.callEvent(new WorldUnloadEvent(this)).isCancelled()) {
+        if (EventFactory.getInstance().callEvent(new WorldUnloadEvent(this)).isCancelled()) {
             return false;
         }
         try {

--- a/src/main/java/net/glowstone/block/GlowBlock.java
+++ b/src/main/java/net/glowstone/block/GlowBlock.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.Getter;
-import net.glowstone.EventFactory;
 import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.MaterialValueManager.ValueCollection;
@@ -654,15 +653,6 @@ public class GlowBlock implements Block {
             return subject.getWorld() + "," + subject.getX() + "," + subject.getY() + "," + subject
                     .getZ() + ":" + metadataKey;
         }
-    }
-
-    /**
-     * Returns the event factory that handles events related to this block.
-     *
-     * @return the event factory
-     */
-    public EventFactory getEventFactory() {
-        return world.getServer().getEventFactory();
     }
 }
 

--- a/src/main/java/net/glowstone/block/GlowBlock.java
+++ b/src/main/java/net/glowstone/block/GlowBlock.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.Getter;
+import net.glowstone.EventFactory;
 import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.MaterialValueManager.ValueCollection;
@@ -653,6 +654,15 @@ public class GlowBlock implements Block {
             return subject.getWorld() + "," + subject.getX() + "," + subject.getY() + "," + subject
                     .getZ() + ":" + metadataKey;
         }
+    }
+
+    /**
+     * Returns the event factory that handles events related to this block.
+     *
+     * @return the event factory
+     */
+    public EventFactory getEventFactory() {
+        return world.getServer().getEventFactory();
     }
 }
 

--- a/src/main/java/net/glowstone/block/blocktype/BlockCactus.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCactus.java
@@ -4,10 +4,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import net.glowstone.EventFactory;
-import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -67,7 +65,7 @@ public class BlockCactus extends BlockType {
                     state.setType(Material.CACTUS);
                     state.setRawData((byte) 0);
                     BlockGrowEvent growEvent = new BlockGrowEvent(blockAbove, state);
-                    block.getEventFactory().callEvent(growEvent);
+                    EventFactory.getInstance().callEvent(growEvent);
                     if (!growEvent.isCancelled()) {
                         state.update(true);
                     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockCactus.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCactus.java
@@ -4,8 +4,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import net.glowstone.EventFactory;
+import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -65,7 +67,7 @@ public class BlockCactus extends BlockType {
                     state.setType(Material.CACTUS);
                     state.setRawData((byte) 0);
                     BlockGrowEvent growEvent = new BlockGrowEvent(blockAbove, state);
-                    EventFactory.callEvent(growEvent);
+                    block.getEventFactory().callEvent(growEvent);
                     if (!growEvent.isCancelled()) {
                         state.update(true);
                     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockCocoa.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCocoa.java
@@ -5,11 +5,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
 import net.glowstone.EventFactory;
-import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.entity.GlowPlayer;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.TreeSpecies;
 import org.bukkit.block.BlockFace;
@@ -114,7 +112,7 @@ public class BlockCocoa extends BlockNeedsAttached implements IBlockGrowable {
             GlowBlockState state = block.getState();
             state.setData(cocoa);
             BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-            block.getEventFactory().callEvent(growEvent);
+            EventFactory.getInstance().callEvent(growEvent);
             if (!growEvent.isCancelled()) {
                 state.update(true);
             }
@@ -140,7 +138,7 @@ public class BlockCocoa extends BlockNeedsAttached implements IBlockGrowable {
                 GlowBlockState state = block.getState();
                 state.setData(cocoa);
                 BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-                block.getEventFactory().callEvent(growEvent);
+                EventFactory.getInstance().callEvent(growEvent);
                 if (!growEvent.isCancelled()) {
                     state.update(true);
                 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockCocoa.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCocoa.java
@@ -5,9 +5,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
 import net.glowstone.EventFactory;
+import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.entity.GlowPlayer;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.TreeSpecies;
 import org.bukkit.block.BlockFace;
@@ -112,7 +114,7 @@ public class BlockCocoa extends BlockNeedsAttached implements IBlockGrowable {
             GlowBlockState state = block.getState();
             state.setData(cocoa);
             BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-            EventFactory.callEvent(growEvent);
+            block.getEventFactory().callEvent(growEvent);
             if (!growEvent.isCancelled()) {
                 state.update(true);
             }
@@ -138,7 +140,7 @@ public class BlockCocoa extends BlockNeedsAttached implements IBlockGrowable {
                 GlowBlockState state = block.getState();
                 state.setData(cocoa);
                 BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-                EventFactory.callEvent(growEvent);
+                block.getEventFactory().callEvent(growEvent);
                 if (!growEvent.isCancelled()) {
                     state.update(true);
                 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockCrops.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCrops.java
@@ -5,11 +5,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
 import net.glowstone.EventFactory;
-import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.entity.GlowPlayer;
-import org.bukkit.Bukkit;
 import org.bukkit.CropState;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
@@ -55,7 +53,7 @@ public class BlockCrops extends BlockNeedsAttached implements IBlockGrowable {
         }
         state.setRawData((byte) cropState);
         BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-        block.getEventFactory().callEvent(growEvent);
+        EventFactory.getInstance().callEvent(growEvent);
         if (!growEvent.isCancelled()) {
             state.update(true);
         }
@@ -82,7 +80,7 @@ public class BlockCrops extends BlockNeedsAttached implements IBlockGrowable {
             }
             state.setRawData((byte) cropState);
             BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-            block.getEventFactory().callEvent(growEvent);
+            EventFactory.getInstance().callEvent(growEvent);
             if (!growEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockCrops.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockCrops.java
@@ -5,9 +5,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
 import net.glowstone.EventFactory;
+import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.entity.GlowPlayer;
+import org.bukkit.Bukkit;
 import org.bukkit.CropState;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
@@ -53,7 +55,7 @@ public class BlockCrops extends BlockNeedsAttached implements IBlockGrowable {
         }
         state.setRawData((byte) cropState);
         BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-        EventFactory.callEvent(growEvent);
+        block.getEventFactory().callEvent(growEvent);
         if (!growEvent.isCancelled()) {
             state.update(true);
         }
@@ -80,7 +82,7 @@ public class BlockCrops extends BlockNeedsAttached implements IBlockGrowable {
             }
             state.setRawData((byte) cropState);
             BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-            EventFactory.callEvent(growEvent);
+            block.getEventFactory().callEvent(growEvent);
             if (!growEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockEnderPortalFrame.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockEnderPortalFrame.java
@@ -3,11 +3,9 @@ package net.glowstone.block.blocktype;
 import java.util.ArrayList;
 import java.util.List;
 import net.glowstone.EventFactory;
-import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.entity.GlowPlayer;
-import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.PortalType;
@@ -109,7 +107,7 @@ public class BlockEnderPortalFrame extends BlockDropless {
                 blocks.add(state);
             }
         }
-        if (!player.getServer().getEventFactory()
+        if (!EventFactory.getInstance()
                 .callEvent(new EntityCreatePortalEvent(player, blocks, PortalType.ENDER))
                 .isCancelled()) {
             for (BlockState state : blocks) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockEnderPortalFrame.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockEnderPortalFrame.java
@@ -3,9 +3,11 @@ package net.glowstone.block.blocktype;
 import java.util.ArrayList;
 import java.util.List;
 import net.glowstone.EventFactory;
+import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.entity.GlowPlayer;
+import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.PortalType;
@@ -107,8 +109,9 @@ public class BlockEnderPortalFrame extends BlockDropless {
                 blocks.add(state);
             }
         }
-        if (!EventFactory.callEvent(new EntityCreatePortalEvent(player, blocks, PortalType.ENDER))
-            .isCancelled()) {
+        if (!player.getServer().getEventFactory()
+                .callEvent(new EntityCreatePortalEvent(player, blocks, PortalType.ENDER))
+                .isCancelled()) {
             for (BlockState state : blocks) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockFence.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockFence.java
@@ -2,12 +2,10 @@ package net.glowstone.block.blocktype;
 
 import com.google.common.collect.ImmutableList;
 import net.glowstone.EventFactory;
-import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.objects.GlowLeashHitch;
 import net.glowstone.inventory.MaterialMatcher;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.LeashHitch;
@@ -26,18 +24,17 @@ public class BlockFence extends BlockDirectDrops {
 
     @Override
     public boolean blockInteract(GlowPlayer player, GlowBlock block, BlockFace face,
-        Vector clickedLoc) {
+            Vector clickedLoc) {
         super.blockInteract(player, block, face, clickedLoc);
 
         if (!player.getLeashedEntities().isEmpty()) {
             LeashHitch leashHitch = GlowLeashHitch.getLeashHitchAt(block);
 
             ImmutableList.copyOf(player.getLeashedEntities()).stream()
-                .filter(
-                    e -> !(block.getEventFactory()
+                    .filter(e -> !(EventFactory.getInstance()
                             .callEvent(new PlayerLeashEntityEvent(e, leashHitch, player))
-                        .isCancelled()))
-                .forEach(e -> e.setLeashHolder(leashHitch));
+                            .isCancelled()))
+                    .forEach(e -> e.setLeashHolder(leashHitch));
             return true;
         }
         return false;

--- a/src/main/java/net/glowstone/block/blocktype/BlockFence.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockFence.java
@@ -2,10 +2,12 @@ package net.glowstone.block.blocktype;
 
 import com.google.common.collect.ImmutableList;
 import net.glowstone.EventFactory;
+import net.glowstone.GlowServer;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.objects.GlowLeashHitch;
 import net.glowstone.inventory.MaterialMatcher;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.LeashHitch;
@@ -32,8 +34,9 @@ public class BlockFence extends BlockDirectDrops {
 
             ImmutableList.copyOf(player.getLeashedEntities()).stream()
                 .filter(
-                    e -> !EventFactory.callEvent(new PlayerLeashEntityEvent(e, leashHitch, player))
-                        .isCancelled())
+                    e -> !(block.getEventFactory()
+                            .callEvent(new PlayerLeashEntityEvent(e, leashHitch, player))
+                        .isCancelled()))
                 .forEach(e -> e.setLeashHolder(leashHitch));
             return true;
         }

--- a/src/main/java/net/glowstone/block/blocktype/BlockFire.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockFire.java
@@ -5,11 +5,13 @@ import java.util.LinkedHashMap;
 import java.util.Map.Entry;
 import java.util.concurrent.ThreadLocalRandom;
 import net.glowstone.EventFactory;
+import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.constants.GlowBiomeClimate;
 import net.glowstone.entity.GlowPlayer;
+import org.bukkit.Bukkit;
 import org.bukkit.Difficulty;
 import org.bukkit.Material;
 import org.bukkit.World.Environment;
@@ -167,7 +169,8 @@ public class BlockFire extends BlockNeedsAttached {
                                         .nextInt(y > 1 ? 100 + 100 * (y - 1) : 100) <= resistance) {
                                         BlockIgniteEvent igniteEvent = new BlockIgniteEvent(
                                             propagationBlock, IgniteCause.SPREAD, block);
-                                        EventFactory.callEvent(igniteEvent);
+                                        world.getServer().getEventFactory()
+                                                .callEvent(igniteEvent);
                                         if (!igniteEvent.isCancelled()) {
                                             if (propagationBlock.getType() == Material.TNT) {
                                                 BlockTnt.igniteBlock(propagationBlock, false);
@@ -233,7 +236,7 @@ public class BlockFire extends BlockNeedsAttached {
         if (ThreadLocalRandom.current().nextInt(burnResistance) < block.getMaterialValues()
             .getFireResistance()) {
             BlockBurnEvent burnEvent = new BlockBurnEvent(block, from);
-            EventFactory.callEvent(burnEvent);
+            block.getEventFactory().callEvent(burnEvent);
             if (!burnEvent.isCancelled()) {
                 if (block.getType() == Material.TNT) {
                     BlockTnt.igniteBlock(block, false);

--- a/src/main/java/net/glowstone/block/blocktype/BlockFire.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockFire.java
@@ -5,13 +5,11 @@ import java.util.LinkedHashMap;
 import java.util.Map.Entry;
 import java.util.concurrent.ThreadLocalRandom;
 import net.glowstone.EventFactory;
-import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.constants.GlowBiomeClimate;
 import net.glowstone.entity.GlowPlayer;
-import org.bukkit.Bukkit;
 import org.bukkit.Difficulty;
 import org.bukkit.Material;
 import org.bukkit.World.Environment;
@@ -169,7 +167,7 @@ public class BlockFire extends BlockNeedsAttached {
                                         .nextInt(y > 1 ? 100 + 100 * (y - 1) : 100) <= resistance) {
                                         BlockIgniteEvent igniteEvent = new BlockIgniteEvent(
                                             propagationBlock, IgniteCause.SPREAD, block);
-                                        world.getServer().getEventFactory()
+                                        EventFactory.getInstance()
                                                 .callEvent(igniteEvent);
                                         if (!igniteEvent.isCancelled()) {
                                             if (propagationBlock.getType() == Material.TNT) {
@@ -236,7 +234,7 @@ public class BlockFire extends BlockNeedsAttached {
         if (ThreadLocalRandom.current().nextInt(burnResistance) < block.getMaterialValues()
             .getFireResistance()) {
             BlockBurnEvent burnEvent = new BlockBurnEvent(block, from);
-            block.getEventFactory().callEvent(burnEvent);
+            EventFactory.getInstance().callEvent(burnEvent);
             if (!burnEvent.isCancelled()) {
                 if (block.getType() == Material.TNT) {
                     BlockTnt.igniteBlock(block, false);

--- a/src/main/java/net/glowstone/block/blocktype/BlockGrass.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockGrass.java
@@ -72,7 +72,7 @@ public class BlockGrass extends BlockType implements IBlockGrowable {
                         }
                     }
                     BlockGrowEvent growEvent = new BlockGrowEvent(b, blockState);
-                    block.getEventFactory().callEvent(growEvent);
+                    EventFactory.getInstance().callEvent(growEvent);
                     if (!growEvent.isCancelled()) {
                         blockState.update(true);
                     }
@@ -104,7 +104,7 @@ public class BlockGrass extends BlockType implements IBlockGrowable {
             GlowBlockState state = block.getState();
             state.setType(Material.DIRT);
             BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-            block.getEventFactory().callEvent(fadeEvent);
+            EventFactory.getInstance().callEvent(fadeEvent);
             if (!fadeEvent.isCancelled()) {
                 state.update(true);
             }
@@ -131,7 +131,7 @@ public class BlockGrass extends BlockType implements IBlockGrowable {
                     state.setType(Material.GRASS);
                     state.setRawData((byte) 0);
                     BlockSpreadEvent spreadEvent = new BlockSpreadEvent(targetBlock, block, state);
-                    block.getEventFactory().callEvent(spreadEvent);
+                    EventFactory.getInstance().callEvent(spreadEvent);
                     if (!spreadEvent.isCancelled()) {
                         state.update(true);
                     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockGrass.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockGrass.java
@@ -72,7 +72,7 @@ public class BlockGrass extends BlockType implements IBlockGrowable {
                         }
                     }
                     BlockGrowEvent growEvent = new BlockGrowEvent(b, blockState);
-                    EventFactory.callEvent(growEvent);
+                    block.getEventFactory().callEvent(growEvent);
                     if (!growEvent.isCancelled()) {
                         blockState.update(true);
                     }
@@ -104,7 +104,7 @@ public class BlockGrass extends BlockType implements IBlockGrowable {
             GlowBlockState state = block.getState();
             state.setType(Material.DIRT);
             BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-            EventFactory.callEvent(fadeEvent);
+            block.getEventFactory().callEvent(fadeEvent);
             if (!fadeEvent.isCancelled()) {
                 state.update(true);
             }
@@ -131,7 +131,7 @@ public class BlockGrass extends BlockType implements IBlockGrowable {
                     state.setType(Material.GRASS);
                     state.setRawData((byte) 0);
                     BlockSpreadEvent spreadEvent = new BlockSpreadEvent(targetBlock, block, state);
-                    EventFactory.callEvent(spreadEvent);
+                    block.getEventFactory().callEvent(spreadEvent);
                     if (!spreadEvent.isCancelled()) {
                         state.update(true);
                     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockIce.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockIce.java
@@ -31,7 +31,7 @@ public class BlockIce extends BlockType {
             state.setType(type);
             state.setData(new MaterialData(type));
             BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-            block.getEventFactory().callEvent(fadeEvent);
+            EventFactory.getInstance().callEvent(fadeEvent);
             if (!fadeEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockIce.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockIce.java
@@ -31,7 +31,7 @@ public class BlockIce extends BlockType {
             state.setType(type);
             state.setData(new MaterialData(type));
             BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-            EventFactory.callEvent(fadeEvent);
+            block.getEventFactory().callEvent(fadeEvent);
             if (!fadeEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockLava.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLava.java
@@ -38,7 +38,7 @@ public class BlockLava extends BlockLiquid {
                 if (aboveB.isEmpty() && b.isFlammable()) {
                     BlockIgniteEvent igniteEvent = new BlockIgniteEvent(aboveB, IgniteCause.LAVA,
                         block);
-                    block.getEventFactory().callEvent(igniteEvent);
+                    EventFactory.getInstance().callEvent(igniteEvent);
                     if (!igniteEvent.isCancelled()) {
                         GlowBlockState state = aboveB.getState();
                         state.setType(Material.FIRE);
@@ -55,7 +55,7 @@ public class BlockLava extends BlockLiquid {
                     if (hasNearFlammableBlock(b)) {
                         BlockIgniteEvent igniteEvent = new BlockIgniteEvent(b, IgniteCause.LAVA,
                             block);
-                        block.getEventFactory().callEvent(igniteEvent);
+                        EventFactory.getInstance().callEvent(igniteEvent);
                         if (!igniteEvent.isCancelled()) {
                             GlowBlockState state = b.getState();
                             state.setType(Material.FIRE);

--- a/src/main/java/net/glowstone/block/blocktype/BlockLava.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLava.java
@@ -38,7 +38,7 @@ public class BlockLava extends BlockLiquid {
                 if (aboveB.isEmpty() && b.isFlammable()) {
                     BlockIgniteEvent igniteEvent = new BlockIgniteEvent(aboveB, IgniteCause.LAVA,
                         block);
-                    EventFactory.callEvent(igniteEvent);
+                    block.getEventFactory().callEvent(igniteEvent);
                     if (!igniteEvent.isCancelled()) {
                         GlowBlockState state = aboveB.getState();
                         state.setType(Material.FIRE);
@@ -55,7 +55,7 @@ public class BlockLava extends BlockLiquid {
                     if (hasNearFlammableBlock(b)) {
                         BlockIgniteEvent igniteEvent = new BlockIgniteEvent(b, IgniteCause.LAVA,
                             block);
-                        EventFactory.callEvent(igniteEvent);
+                        block.getEventFactory().callEvent(igniteEvent);
                         if (!igniteEvent.isCancelled()) {
                             GlowBlockState state = b.getState();
                             state.setType(Material.FIRE);

--- a/src/main/java/net/glowstone/block/blocktype/BlockLeaves.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLeaves.java
@@ -141,7 +141,7 @@ public class BlockLeaves extends BlockType {
 
             if (getBlockInMap(4, 4, 4) < 0) { // leaf decay
                 LeavesDecayEvent decayEvent = new LeavesDecayEvent(block);
-                EventFactory.callEvent(decayEvent);
+                block.getEventFactory().callEvent(decayEvent);
                 if (!decayEvent.isCancelled()) {
                     block.breakNaturally();
                 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockLeaves.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLeaves.java
@@ -141,7 +141,7 @@ public class BlockLeaves extends BlockType {
 
             if (getBlockInMap(4, 4, 4) < 0) { // leaf decay
                 LeavesDecayEvent decayEvent = new LeavesDecayEvent(block);
-                block.getEventFactory().callEvent(decayEvent);
+                EventFactory.getInstance().callEvent(decayEvent);
                 if (!decayEvent.isCancelled()) {
                     block.breakNaturally();
                 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockLitRedstoneOre.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLitRedstoneOre.java
@@ -18,7 +18,7 @@ public class BlockLitRedstoneOre extends BlockRedstoneOre {
         GlowBlockState state = block.getState();
         state.setType(Material.REDSTONE_ORE);
         BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-        EventFactory.callEvent(fadeEvent);
+        block.getEventFactory().callEvent(fadeEvent);
         if (!fadeEvent.isCancelled()) {
             state.update(true);
         }

--- a/src/main/java/net/glowstone/block/blocktype/BlockLitRedstoneOre.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLitRedstoneOre.java
@@ -18,7 +18,7 @@ public class BlockLitRedstoneOre extends BlockRedstoneOre {
         GlowBlockState state = block.getState();
         state.setType(Material.REDSTONE_ORE);
         BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-        block.getEventFactory().callEvent(fadeEvent);
+        EventFactory.getInstance().callEvent(fadeEvent);
         if (!fadeEvent.isCancelled()) {
             state.update(true);
         }

--- a/src/main/java/net/glowstone/block/blocktype/BlockMushroom.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockMushroom.java
@@ -80,7 +80,7 @@ public class BlockMushroom extends BlockNeedsAttached implements IBlockGrowable 
             List<BlockState> blockStates = new ArrayList<>(blockStateDelegate.getBlockStates());
             StructureGrowEvent growEvent = new StructureGrowEvent(loc, type, true, player,
                 blockStates);
-            EventFactory.callEvent(growEvent);
+            block.getEventFactory().callEvent(growEvent);
             if (!growEvent.isCancelled()) {
                 for (BlockState state : blockStates) {
                     state.update(true);
@@ -138,7 +138,7 @@ public class BlockMushroom extends BlockNeedsAttached implements IBlockGrowable 
                 GlowBlockState state = world.getBlockAt(nx, ny, nz).getState();
                 state.setType(mushroomType);
                 BlockSpreadEvent spreadEvent = new BlockSpreadEvent(state.getBlock(), block, state);
-                EventFactory.callEvent(spreadEvent);
+                block.getEventFactory().callEvent(spreadEvent);
                 if (!spreadEvent.isCancelled()) {
                     state.update(true);
                 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockMushroom.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockMushroom.java
@@ -80,7 +80,7 @@ public class BlockMushroom extends BlockNeedsAttached implements IBlockGrowable 
             List<BlockState> blockStates = new ArrayList<>(blockStateDelegate.getBlockStates());
             StructureGrowEvent growEvent = new StructureGrowEvent(loc, type, true, player,
                 blockStates);
-            block.getEventFactory().callEvent(growEvent);
+            EventFactory.getInstance().callEvent(growEvent);
             if (!growEvent.isCancelled()) {
                 for (BlockState state : blockStates) {
                     state.update(true);
@@ -138,7 +138,7 @@ public class BlockMushroom extends BlockNeedsAttached implements IBlockGrowable 
                 GlowBlockState state = world.getBlockAt(nx, ny, nz).getState();
                 state.setType(mushroomType);
                 BlockSpreadEvent spreadEvent = new BlockSpreadEvent(state.getBlock(), block, state);
-                block.getEventFactory().callEvent(spreadEvent);
+                EventFactory.getInstance().callEvent(spreadEvent);
                 if (!spreadEvent.isCancelled()) {
                     state.update(true);
                 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockMycel.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockMycel.java
@@ -31,7 +31,7 @@ public class BlockMycel extends BlockType {
             GlowBlockState state = block.getState();
             state.setType(Material.DIRT);
             BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-            block.getEventFactory().callEvent(fadeEvent);
+            EventFactory.getInstance().callEvent(fadeEvent);
             if (!fadeEvent.isCancelled()) {
                 state.update(true);
             }
@@ -57,7 +57,7 @@ public class BlockMycel extends BlockType {
                     state.setType(Material.MYCEL);
                     state.setRawData((byte) 0);
                     BlockSpreadEvent spreadEvent = new BlockSpreadEvent(targetBlock, block, state);
-                    block.getEventFactory().callEvent(spreadEvent);
+                    EventFactory.getInstance().callEvent(spreadEvent);
                     if (!spreadEvent.isCancelled()) {
                         state.update(true);
                     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockMycel.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockMycel.java
@@ -31,7 +31,7 @@ public class BlockMycel extends BlockType {
             GlowBlockState state = block.getState();
             state.setType(Material.DIRT);
             BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-            EventFactory.callEvent(fadeEvent);
+            block.getEventFactory().callEvent(fadeEvent);
             if (!fadeEvent.isCancelled()) {
                 state.update(true);
             }
@@ -57,7 +57,7 @@ public class BlockMycel extends BlockType {
                     state.setType(Material.MYCEL);
                     state.setRawData((byte) 0);
                     BlockSpreadEvent spreadEvent = new BlockSpreadEvent(targetBlock, block, state);
-                    EventFactory.callEvent(spreadEvent);
+                    block.getEventFactory().callEvent(spreadEvent);
                     if (!spreadEvent.isCancelled()) {
                         state.update(true);
                     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockNetherWart.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockNetherWart.java
@@ -36,7 +36,7 @@ public class BlockNetherWart extends BlockNeedsAttached {
             GlowBlockState state = block.getState();
             state.setRawData((byte) cropState);
             BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-            block.getEventFactory().callEvent(growEvent);
+            EventFactory.getInstance().callEvent(growEvent);
             if (!growEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockNetherWart.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockNetherWart.java
@@ -36,7 +36,7 @@ public class BlockNetherWart extends BlockNeedsAttached {
             GlowBlockState state = block.getState();
             state.setRawData((byte) cropState);
             BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-            EventFactory.callEvent(growEvent);
+            block.getEventFactory().callEvent(growEvent);
             if (!growEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneOre.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneOre.java
@@ -21,7 +21,7 @@ public class BlockRedstoneOre extends BlockRandomDrops {
         Vector clickedLoc) {
         EntityChangeBlockEvent changeBlockEvent = new EntityChangeBlockEvent(player, block,
             Material.GLOWING_REDSTONE_ORE, (byte) 0);
-        EventFactory.callEvent(changeBlockEvent);
+        block.getEventFactory().callEvent(changeBlockEvent);
         if (!changeBlockEvent.isCancelled()) {
             GlowBlockState state = block.getState();
             state.setType(Material.GLOWING_REDSTONE_ORE);

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstoneOre.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstoneOre.java
@@ -21,7 +21,7 @@ public class BlockRedstoneOre extends BlockRandomDrops {
         Vector clickedLoc) {
         EntityChangeBlockEvent changeBlockEvent = new EntityChangeBlockEvent(player, block,
             Material.GLOWING_REDSTONE_ORE, (byte) 0);
-        block.getEventFactory().callEvent(changeBlockEvent);
+        EventFactory.getInstance().callEvent(changeBlockEvent);
         if (!changeBlockEvent.isCancelled()) {
             GlowBlockState state = block.getState();
             state.setType(Material.GLOWING_REDSTONE_ORE);

--- a/src/main/java/net/glowstone/block/blocktype/BlockSapling.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSapling.java
@@ -116,7 +116,7 @@ public class BlockSapling extends BlockNeedsAttached implements IBlockGrowable {
             List<BlockState> blockStates = new ArrayList<>(blockStateDelegate.getBlockStates());
             StructureGrowEvent growEvent =
                 new StructureGrowEvent(loc, type, player != null, player, blockStates);
-            block.getEventFactory().callEvent(growEvent);
+            EventFactory.getInstance().callEvent(growEvent);
             if (!growEvent.isCancelled()) {
                 canGrow = true;
                 for (BlockState state : blockStates) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockSapling.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSapling.java
@@ -116,7 +116,7 @@ public class BlockSapling extends BlockNeedsAttached implements IBlockGrowable {
             List<BlockState> blockStates = new ArrayList<>(blockStateDelegate.getBlockStates());
             StructureGrowEvent growEvent =
                 new StructureGrowEvent(loc, type, player != null, player, blockStates);
-            EventFactory.callEvent(growEvent);
+            block.getEventFactory().callEvent(growEvent);
             if (!growEvent.isCancelled()) {
                 canGrow = true;
                 for (BlockState state : blockStates) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockSnow.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSnow.java
@@ -72,7 +72,7 @@ public class BlockSnow extends BlockNeedsAttached {
             state.setType(Material.AIR);
             state.setData(new MaterialData(Material.AIR));
             BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-            EventFactory.callEvent(fadeEvent);
+            block.getEventFactory().callEvent(fadeEvent);
             if (!fadeEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockSnow.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSnow.java
@@ -72,7 +72,7 @@ public class BlockSnow extends BlockNeedsAttached {
             state.setType(Material.AIR);
             state.setData(new MaterialData(Material.AIR));
             BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-            block.getEventFactory().callEvent(fadeEvent);
+            EventFactory.getInstance().callEvent(fadeEvent);
             if (!fadeEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockSnowBlock.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSnowBlock.java
@@ -34,7 +34,7 @@ public class BlockSnowBlock extends BlockType {
             state.setType(Material.AIR);
             state.setData(new MaterialData(Material.AIR));
             BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-            EventFactory.callEvent(fadeEvent);
+            block.getEventFactory().callEvent(fadeEvent);
             if (!fadeEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockSnowBlock.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSnowBlock.java
@@ -34,7 +34,7 @@ public class BlockSnowBlock extends BlockType {
             state.setType(Material.AIR);
             state.setData(new MaterialData(Material.AIR));
             BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-            block.getEventFactory().callEvent(fadeEvent);
+            EventFactory.getInstance().callEvent(fadeEvent);
             if (!fadeEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockSoil.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSoil.java
@@ -39,7 +39,7 @@ public class BlockSoil extends BlockType {
             state.setType(Material.DIRT);
             state.setRawData((byte) 0);
             BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-            block.getEventFactory().callEvent(fadeEvent);
+            EventFactory.getInstance().callEvent(fadeEvent);
             if (!fadeEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockSoil.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSoil.java
@@ -39,7 +39,7 @@ public class BlockSoil extends BlockType {
             state.setType(Material.DIRT);
             state.setRawData((byte) 0);
             BlockFadeEvent fadeEvent = new BlockFadeEvent(block, state);
-            EventFactory.callEvent(fadeEvent);
+            block.getEventFactory().callEvent(fadeEvent);
             if (!fadeEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockStem.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockStem.java
@@ -75,7 +75,7 @@ public class BlockStem extends BlockCrops {
         }
         state.setRawData((byte) cropState);
         BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-        block.getEventFactory().callEvent(growEvent);
+        EventFactory.getInstance().callEvent(growEvent);
         if (!growEvent.isCancelled()) {
             state.update(true);
         }
@@ -133,7 +133,7 @@ public class BlockStem extends BlockCrops {
                 GlowBlockState state = block.getState();
                 state.setRawData((byte) cropState);
                 BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-                block.getEventFactory().callEvent(growEvent);
+                EventFactory.getInstance().callEvent(growEvent);
                 if (!growEvent.isCancelled()) {
                     state.update(true);
                 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockStem.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockStem.java
@@ -75,7 +75,7 @@ public class BlockStem extends BlockCrops {
         }
         state.setRawData((byte) cropState);
         BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-        EventFactory.callEvent(growEvent);
+        block.getEventFactory().callEvent(growEvent);
         if (!growEvent.isCancelled()) {
             state.update(true);
         }
@@ -133,7 +133,7 @@ public class BlockStem extends BlockCrops {
                 GlowBlockState state = block.getState();
                 state.setRawData((byte) cropState);
                 BlockGrowEvent growEvent = new BlockGrowEvent(block, state);
-                EventFactory.callEvent(growEvent);
+                block.getEventFactory().callEvent(growEvent);
                 if (!growEvent.isCancelled()) {
                     state.update(true);
                 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockSugarCane.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSugarCane.java
@@ -72,7 +72,7 @@ public class BlockSugarCane extends BlockNeedsAttached {
                     state.setType(Material.SUGAR_CANE_BLOCK);
                     state.setRawData((byte) 0);
                     BlockGrowEvent growEvent = new BlockGrowEvent(blockAbove, state);
-                    EventFactory.callEvent(growEvent);
+                    block.getEventFactory().callEvent(growEvent);
                     if (!growEvent.isCancelled()) {
                         state.update(true);
                     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockSugarCane.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockSugarCane.java
@@ -72,7 +72,7 @@ public class BlockSugarCane extends BlockNeedsAttached {
                     state.setType(Material.SUGAR_CANE_BLOCK);
                     state.setRawData((byte) 0);
                     BlockGrowEvent growEvent = new BlockGrowEvent(blockAbove, state);
-                    block.getEventFactory().callEvent(growEvent);
+                    EventFactory.getInstance().callEvent(growEvent);
                     if (!growEvent.isCancelled()) {
                         state.update(true);
                     }

--- a/src/main/java/net/glowstone/block/blocktype/BlockTallGrass.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockTallGrass.java
@@ -81,7 +81,7 @@ public class BlockTallGrass extends BlockNeedsAttached implements IBlockGrowable
                     headBlockState.setType(Material.DOUBLE_PLANT);
                     headBlockState.setData(new DoublePlant(DoublePlantSpecies.PLANT_APEX));
                     BlockGrowEvent growEvent = new BlockGrowEvent(block, blockState);
-                    block.getEventFactory().callEvent(growEvent);
+                    EventFactory.getInstance().callEvent(growEvent);
                     if (!growEvent.isCancelled()) {
                         blockState.update(true);
                         headBlockState.update(true);

--- a/src/main/java/net/glowstone/block/blocktype/BlockTallGrass.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockTallGrass.java
@@ -81,7 +81,7 @@ public class BlockTallGrass extends BlockNeedsAttached implements IBlockGrowable
                     headBlockState.setType(Material.DOUBLE_PLANT);
                     headBlockState.setData(new DoublePlant(DoublePlantSpecies.PLANT_APEX));
                     BlockGrowEvent growEvent = new BlockGrowEvent(block, blockState);
-                    EventFactory.callEvent(growEvent);
+                    block.getEventFactory().callEvent(growEvent);
                     if (!growEvent.isCancelled()) {
                         blockState.update(true);
                         headBlockState.update(true);

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -352,7 +352,7 @@ public class BlockType extends ItemType {
         // call canBuild event
         boolean canBuild = canPlaceAt(target, face);
         BlockCanBuildEvent canBuildEvent = new BlockCanBuildEvent(target, getId(), canBuild);
-        if (!EventFactory.callEvent(canBuildEvent).isBuildable()) {
+        if (!player.getServer().getEventFactory().callEvent(canBuildEvent).isBuildable()) {
             //revert(player, target);
             return;
         }
@@ -373,7 +373,7 @@ public class BlockType extends ItemType {
         // call blockPlace event
         BlockPlaceEvent event = new BlockPlaceEvent(target, oldState, against, holding, player,
             canBuild, hand);
-        EventFactory.callEvent(event);
+        player.getServer().getEventFactory().callEvent(event);
         if (event.isCancelled() || !event.canBuild()) {
             oldState.update(true);
             return;

--- a/src/main/java/net/glowstone/block/blocktype/BlockType.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockType.java
@@ -352,7 +352,7 @@ public class BlockType extends ItemType {
         // call canBuild event
         boolean canBuild = canPlaceAt(target, face);
         BlockCanBuildEvent canBuildEvent = new BlockCanBuildEvent(target, getId(), canBuild);
-        if (!player.getServer().getEventFactory().callEvent(canBuildEvent).isBuildable()) {
+        if (!EventFactory.getInstance().callEvent(canBuildEvent).isBuildable()) {
             //revert(player, target);
             return;
         }
@@ -373,7 +373,7 @@ public class BlockType extends ItemType {
         // call blockPlace event
         BlockPlaceEvent event = new BlockPlaceEvent(target, oldState, against, holding, player,
             canBuild, hand);
-        player.getServer().getEventFactory().callEvent(event);
+        EventFactory.getInstance().callEvent(event);
         if (event.isCancelled() || !event.canBuild()) {
             oldState.update(true);
             return;

--- a/src/main/java/net/glowstone/block/blocktype/BlockVine.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockVine.java
@@ -182,7 +182,7 @@ public class BlockVine extends BlockClimbable {
         state.setData(vine);
         if (fromBlock != null) {
             BlockSpreadEvent spreadEvent = new BlockSpreadEvent(block, fromBlock, state);
-            block.getEventFactory().callEvent(spreadEvent);
+            EventFactory.getInstance().callEvent(spreadEvent);
             if (!spreadEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockVine.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockVine.java
@@ -182,7 +182,7 @@ public class BlockVine extends BlockClimbable {
         state.setData(vine);
         if (fromBlock != null) {
             BlockSpreadEvent spreadEvent = new BlockSpreadEvent(block, fromBlock, state);
-            EventFactory.callEvent(spreadEvent);
+            block.getEventFactory().callEvent(spreadEvent);
             if (!spreadEvent.isCancelled()) {
                 state.update(true);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockWater.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockWater.java
@@ -32,7 +32,7 @@ public class BlockWater extends BlockLiquid {
                 state.setType(Material.ICE);
                 state.setData(new MaterialData(Material.ICE));
                 BlockSpreadEvent spreadEvent = new BlockSpreadEvent(state.getBlock(), block, state);
-                block.getEventFactory().callEvent(spreadEvent);
+                EventFactory.getInstance().callEvent(spreadEvent);
                 if (!spreadEvent.isCancelled()) {
                     state.update(true);
                 }

--- a/src/main/java/net/glowstone/block/blocktype/BlockWater.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockWater.java
@@ -32,7 +32,7 @@ public class BlockWater extends BlockLiquid {
                 state.setType(Material.ICE);
                 state.setData(new MaterialData(Material.ICE));
                 BlockSpreadEvent spreadEvent = new BlockSpreadEvent(state.getBlock(), block, state);
-                EventFactory.callEvent(spreadEvent);
+                block.getEventFactory().callEvent(spreadEvent);
                 if (!spreadEvent.isCancelled()) {
                     state.update(true);
                 }

--- a/src/main/java/net/glowstone/block/entity/FurnaceEntity.java
+++ b/src/main/java/net/glowstone/block/entity/FurnaceEntity.java
@@ -95,7 +95,7 @@ public class FurnaceEntity extends ContainerEntity {
                 CraftingManager cm = ((GlowServer) Bukkit.getServer()).getCraftingManager();
                 FurnaceBurnEvent burnEvent = new FurnaceBurnEvent(block, inv.getFuel(),
                     cm.getFuelTime(inv.getFuel().getType()));
-                block.getEventFactory().callEvent(burnEvent);
+                EventFactory.getInstance().callEvent(burnEvent);
                 if (!burnEvent.isCancelled() && burnEvent.isBurning()) {
                     burnTime = (short) burnEvent.getBurnTime();
                     burnTimeFuel = burnTime;
@@ -133,7 +133,7 @@ public class FurnaceEntity extends ContainerEntity {
             if (recipe != null) {
                 FurnaceSmeltEvent smeltEvent = new FurnaceSmeltEvent(block, inv.getSmelting(),
                     recipe.getResult());
-                block.getEventFactory().callEvent(smeltEvent);
+                EventFactory.getInstance().callEvent(smeltEvent);
                 if (!smeltEvent.isCancelled()) {
                     if (inv.getSmelting().getType().equals(Material.SPONGE)
                         && inv.getSmelting().getData().getData() == 1 && inv.getFuel() != null

--- a/src/main/java/net/glowstone/block/entity/FurnaceEntity.java
+++ b/src/main/java/net/glowstone/block/entity/FurnaceEntity.java
@@ -95,7 +95,7 @@ public class FurnaceEntity extends ContainerEntity {
                 CraftingManager cm = ((GlowServer) Bukkit.getServer()).getCraftingManager();
                 FurnaceBurnEvent burnEvent = new FurnaceBurnEvent(block, inv.getFuel(),
                     cm.getFuelTime(inv.getFuel().getType()));
-                EventFactory.callEvent(burnEvent);
+                block.getEventFactory().callEvent(burnEvent);
                 if (!burnEvent.isCancelled() && burnEvent.isBurning()) {
                     burnTime = (short) burnEvent.getBurnTime();
                     burnTimeFuel = burnTime;
@@ -133,7 +133,7 @@ public class FurnaceEntity extends ContainerEntity {
             if (recipe != null) {
                 FurnaceSmeltEvent smeltEvent = new FurnaceSmeltEvent(block, inv.getSmelting(),
                     recipe.getResult());
-                EventFactory.callEvent(smeltEvent);
+                block.getEventFactory().callEvent(smeltEvent);
                 if (!smeltEvent.isCancelled()) {
                     if (inv.getSmelting().getType().equals(Material.SPONGE)
                         && inv.getSmelting().getData().getData() == 1 && inv.getFuel() != null

--- a/src/main/java/net/glowstone/block/entity/state/GlowNoteBlock.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowNoteBlock.java
@@ -193,7 +193,7 @@ public class GlowNoteBlock extends GlowBlockState implements NoteBlock {
         if (getBlock().getType() != Material.NOTE_BLOCK) {
             return false;
         }
-        NotePlayEvent event = getBlock().getEventFactory()
+        NotePlayEvent event = EventFactory.getInstance()
             .callEvent(new NotePlayEvent(getBlock(), instrument, note));
         if (event.isCancelled()) {
             return false;

--- a/src/main/java/net/glowstone/block/entity/state/GlowNoteBlock.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowNoteBlock.java
@@ -193,7 +193,7 @@ public class GlowNoteBlock extends GlowBlockState implements NoteBlock {
         if (getBlock().getType() != Material.NOTE_BLOCK) {
             return false;
         }
-        NotePlayEvent event = EventFactory
+        NotePlayEvent event = getBlock().getEventFactory()
             .callEvent(new NotePlayEvent(getBlock(), instrument, note));
         if (event.isCancelled()) {
             return false;

--- a/src/main/java/net/glowstone/block/itemtype/ItemBucket.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemBucket.java
@@ -77,7 +77,7 @@ public class ItemBucket extends ItemType {
 
             Material replaceWith = ((BlockLiquid) targetBlockType).getBucketType();
 
-            PlayerBucketFillEvent event = player.getServer().getEventFactory().callEvent(
+            PlayerBucketFillEvent event = EventFactory.getInstance().callEvent(
                 new PlayerBucketFillEvent(player, target, face, holding.getType(), holding));
             if (event.isCancelled()) {
                 return;

--- a/src/main/java/net/glowstone/block/itemtype/ItemBucket.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemBucket.java
@@ -77,7 +77,7 @@ public class ItemBucket extends ItemType {
 
             Material replaceWith = ((BlockLiquid) targetBlockType).getBucketType();
 
-            PlayerBucketFillEvent event = EventFactory.callEvent(
+            PlayerBucketFillEvent event = player.getServer().getEventFactory().callEvent(
                 new PlayerBucketFillEvent(player, target, face, holding.getType(), holding));
             if (event.isCancelled()) {
                 return;

--- a/src/main/java/net/glowstone/block/itemtype/ItemFilledBucket.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFilledBucket.java
@@ -44,7 +44,7 @@ public class ItemFilledBucket extends ItemType {
 
         GlowBlockState newState = target.getState();
 
-        PlayerBucketEmptyEvent event = EventFactory.callEvent(
+        PlayerBucketEmptyEvent event = player.getServer().getEventFactory().callEvent(
             new PlayerBucketEmptyEvent(player, target, face, holding.getType(), holding));
         if (event.isCancelled()) {
             return;

--- a/src/main/java/net/glowstone/block/itemtype/ItemFilledBucket.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFilledBucket.java
@@ -44,7 +44,7 @@ public class ItemFilledBucket extends ItemType {
 
         GlowBlockState newState = target.getState();
 
-        PlayerBucketEmptyEvent event = player.getServer().getEventFactory().callEvent(
+        PlayerBucketEmptyEvent event = EventFactory.getInstance().callEvent(
             new PlayerBucketEmptyEvent(player, target, face, holding.getType(), holding));
         if (event.isCancelled()) {
             return;

--- a/src/main/java/net/glowstone/block/itemtype/ItemFlintAndSteel.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFlintAndSteel.java
@@ -65,7 +65,7 @@ public class ItemFlintAndSteel extends ItemTool {
             return true;
         }
 
-        BlockIgniteEvent event = EventFactory
+        BlockIgniteEvent event = player.getServer().getEventFactory()
             .callEvent(new BlockIgniteEvent(fireBlock, IgniteCause.FLINT_AND_STEEL, player, null));
         if (event.isCancelled()) {
             player.setItemInHand(holding);

--- a/src/main/java/net/glowstone/block/itemtype/ItemFlintAndSteel.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFlintAndSteel.java
@@ -65,7 +65,7 @@ public class ItemFlintAndSteel extends ItemTool {
             return true;
         }
 
-        BlockIgniteEvent event = player.getServer().getEventFactory()
+        BlockIgniteEvent event = EventFactory.getInstance()
             .callEvent(new BlockIgniteEvent(fireBlock, IgniteCause.FLINT_AND_STEEL, player, null));
         if (event.isCancelled()) {
             player.setItemInHand(holding);

--- a/src/main/java/net/glowstone/block/itemtype/ItemFood.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFood.java
@@ -33,14 +33,14 @@ public class ItemFood extends ItemTimedUsage {
 
     protected boolean handleEat(GlowPlayer player, ItemStack item) {
         PlayerItemConsumeEvent event1 = new PlayerItemConsumeEvent(player, item);
-        player.getServer().getEventFactory().callEvent(event1);
+        EventFactory.getInstance().callEvent(event1);
         if (event1.isCancelled()) {
             return false;
         }
 
         FoodLevelChangeEvent event2 = new FoodLevelChangeEvent(player,
             getFoodLevel(item) + player.getFoodLevel());
-        player.getServer().getEventFactory().callEvent(event2);
+        EventFactory.getInstance().callEvent(event2);
 
         if (!event2.isCancelled()) {
             player.setFoodLevelAndSaturation(event2.getFoodLevel(), getSaturation(item));

--- a/src/main/java/net/glowstone/block/itemtype/ItemFood.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemFood.java
@@ -33,14 +33,14 @@ public class ItemFood extends ItemTimedUsage {
 
     protected boolean handleEat(GlowPlayer player, ItemStack item) {
         PlayerItemConsumeEvent event1 = new PlayerItemConsumeEvent(player, item);
-        EventFactory.callEvent(event1);
+        player.getServer().getEventFactory().callEvent(event1);
         if (event1.isCancelled()) {
             return false;
         }
 
         FoodLevelChangeEvent event2 = new FoodLevelChangeEvent(player,
             getFoodLevel(item) + player.getFoodLevel());
-        EventFactory.callEvent(event2);
+        player.getServer().getEventFactory().callEvent(event2);
 
         if (!event2.isCancelled()) {
             player.setFoodLevelAndSaturation(event2.getFoodLevel(), getSaturation(item));

--- a/src/main/java/net/glowstone/block/itemtype/ItemItemFrame.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemItemFrame.java
@@ -20,7 +20,7 @@ public class ItemItemFrame extends ItemType {
         GlowItemFrame entity = new GlowItemFrame(player, target.getRelative(face).getLocation(),
             face);
 
-        if (player.getServer().getEventFactory()
+        if (EventFactory.getInstance()
                 .callEvent(new HangingPlaceEvent(entity, player, target, face))
             .isCancelled()) {
             return;

--- a/src/main/java/net/glowstone/block/itemtype/ItemItemFrame.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemItemFrame.java
@@ -20,7 +20,8 @@ public class ItemItemFrame extends ItemType {
         GlowItemFrame entity = new GlowItemFrame(player, target.getRelative(face).getLocation(),
             face);
 
-        if (EventFactory.callEvent(new HangingPlaceEvent(entity, player, target, face))
+        if (player.getServer().getEventFactory()
+                .callEvent(new HangingPlaceEvent(entity, player, target, face))
             .isCancelled()) {
             return;
         }

--- a/src/main/java/net/glowstone/block/itemtype/ItemMilk.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemMilk.java
@@ -16,7 +16,7 @@ public class ItemMilk extends ItemFood {
     @Override
     public boolean eat(GlowPlayer player, ItemStack item) {
         PlayerItemConsumeEvent event1 = new PlayerItemConsumeEvent(player, item);
-        player.getServer().getEventFactory().callEvent(event1);
+        EventFactory.getInstance().callEvent(event1);
         if (event1.isCancelled()) {
             return false;
         }

--- a/src/main/java/net/glowstone/block/itemtype/ItemMilk.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemMilk.java
@@ -16,7 +16,7 @@ public class ItemMilk extends ItemFood {
     @Override
     public boolean eat(GlowPlayer player, ItemStack item) {
         PlayerItemConsumeEvent event1 = new PlayerItemConsumeEvent(player, item);
-        EventFactory.callEvent(event1);
+        player.getServer().getEventFactory().callEvent(event1);
         if (event1.isCancelled()) {
             return false;
         }

--- a/src/main/java/net/glowstone/chunk/ChunkManager.java
+++ b/src/main/java/net/glowstone/chunk/ChunkManager.java
@@ -149,7 +149,7 @@ public final class ChunkManager {
         // try to load chunk
         try {
             if (service.read(chunk)) {
-                chunk.getWorld().getServer().getEventFactory()
+                EventFactory.getInstance()
                         .callEvent(new ChunkLoadEvent(chunk, false));
                 return true;
             }
@@ -177,7 +177,7 @@ public final class ChunkManager {
             return false;
         }
 
-        chunk.getWorld().getServer().getEventFactory().callEvent(new ChunkLoadEvent(chunk, true));
+        EventFactory.getInstance().callEvent(new ChunkLoadEvent(chunk, true));
 
         // right now, forcePopulate takes care of populating chunks that players actually see.
         /*for (int x2 = x - 1; x2 <= x + 1; ++x2) {
@@ -243,7 +243,7 @@ public final class ChunkManager {
             p.populate(world, random, chunk);
         }
 
-        chunk.getWorld().getServer().getEventFactory().callEvent(new ChunkPopulateEvent(chunk));
+        EventFactory.getInstance().callEvent(new ChunkPopulateEvent(chunk));
     }
 
     /**

--- a/src/main/java/net/glowstone/chunk/ChunkManager.java
+++ b/src/main/java/net/glowstone/chunk/ChunkManager.java
@@ -149,7 +149,8 @@ public final class ChunkManager {
         // try to load chunk
         try {
             if (service.read(chunk)) {
-                EventFactory.callEvent(new ChunkLoadEvent(chunk, false));
+                chunk.getWorld().getServer().getEventFactory()
+                        .callEvent(new ChunkLoadEvent(chunk, false));
                 return true;
             }
         } catch (IOException e) {
@@ -176,7 +177,7 @@ public final class ChunkManager {
             return false;
         }
 
-        EventFactory.callEvent(new ChunkLoadEvent(chunk, true));
+        chunk.getWorld().getServer().getEventFactory().callEvent(new ChunkLoadEvent(chunk, true));
 
         // right now, forcePopulate takes care of populating chunks that players actually see.
         /*for (int x2 = x - 1; x2 <= x + 1; ++x2) {
@@ -242,7 +243,7 @@ public final class ChunkManager {
             p.populate(world, random, chunk);
         }
 
-        EventFactory.callEvent(new ChunkPopulateEvent(chunk));
+        chunk.getWorld().getServer().getEventFactory().callEvent(new ChunkPopulateEvent(chunk));
     }
 
     /**

--- a/src/main/java/net/glowstone/chunk/GlowChunk.java
+++ b/src/main/java/net/glowstone/chunk/GlowChunk.java
@@ -225,7 +225,7 @@ public class GlowChunk implements Chunk {
             return false;
         }
 
-        if (world.getServer().getEventFactory()
+        if (EventFactory.getInstance()
                 .callEvent(new ChunkUnloadEvent(this)).isCancelled()) {
             return false;
         }

--- a/src/main/java/net/glowstone/chunk/GlowChunk.java
+++ b/src/main/java/net/glowstone/chunk/GlowChunk.java
@@ -225,7 +225,8 @@ public class GlowChunk implements Chunk {
             return false;
         }
 
-        if (EventFactory.callEvent(new ChunkUnloadEvent(this)).isCancelled()) {
+        if (world.getServer().getEventFactory()
+                .callEvent(new ChunkUnloadEvent(this)).isCancelled()) {
             return false;
         }
 

--- a/src/main/java/net/glowstone/dispenser/DefaultDispenseBehavior.java
+++ b/src/main/java/net/glowstone/dispenser/DefaultDispenseBehavior.java
@@ -61,7 +61,7 @@ public class DefaultDispenseBehavior implements DispenseBehavior {
 
         BlockDispenseEvent dispenseEvent = new BlockDispenseEvent(block, items,
             new Vector(velocityX, velocityY, velocityZ));
-        block.getEventFactory().callEvent(dispenseEvent);
+        EventFactory.getInstance().callEvent(dispenseEvent);
         if (!dispenseEvent.isCancelled()) {
             GlowItem item = block.getWorld().dropItem(new Location(block.getWorld(), x, y, z),
                 dispenseEvent.getItem());

--- a/src/main/java/net/glowstone/dispenser/DefaultDispenseBehavior.java
+++ b/src/main/java/net/glowstone/dispenser/DefaultDispenseBehavior.java
@@ -61,7 +61,7 @@ public class DefaultDispenseBehavior implements DispenseBehavior {
 
         BlockDispenseEvent dispenseEvent = new BlockDispenseEvent(block, items,
             new Vector(velocityX, velocityY, velocityZ));
-        EventFactory.callEvent(dispenseEvent);
+        block.getEventFactory().callEvent(dispenseEvent);
         if (!dispenseEvent.isCancelled()) {
             GlowItem item = block.getWorld().dropItem(new Location(block.getWorld(), x, y, z),
                 dispenseEvent.getItem());

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -290,7 +290,7 @@ public abstract class GlowEntity implements Entity {
         this.location = location.clone();
         world = (GlowWorld) location.getWorld();
         server = world.getServer();
-        eventFactory = server.getEventFactory();
+        eventFactory = EventFactory.getInstance();
         // this is so dirty I washed my hands after writing it.
         if (this instanceof GlowPlayer) {
             // spawn location event
@@ -571,7 +571,7 @@ public abstract class GlowEntity implements Entity {
                         success = teleportToEnd();
                     }
                     if (success) {
-                        EntityPortalExitEvent e = server.getEventFactory()
+                        EntityPortalExitEvent e = EventFactory.getInstance()
                                 .callEvent(new EntityPortalExitEvent(this, previousLocation,
                                         location
                                         .clone(), velocity.clone(), new Vector()));

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -1195,7 +1195,8 @@ public abstract class GlowEntity implements Entity {
             return false; // nothing changed
         }
 
-        if (EventFactory.getInstance().callEvent(new EntityDismountEvent(passenger, this)).isCancelled()) {
+        if (EventFactory.getInstance()
+                .callEvent(new EntityDismountEvent(passenger, this)).isCancelled()) {
             return false;
         }
 

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -132,7 +132,6 @@ public abstract class GlowEntity implements Entity {
      */
     @Getter
     private final List<String> customTags = Lists.newArrayList();
-    protected final EventFactory eventFactory;
     /**
      * The world this entity belongs to. Guarded by {@link #worldLock}.
      */
@@ -290,11 +289,10 @@ public abstract class GlowEntity implements Entity {
         this.location = location.clone();
         world = (GlowWorld) location.getWorld();
         server = world.getServer();
-        eventFactory = EventFactory.getInstance();
         // this is so dirty I washed my hands after writing it.
         if (this instanceof GlowPlayer) {
             // spawn location event
-            location = eventFactory
+            location = EventFactory.getInstance()
                     .callEvent(new PlayerSpawnLocationEvent((Player) this, location))
                     .getSpawnLocation();
         }
@@ -560,7 +558,7 @@ public abstract class GlowEntity implements Entity {
         if (hasMoved()) {
             Block currentBlock = location.getBlock();
             if (currentBlock.getType() == Material.ENDER_PORTAL) {
-                eventFactory
+                EventFactory.getInstance()
                         .callEvent(new EntityPortalEnterEvent(this, currentBlock.getLocation()));
                 if (server.getAllowEnd()) {
                     Location previousLocation = location.clone();
@@ -862,7 +860,7 @@ public abstract class GlowEntity implements Entity {
     protected boolean teleportToSpawn() {
         Location target = server.getWorlds().get(0).getSpawnLocation();
 
-        EntityPortalEvent event = eventFactory
+        EntityPortalEvent event = EventFactory.getInstance()
                 .callEvent(new EntityPortalEvent(this, location.clone(), target, null));
         if (event.isCancelled()) {
             return false;
@@ -896,7 +894,7 @@ public abstract class GlowEntity implements Entity {
             return false;
         }
 
-        EntityPortalEvent event = eventFactory
+        EntityPortalEvent event = EventFactory.getInstance()
                 .callEvent(new EntityPortalEvent(this, location.clone(), target, null));
         if (event.isCancelled()) {
             return false;
@@ -1082,7 +1080,7 @@ public abstract class GlowEntity implements Entity {
     // Miscellaneous actions
 
     private void unleash(GlowEntity entity, UnleashReason reason) {
-        eventFactory.callEvent(new EntityUnleashEvent(entity, reason));
+        EventFactory.getInstance().callEvent(new EntityUnleashEvent(entity, reason));
         world.dropItemNaturally(entity.location, new ItemStack(Material.LEASH));
         entity.setLeashHolder(null);
     }
@@ -1197,7 +1195,7 @@ public abstract class GlowEntity implements Entity {
             return false; // nothing changed
         }
 
-        if (eventFactory.callEvent(new EntityDismountEvent(passenger, this)).isCancelled()) {
+        if (EventFactory.getInstance().callEvent(new EntityDismountEvent(passenger, this)).isCancelled()) {
             return false;
         }
 
@@ -1234,7 +1232,7 @@ public abstract class GlowEntity implements Entity {
         }
 
         EntityMountEvent event = new EntityMountEvent(passenger, this);
-        eventFactory.callEvent(event);
+        EventFactory.getInstance().callEvent(event);
         if (event.isCancelled()) {
             return false;
         }

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -132,6 +132,7 @@ public abstract class GlowEntity implements Entity {
      */
     @Getter
     private final List<String> customTags = Lists.newArrayList();
+    protected final EventFactory eventFactory;
     /**
      * The world this entity belongs to. Guarded by {@link #worldLock}.
      */
@@ -285,16 +286,18 @@ public abstract class GlowEntity implements Entity {
      * @param location The location of the entity.
      */
     public GlowEntity(Location location) {
-        // this is so dirty I washed my hands after writing it.
-        if (this instanceof GlowPlayer) {
-            // spawn location event
-            location = EventFactory.callEvent(new PlayerSpawnLocationEvent((Player) this, location))
-                    .getSpawnLocation();
-        }
         this.origin = location.clone();
         this.location = location.clone();
         world = (GlowWorld) location.getWorld();
         server = world.getServer();
+        eventFactory = server.getEventFactory();
+        // this is so dirty I washed my hands after writing it.
+        if (this instanceof GlowPlayer) {
+            // spawn location event
+            location = eventFactory
+                    .callEvent(new PlayerSpawnLocationEvent((Player) this, location))
+                    .getSpawnLocation();
+        }
         server.getEntityIdManager().allocate(this);
         world.getEntityManager().register(this);
         previousLocation = location.clone();
@@ -557,7 +560,7 @@ public abstract class GlowEntity implements Entity {
         if (hasMoved()) {
             Block currentBlock = location.getBlock();
             if (currentBlock.getType() == Material.ENDER_PORTAL) {
-                EventFactory
+                eventFactory
                         .callEvent(new EntityPortalEnterEvent(this, currentBlock.getLocation()));
                 if (server.getAllowEnd()) {
                     Location previousLocation = location.clone();
@@ -568,7 +571,7 @@ public abstract class GlowEntity implements Entity {
                         success = teleportToEnd();
                     }
                     if (success) {
-                        EntityPortalExitEvent e = EventFactory
+                        EntityPortalExitEvent e = server.getEventFactory()
                                 .callEvent(new EntityPortalExitEvent(this, previousLocation,
                                         location
                                         .clone(), velocity.clone(), new Vector()));
@@ -859,7 +862,7 @@ public abstract class GlowEntity implements Entity {
     protected boolean teleportToSpawn() {
         Location target = server.getWorlds().get(0).getSpawnLocation();
 
-        EntityPortalEvent event = EventFactory
+        EntityPortalEvent event = eventFactory
                 .callEvent(new EntityPortalEvent(this, location.clone(), target, null));
         if (event.isCancelled()) {
             return false;
@@ -893,7 +896,7 @@ public abstract class GlowEntity implements Entity {
             return false;
         }
 
-        EntityPortalEvent event = EventFactory
+        EntityPortalEvent event = eventFactory
                 .callEvent(new EntityPortalEvent(this, location.clone(), target, null));
         if (event.isCancelled()) {
             return false;
@@ -1079,7 +1082,7 @@ public abstract class GlowEntity implements Entity {
     // Miscellaneous actions
 
     private void unleash(GlowEntity entity, UnleashReason reason) {
-        EventFactory.callEvent(new EntityUnleashEvent(entity, reason));
+        eventFactory.callEvent(new EntityUnleashEvent(entity, reason));
         world.dropItemNaturally(entity.location, new ItemStack(Material.LEASH));
         entity.setLeashHolder(null);
     }
@@ -1194,7 +1197,7 @@ public abstract class GlowEntity implements Entity {
             return false; // nothing changed
         }
 
-        if (EventFactory.callEvent(new EntityDismountEvent(passenger, this)).isCancelled()) {
+        if (eventFactory.callEvent(new EntityDismountEvent(passenger, this)).isCancelled()) {
             return false;
         }
 
@@ -1231,7 +1234,7 @@ public abstract class GlowEntity implements Entity {
         }
 
         EntityMountEvent event = new EntityMountEvent(passenger, this);
-        EventFactory.callEvent(event);
+        eventFactory.callEvent(event);
         if (event.isCancelled()) {
             return false;
         }

--- a/src/main/java/net/glowstone/entity/GlowHumanEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowHumanEntity.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
+import net.glowstone.EventFactory;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.profile.GlowPlayerProfile;
 import net.glowstone.entity.objects.GlowItem;
@@ -393,7 +394,7 @@ public abstract class GlowHumanEntity extends GlowLivingEntity implements HumanE
 
     @Override
     public void closeInventory() {
-        eventFactory.callEvent(new InventoryCloseEvent(openInventory));
+        EventFactory.getInstance().callEvent(new InventoryCloseEvent(openInventory));
         if (getGameMode() != GameMode.CREATIVE) {
             if (!InventoryUtil.isEmpty(getItemOnCursor())) {
                 drop(getItemOnCursor());

--- a/src/main/java/net/glowstone/entity/GlowHumanEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowHumanEntity.java
@@ -394,7 +394,7 @@ public abstract class GlowHumanEntity extends GlowLivingEntity implements HumanE
 
     @Override
     public void closeInventory() {
-        EventFactory.callEvent(new InventoryCloseEvent(openInventory));
+        eventFactory.callEvent(new InventoryCloseEvent(openInventory));
         if (getGameMode() != GameMode.CREATIVE) {
             if (!InventoryUtil.isEmpty(getItemOnCursor())) {
                 drop(getItemOnCursor());

--- a/src/main/java/net/glowstone/entity/GlowHumanEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowHumanEntity.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
-import net.glowstone.EventFactory;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.profile.GlowPlayerProfile;
 import net.glowstone.entity.objects.GlowItem;

--- a/src/main/java/net/glowstone/entity/GlowLightningStrike.java
+++ b/src/main/java/net/glowstone/entity/GlowLightningStrike.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.Getter;
+import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.physics.BoundingBox;
@@ -151,7 +152,7 @@ public class GlowLightningStrike extends GlowWeather implements LightningStrike 
     private void setBlockOnFire(GlowBlock block) {
         if (block.isEmpty() && block.getRelative(BlockFace.DOWN).isFlammable()) {
             BlockIgniteEvent igniteEvent = new BlockIgniteEvent(block, IgniteCause.LIGHTNING, this);
-            eventFactory.callEvent(igniteEvent);
+            EventFactory.getInstance().callEvent(igniteEvent);
             if (!igniteEvent.isCancelled()) {
                 BlockState state = block.getState();
                 state.setType(Material.FIRE);

--- a/src/main/java/net/glowstone/entity/GlowLightningStrike.java
+++ b/src/main/java/net/glowstone/entity/GlowLightningStrike.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.Getter;
-import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.physics.BoundingBox;

--- a/src/main/java/net/glowstone/entity/GlowLightningStrike.java
+++ b/src/main/java/net/glowstone/entity/GlowLightningStrike.java
@@ -152,7 +152,7 @@ public class GlowLightningStrike extends GlowWeather implements LightningStrike 
     private void setBlockOnFire(GlowBlock block) {
         if (block.isEmpty() && block.getRelative(BlockFace.DOWN).isFlammable()) {
             BlockIgniteEvent igniteEvent = new BlockIgniteEvent(block, IgniteCause.LIGHTNING, this);
-            EventFactory.callEvent(igniteEvent);
+            eventFactory.callEvent(igniteEvent);
             if (!igniteEvent.isCancelled()) {
                 BlockState state = block.getState();
                 state.setType(Material.FIRE);

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -19,7 +19,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.Setter;
-import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.ItemTable;

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.Setter;
+import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.ItemTable;
@@ -812,7 +813,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                 }
                 PlayerDeathEvent event = new PlayerDeathEvent(player, items, 0,
                     player.getDisplayName() + " died.");
-                eventFactory.callEvent(event);
+                EventFactory.getInstance().callEvent(event);
                 server.broadcastMessage(event.getDeathMessage());
                 for (ItemStack item : items) {
                     world.dropItemNaturally(getLocation(), item);
@@ -846,7 +847,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                         }
                     }
                 }
-                deathEvent = eventFactory.callEvent(deathEvent);
+                deathEvent = EventFactory.getInstance().callEvent(deathEvent);
                 for (ItemStack item : deathEvent.getDrops()) {
                     world.dropItemNaturally(getLocation(), item);
                 }
@@ -890,9 +891,9 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         // fire event
         EntityDamageEvent event;
         if (source == null) {
-            event = eventFactory.onEntityDamage(new EntityDamageEvent(this, cause, amount));
+            event = EventFactory.getInstance().onEntityDamage(new EntityDamageEvent(this, cause, amount));
         } else {
-            event = eventFactory
+            event = EventFactory.getInstance()
                 .onEntityDamage(new EntityDamageByEntityEvent(source, this, cause, amount));
         }
         if (event.isCancelled()) {
@@ -1117,7 +1118,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
     @Override
     public void setGliding(boolean gliding) {
-        if (eventFactory.callEvent(new EntityToggleGlideEvent(this, gliding)).isCancelled()) {
+        if (EventFactory.getInstance().callEvent(new EntityToggleGlideEvent(this, gliding)).isCancelled()) {
             return;
         }
 
@@ -1178,7 +1179,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             .itemOrEmpty(player.getInventory().getItem(message.getHandSlot()));
         if (isLeashed() && player.equals(this.getLeashHolder())
             && message.getHandSlot() == EquipmentSlot.HAND) {
-            if (eventFactory.callEvent(new PlayerUnleashEntityEvent(this, player)).isCancelled()) {
+            if (EventFactory.getInstance().callEvent(new PlayerUnleashEntityEvent(this, player)).isCancelled()) {
                 return false;
             }
 
@@ -1189,7 +1190,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             return true;
         } else if (!InventoryUtil.isEmpty(handItem) && handItem.getType() == Material.LEASH) {
             if (!GlowLeashHitch.isAllowedLeashHolder(this.getType()) || this.isLeashed()
-                || eventFactory.callEvent(new PlayerLeashEntityEvent(this, player, player))
+                || EventFactory.getInstance().callEvent(new PlayerLeashEntityEvent(this, player, player))
                 .isCancelled()) {
                 return false;
             }

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -253,7 +253,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     /**
      * Creates a mob within the specified world.
      *
-     * @param location The location.
+     * @param location  The location.
      * @param maxHealth The max health of this mob.
      */
     protected GlowLivingEntity(Location location, double maxHealth) {
@@ -310,7 +310,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         }
 
         if (getLocation().getBlock().getType() == Material.LAVA
-            || getLocation().getBlock().getType() == Material.STATIONARY_LAVA) {
+                || getLocation().getBlock().getType() == Material.STATIONARY_LAVA) {
             damage(4, DamageCause.LAVA);
             if (swamInLava) {
                 setFireTicks(getFireTicks() + 2);
@@ -321,7 +321,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         } else {
             swamInLava = false;
             if (getLocation().getBlock().getType() == Material.WATER
-                || getLocation().getBlock().getType() == Material.STATIONARY_WATER) {
+                    || getLocation().getBlock().getType() == Material.STATIONARY_WATER) {
                 setFireTicks(0);
             }
         }
@@ -339,8 +339,8 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             if (effect.getDuration() > 0) {
                 // reduce duration and re-add
                 addPotionEffect(
-                    new PotionEffect(type, effect.getDuration() - 1, effect.getAmplifier(),
-                        effect.isAmbient()), true);
+                        new PotionEffect(type, effect.getDuration() - 1, effect.getAmplifier(),
+                                effect.isAmbient()), true);
             } else {
                 // remove
                 removePotionEffect(type);
@@ -361,7 +361,8 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             double v = ThreadLocalRandom.current().nextDouble();
             if (v <= 0.2) {
                 world
-                    .playSound(getLocation(), getAmbientSound(), getSoundVolume(), getSoundPitch());
+                        .playSound(getLocation(), getAmbientSound(), getSoundVolume(),
+                                getSoundPitch());
             }
         }
         if (nextAmbientTime == 0) {
@@ -410,7 +411,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             movement.multiply(0.02);
         } else {
             this.slipMultiplier = ((GlowBlock) location.getBlock()).getMaterialValues()
-                .getSlipperiness();
+                    .getSlipperiness();
             double slipperiness = slipMultiplier * 0.91;
             movement.multiply(0.1 * (0.1627714 / Math.pow(slipperiness, 3)));
         }
@@ -444,8 +445,8 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         List<Message> messages = super.createUpdateMessage(session);
 
         messages.addAll(equipmentMonitor.getChanges().stream()
-            .map(change -> new EntityEquipmentMessage(entityId, change.slot, change.item))
-            .collect(Collectors.toList()));
+                .map(change -> new EntityEquipmentMessage(entityId, change.slot, change.item))
+                .collect(Collectors.toList()));
         if (headRotated) {
             messages.add(new EntityHeadRotationMessage(entityId, Position.getIntHeadYaw(headYaw)));
         }
@@ -627,7 +628,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
     private List<Block> getLineOfSight(HashSet<Byte> transparent, int maxDistance, int maxLength) {
         Set<Material> materials = transparent.stream().map(Material::getMaterial)
-            .collect(Collectors.toSet());
+                .collect(Collectors.toSet());
         return getLineOfSight(materials, maxDistance, maxLength);
     }
 
@@ -671,7 +672,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     @Override
     public <T extends Projectile> T launchProjectile(Class<? extends T> type) {
         return launchProjectile(type,
-            getLocation().getDirection());  // todo: multiply by some speed
+                getLocation().getDirection());  // todo: multiply by some speed
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -688,11 +689,11 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     /**
      * Launches a projectile from this entity.
      *
-     * @param type the projectile class
+     * @param type   the projectile class
      * @param vector the direction to shoot in
      * @param offset TODO: document this parameter
-     * @param speed the speed for the first flight tick
-     * @param <T> the projectile class
+     * @param speed  the speed for the first flight tick
+     * @param <T>    the projectile class
      * @return the launched projectile
      */
     public <T extends Projectile> T launchProjectile(Class<? extends T> type, Vector vector,
@@ -710,13 +711,13 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
      * Launches a projectile from this entity in the horizontal direction it is facing, relative to
      * the given velocity vector.
      *
-     * @param type the projectile class
-     * @param location the location to launch the projectile from
+     * @param type           the projectile class
+     * @param location       the location to launch the projectile from
      * @param originalVector the direction to shoot in
-     * @param pitchOffset degrees to subtract from the pitch angle while calculating the y component
-     *         of the initial direction
-     * @param velocity the speed for the first flight tick
-     * @param <T> the projectile class
+     * @param pitchOffset    degrees to subtract from the pitch angle while calculating the y
+     *                       component of the initial direction
+     * @param velocity       the speed for the first flight tick
+     * @param <T>            the projectile class
      * @return the launched projectile
      */
     protected <T extends Projectile> T launchProjectile(Class<? extends T> type, Location location,
@@ -737,14 +738,14 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     /**
      * Throws and returns a projectile, initializing its velocity.
      *
-     * @param type a projectile class that can be passed to
-     *         {@link org.bukkit.World#spawn(Location, Class)}
+     * @param type     a projectile class that can be passed to
+     *                 {@link org.bukkit.World#spawn(Location, Class)}
      * @param location initial location
-     * @param x x component of direction (doesn't need to be normalized)
-     * @param y y component of direction (doesn't need to be normalized)
-     * @param z z component of direction (doesn't need to be normalized)
-     * @param speed speed
-     * @param <T> the projectile class
+     * @param x        x component of direction (doesn't need to be normalized)
+     * @param y        y component of direction (doesn't need to be normalized)
+     * @param z        z component of direction (doesn't need to be normalized)
+     * @param speed    speed
+     * @param <T>      the projectile class
      * @return the newly launched projectile
      */
     private <T extends Projectile> T launchProjectile(Class<? extends T> type, Location location,
@@ -778,7 +779,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         metadata.set(MetadataIndex.HEALTH, (float) health);
 
         for (Objective objective : getServer().getScoreboardManager().getMainScoreboard()
-            .getObjectivesByCriteria(Criterias.HEALTH)) {
+                .getObjectivesByCriteria(Criterias.HEALTH)) {
             objective.getScore(getName()).setScore((int) health);
         }
 
@@ -807,12 +808,12 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                 List<ItemStack> items = new ArrayList<>();
                 if (!world.getGameRuleMap().getBoolean("keepInventory")) {
                     items = Arrays.stream(player.getInventory().getContents())
-                        .filter(stack -> !InventoryUtil.isEmpty(stack))
-                        .collect(Collectors.toList());
+                            .filter(stack -> !InventoryUtil.isEmpty(stack))
+                            .collect(Collectors.toList());
                     player.getInventory().clear();
                 }
                 PlayerDeathEvent event = new PlayerDeathEvent(player, items, 0,
-                    player.getDisplayName() + " died.");
+                        player.getDisplayName() + " died.");
                 EventFactory.getInstance().callEvent(event);
                 server.broadcastMessage(event.getDeathMessage());
                 for (ItemStack item : items) {
@@ -835,10 +836,10 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                             double modX = random.nextDouble() - 0.5;
                             double modZ = random.nextDouble() - 0.5;
                             Location xpLocation = new Location(world,
-                                location.getBlockX() + 0.5 + modX, location.getY(),
-                                location.getBlockZ() + 0.5 + modZ);
+                                    location.getBlockX() + 0.5 + modX, location.getY(),
+                                    location.getBlockZ() + 0.5 + modZ);
                             GlowExperienceOrb orb = (GlowExperienceOrb) world
-                                .spawnEntity(xpLocation, EntityType.EXPERIENCE_ORB);
+                                    .spawnEntity(xpLocation, EntityType.EXPERIENCE_ORB);
                             orb.setExperience(exp);
                             orb.setSourceEntityId(this.getUniqueId());
                             if (getLastDamager() != null) {
@@ -886,16 +887,13 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         double defensePoints = getAttributeManager().getPropertyValue(Key.KEY_ARMOR);
         double toughness = getAttributeManager().getPropertyValue(Key.KEY_ARMOR_TOUGHNESS);
         amount = amount * (1 - Math.min(20.0,
-            Math.max(defensePoints / 5.0, defensePoints - amount / (2.0 + toughness / 4.0))) / 25);
+                Math.max(defensePoints / 5.0,
+                        defensePoints - amount / (2.0 + toughness / 4.0))) / 25);
 
         // fire event
-        EntityDamageEvent event;
-        if (source == null) {
-            event = EventFactory.getInstance().onEntityDamage(new EntityDamageEvent(this, cause, amount));
-        } else {
-            event = EventFactory.getInstance()
-                .onEntityDamage(new EntityDamageByEntityEvent(source, this, cause, amount));
-        }
+        EntityDamageEvent event = EventFactory.getInstance().onEntityDamage(source == null
+                ? new EntityDamageEvent(this, cause, amount)
+                : new EntityDamageByEntityEvent(source, this, cause, amount));
         if (event.isCancelled()) {
             return;
         }
@@ -916,7 +914,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
         if (cause == DamageCause.ENTITY_ATTACK && source != null) {
             Vector distance = RayUtil
-                .getRayBetween(getLocation(), ((LivingEntity) source).getEyeLocation());
+                    .getRayBetween(getLocation(), ((LivingEntity) source).getEyeLocation());
 
             Vector rayLength = RayUtil.getVelocityRay(distance).normalize();
 
@@ -949,11 +947,11 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
         // If damaged by a TNT ignited by a player
         if (source instanceof GlowTntPrimed) {
-            GlowPlayer player = (GlowPlayer)((GlowTntPrimed) source).getSource();
+            GlowPlayer player = (GlowPlayer) ((GlowTntPrimed) source).getSource();
             return
-                player != null
-                && (player.getGameMode() == GameMode.SURVIVAL
-                || player.getGameMode() == GameMode.ADVENTURE);
+                    player != null
+                            && (player.getGameMode() == GameMode.SURVIVAL
+                            || player.getGameMode() == GameMode.ADVENTURE);
         }
 
         // If damaged by a tamed wolf
@@ -974,7 +972,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     private Player determinePlayer(Entity source) {
         // If been killed by an ignited tnt
         if (source instanceof GlowTntPrimed) {
-            return (Player)((GlowTntPrimed) source).getSource();
+            return (Player) ((GlowTntPrimed) source).getSource();
         }
 
         // If been killed by a player
@@ -984,7 +982,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
         // If been killed by a tamed wolf
         if (source instanceof GlowWolf) {
-            return (Player)((GlowWolf) source).getOwner();
+            return (Player) ((GlowWolf) source).getOwner();
         }
 
         // All other cases
@@ -1027,13 +1025,13 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         potionEffects.put(effect.getType(), effect);
 
         EntityEffectMessage msg = new EntityEffectMessage(getEntityId(), effect.getType().getId(),
-            effect.getAmplifier(), effect.getDuration(), effect.isAmbient());
+                effect.getAmplifier(), effect.getDuration(), effect.isAmbient());
         for (GlowPlayer player : world.getRawPlayers()) {
             if (player == this) {
                 // special handling for players having a different view of themselves
                 player.getSession().send(
-                    new EntityEffectMessage(0, effect.getType().getId(), effect.getAmplifier(),
-                        effect.getDuration(), effect.isAmbient()));
+                        new EntityEffectMessage(0, effect.getType().getId(), effect.getAmplifier(),
+                                effect.getDuration(), effect.isAmbient()));
             } else if (player.canSeeEntity(this)) {
                 player.getSession().send(msg);
             }
@@ -1118,7 +1116,8 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
     @Override
     public void setGliding(boolean gliding) {
-        if (EventFactory.getInstance().callEvent(new EntityToggleGlideEvent(this, gliding)).isCancelled()) {
+        if (EventFactory.getInstance().callEvent(
+                new EntityToggleGlideEvent(this, gliding)).isCancelled()) {
             return;
         }
 
@@ -1157,8 +1156,8 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     public void playAnimation(EntityAnimation animation) {
         AnimateEntityMessage message = new AnimateEntityMessage(getEntityId(), animation.ordinal());
         getWorld().getRawPlayers().stream()
-            .filter(observer -> observer != this && observer.canSeeEntity(this))
-            .forEach(observer -> observer.getSession().send(message));
+                .filter(observer -> observer != this && observer.canSeeEntity(this))
+                .forEach(observer -> observer.getSession().send(message));
     }
 
     @Override
@@ -1176,10 +1175,11 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         }
 
         ItemStack handItem = InventoryUtil
-            .itemOrEmpty(player.getInventory().getItem(message.getHandSlot()));
+                .itemOrEmpty(player.getInventory().getItem(message.getHandSlot()));
         if (isLeashed() && player.equals(this.getLeashHolder())
-            && message.getHandSlot() == EquipmentSlot.HAND) {
-            if (EventFactory.getInstance().callEvent(new PlayerUnleashEntityEvent(this, player)).isCancelled()) {
+                && message.getHandSlot() == EquipmentSlot.HAND) {
+            if (EventFactory.getInstance()
+                    .callEvent(new PlayerUnleashEntityEvent(this, player)).isCancelled()) {
                 return false;
             }
 
@@ -1190,8 +1190,9 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             return true;
         } else if (!InventoryUtil.isEmpty(handItem) && handItem.getType() == Material.LEASH) {
             if (!GlowLeashHitch.isAllowedLeashHolder(this.getType()) || this.isLeashed()
-                || EventFactory.getInstance().callEvent(new PlayerLeashEntityEvent(this, player, player))
-                .isCancelled()) {
+                    || EventFactory.getInstance().callEvent(
+                            new PlayerLeashEntityEvent(this, player, player))
+                    .isCancelled()) {
                 return false;
             }
 

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -813,7 +813,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                 }
                 PlayerDeathEvent event = new PlayerDeathEvent(player, items, 0,
                     player.getDisplayName() + " died.");
-                EventFactory.callEvent(event);
+                eventFactory.callEvent(event);
                 server.broadcastMessage(event.getDeathMessage());
                 for (ItemStack item : items) {
                     world.dropItemNaturally(getLocation(), item);
@@ -847,7 +847,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                         }
                     }
                 }
-                deathEvent = EventFactory.callEvent(deathEvent);
+                deathEvent = eventFactory.callEvent(deathEvent);
                 for (ItemStack item : deathEvent.getDrops()) {
                     world.dropItemNaturally(getLocation(), item);
                 }
@@ -891,9 +891,9 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         // fire event
         EntityDamageEvent event;
         if (source == null) {
-            event = EventFactory.onEntityDamage(new EntityDamageEvent(this, cause, amount));
+            event = eventFactory.onEntityDamage(new EntityDamageEvent(this, cause, amount));
         } else {
-            event = EventFactory
+            event = eventFactory
                 .onEntityDamage(new EntityDamageByEntityEvent(source, this, cause, amount));
         }
         if (event.isCancelled()) {
@@ -1118,7 +1118,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
     @Override
     public void setGliding(boolean gliding) {
-        if (EventFactory.callEvent(new EntityToggleGlideEvent(this, gliding)).isCancelled()) {
+        if (eventFactory.callEvent(new EntityToggleGlideEvent(this, gliding)).isCancelled()) {
             return;
         }
 
@@ -1179,7 +1179,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             .itemOrEmpty(player.getInventory().getItem(message.getHandSlot()));
         if (isLeashed() && player.equals(this.getLeashHolder())
             && message.getHandSlot() == EquipmentSlot.HAND) {
-            if (EventFactory.callEvent(new PlayerUnleashEntityEvent(this, player)).isCancelled()) {
+            if (eventFactory.callEvent(new PlayerUnleashEntityEvent(this, player)).isCancelled()) {
                 return false;
             }
 
@@ -1190,7 +1190,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             return true;
         } else if (!InventoryUtil.isEmpty(handItem) && handItem.getType() == Material.LEASH) {
             if (!GlowLeashHitch.isAllowedLeashHolder(this.getType()) || this.isLeashed()
-                || EventFactory.callEvent(new PlayerLeashEntityEvent(this, player, player))
+                || eventFactory.callEvent(new PlayerLeashEntityEvent(this, player, player))
                 .isCancelled()) {
                 return false;
             }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -820,7 +820,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                 saturation = Math.max(saturation - 1f, 0f);
                 sendHealth();
             } else if (world.getDifficulty() != Difficulty.PEACEFUL) {
-                FoodLevelChangeEvent event = server.getEventFactory()
+                FoodLevelChangeEvent event = EventFactory.getInstance()
                         .callEvent(new FoodLevelChangeEvent(this, Math.max(foodLevel - 1, 0)));
                 if (!event.isCancelled()) {
                     foodLevel = event.getFoodLevel();
@@ -835,7 +835,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
                 EntityRegainHealthEvent event1
                         = new EntityRegainHealthEvent(this, 1f, RegainReason.SATIATED);
-                server.getEventFactory().callEvent(event1);
+                EventFactory.getInstance().callEvent(event1);
                 if (!event1.isCancelled()) {
                     setHealth(getHealth() + 1);
                 }
@@ -1155,7 +1155,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         // fire world change if needed
         if (oldWorld != world) {
             session.send(((GlowWorldBorder) world.getWorldBorder()).createMessage());
-            server.getEventFactory().callEvent(new PlayerChangedWorldEvent(this, oldWorld));
+            EventFactory.getInstance().callEvent(new PlayerChangedWorldEvent(this, oldWorld));
         }
     }
 
@@ -1215,7 +1215,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
             // fire event and perform spawn
             PlayerRespawnEvent event = new PlayerRespawnEvent(this, dest, spawnAtBed);
-            server.getEventFactory().callEvent(event);
+            EventFactory.getInstance().callEvent(event);
             if (event.getRespawnLocation().getWorld().equals(getWorld()) && !knownEntities
                     .isEmpty()) {
                 // we need to manually reset all known entities if the player respawns in the
@@ -1326,7 +1326,8 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public void setVelocity(Vector velocity) {
-        PlayerVelocityEvent event = server.getEventFactory().callEvent(new PlayerVelocityEvent(this, velocity));
+        PlayerVelocityEvent event = EventFactory.getInstance()
+                .callEvent(new PlayerVelocityEvent(this, velocity));
         if (!event.isCancelled()) {
             velocity = event.getVelocity();
             super.setVelocity(velocity);
@@ -1539,7 +1540,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
     public void setGameMode(GameMode mode) {
         if (getGameMode() != mode) {
             PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(this, mode);
-            if (server.getEventFactory().callEvent(event).isCancelled()) {
+            if (EventFactory.getInstance().callEvent(event).isCancelled()) {
                 return;
             }
 
@@ -1572,7 +1573,8 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public void setSneaking(boolean sneak) {
-        if (server.getEventFactory().callEvent(new PlayerToggleSneakEvent(this, sneak)).isCancelled()) {
+        if (EventFactory.getInstance()
+                .callEvent(new PlayerToggleSneakEvent(this, sneak)).isCancelled()) {
             return;
         }
 
@@ -1586,7 +1588,8 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public void setSprinting(boolean sprinting) {
-        if (server.getEventFactory().callEvent(new PlayerToggleSprintEvent(this, sprinting)).isCancelled()) {
+        if (EventFactory.getInstance()
+                .callEvent(new PlayerToggleSprintEvent(this, sprinting)).isCancelled()) {
             return;
         }
 
@@ -1885,7 +1888,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         if (this.location != null && this.location.getWorld() != null) {
             PlayerTeleportEvent event
                     = new PlayerTeleportEvent(this, this.location, location, cause);
-            if (server.getEventFactory().callEvent(event).isCancelled()) {
+            if (EventFactory.getInstance().callEvent(event).isCancelled()) {
                 return false;
             }
             location = event.getTo();
@@ -1926,7 +1929,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             target = server.getWorlds().get(0).getSpawnLocation();
         }
 
-        PlayerPortalEvent event = server.getEventFactory()
+        PlayerPortalEvent event = EventFactory.getInstance()
                 .callEvent(new PlayerPortalEvent(this, location.clone(), target, null));
         if (event.isCancelled()) {
             return false;
@@ -1956,7 +1959,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             return false;
         }
 
-        PlayerPortalEvent event = server.getEventFactory()
+        PlayerPortalEvent event = EventFactory.getInstance()
                 .callEvent(new PlayerPortalEvent(this, location.clone(), target, null));
         if (event.isCancelled()) {
             return false;
@@ -1981,7 +1984,8 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
         GlowBlock head = BlockBed.getHead(block);
         GlowBlock foot = BlockBed.getFoot(block);
-        if (server.getEventFactory().callEvent(new PlayerBedEnterEvent(this, head)).isCancelled()) {
+        if (EventFactory.getInstance()
+                .callEvent(new PlayerBedEnterEvent(this, head)).isCancelled()) {
             return;
         }
 
@@ -2029,7 +2033,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         teleported = true;
 
         // Call event
-        server.getEventFactory().callEvent(new PlayerBedLeaveEvent(this, head));
+        EventFactory.getInstance().callEvent(new PlayerBedLeaveEvent(this, head));
 
         playAnimationToSelf(EntityAnimation.LEAVE_BED);
         playAnimation(EntityAnimation.LEAVE_BED);
@@ -2223,7 +2227,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                 try {
                     PlayerCommandPreprocessEvent event
                             = new PlayerCommandPreprocessEvent(this, text);
-                    if (!server.getEventFactory().callEvent(event).isCancelled()) {
+                    if (!EventFactory.getInstance().callEvent(event).isCancelled()) {
                         server.dispatchCommand(this, event.getMessage().substring(1));
                     }
                 } catch (Exception ex) {
@@ -2242,7 +2246,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                 task.run();
             }
         } else {
-            AsyncPlayerChatEvent event = server.getEventFactory().onPlayerChat(async, this, text);
+            AsyncPlayerChatEvent event = EventFactory.getInstance().onPlayerChat(async, this, text);
             if (event.isCancelled()) {
                 return;
             }
@@ -2819,7 +2823,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         }
 
         PlayerAchievementAwardedEvent event = new PlayerAchievementAwardedEvent(this, achievement);
-        if (server.getEventFactory().callEvent(event).isCancelled()) {
+        if (EventFactory.getInstance().callEvent(event).isCancelled()) {
             return false; // event was cancelled
         }
 
@@ -3054,7 +3058,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         GlowItem dropping = super.drop(stack);
         if (dropping != null) {
             PlayerDropItemEvent event = new PlayerDropItemEvent(this, dropping);
-            server.getEventFactory().callEvent(event);
+            EventFactory.getInstance().callEvent(event);
             if (event.isCancelled()) {
                 dropping.remove();
                 dropping = null;
@@ -3294,7 +3298,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
     public void addChannel(String channel) {
         checkArgument(listeningChannels.size() < 128, "Cannot add more than 127 channels!");
         if (listeningChannels.add(channel)) {
-            server.getEventFactory().callEvent(new PlayerRegisterChannelEvent(this, channel));
+            EventFactory.getInstance().callEvent(new PlayerRegisterChannelEvent(this, channel));
         }
     }
 
@@ -3305,7 +3309,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
      */
     public void removeChannel(String channel) {
         if (listeningChannels.remove(channel)) {
-            server.getEventFactory().callEvent(new PlayerUnregisterChannelEvent(this, channel));
+            EventFactory.getInstance().callEvent(new PlayerUnregisterChannelEvent(this, channel));
         }
     }
 

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -820,7 +820,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                 saturation = Math.max(saturation - 1f, 0f);
                 sendHealth();
             } else if (world.getDifficulty() != Difficulty.PEACEFUL) {
-                FoodLevelChangeEvent event = EventFactory
+                FoodLevelChangeEvent event = server.getEventFactory()
                         .callEvent(new FoodLevelChangeEvent(this, Math.max(foodLevel - 1, 0)));
                 if (!event.isCancelled()) {
                     foodLevel = event.getFoodLevel();
@@ -835,7 +835,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
                 EntityRegainHealthEvent event1
                         = new EntityRegainHealthEvent(this, 1f, RegainReason.SATIATED);
-                EventFactory.callEvent(event1);
+                server.getEventFactory().callEvent(event1);
                 if (!event1.isCancelled()) {
                     setHealth(getHealth() + 1);
                 }
@@ -1155,7 +1155,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         // fire world change if needed
         if (oldWorld != world) {
             session.send(((GlowWorldBorder) world.getWorldBorder()).createMessage());
-            EventFactory.callEvent(new PlayerChangedWorldEvent(this, oldWorld));
+            server.getEventFactory().callEvent(new PlayerChangedWorldEvent(this, oldWorld));
         }
     }
 
@@ -1215,7 +1215,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
             // fire event and perform spawn
             PlayerRespawnEvent event = new PlayerRespawnEvent(this, dest, spawnAtBed);
-            EventFactory.callEvent(event);
+            server.getEventFactory().callEvent(event);
             if (event.getRespawnLocation().getWorld().equals(getWorld()) && !knownEntities
                     .isEmpty()) {
                 // we need to manually reset all known entities if the player respawns in the
@@ -1326,7 +1326,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public void setVelocity(Vector velocity) {
-        PlayerVelocityEvent event = EventFactory.callEvent(new PlayerVelocityEvent(this, velocity));
+        PlayerVelocityEvent event = server.getEventFactory().callEvent(new PlayerVelocityEvent(this, velocity));
         if (!event.isCancelled()) {
             velocity = event.getVelocity();
             super.setVelocity(velocity);
@@ -1539,7 +1539,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
     public void setGameMode(GameMode mode) {
         if (getGameMode() != mode) {
             PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(this, mode);
-            if (EventFactory.callEvent(event).isCancelled()) {
+            if (server.getEventFactory().callEvent(event).isCancelled()) {
                 return;
             }
 
@@ -1572,7 +1572,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public void setSneaking(boolean sneak) {
-        if (EventFactory.callEvent(new PlayerToggleSneakEvent(this, sneak)).isCancelled()) {
+        if (server.getEventFactory().callEvent(new PlayerToggleSneakEvent(this, sneak)).isCancelled()) {
             return;
         }
 
@@ -1586,7 +1586,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public void setSprinting(boolean sprinting) {
-        if (EventFactory.callEvent(new PlayerToggleSprintEvent(this, sprinting)).isCancelled()) {
+        if (server.getEventFactory().callEvent(new PlayerToggleSprintEvent(this, sprinting)).isCancelled()) {
             return;
         }
 
@@ -1885,7 +1885,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         if (this.location != null && this.location.getWorld() != null) {
             PlayerTeleportEvent event
                     = new PlayerTeleportEvent(this, this.location, location, cause);
-            if (EventFactory.callEvent(event).isCancelled()) {
+            if (server.getEventFactory().callEvent(event).isCancelled()) {
                 return false;
             }
             location = event.getTo();
@@ -1926,7 +1926,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             target = server.getWorlds().get(0).getSpawnLocation();
         }
 
-        PlayerPortalEvent event = EventFactory
+        PlayerPortalEvent event = server.getEventFactory()
                 .callEvent(new PlayerPortalEvent(this, location.clone(), target, null));
         if (event.isCancelled()) {
             return false;
@@ -1956,7 +1956,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             return false;
         }
 
-        PlayerPortalEvent event = EventFactory
+        PlayerPortalEvent event = server.getEventFactory()
                 .callEvent(new PlayerPortalEvent(this, location.clone(), target, null));
         if (event.isCancelled()) {
             return false;
@@ -1981,7 +1981,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
         GlowBlock head = BlockBed.getHead(block);
         GlowBlock foot = BlockBed.getFoot(block);
-        if (EventFactory.callEvent(new PlayerBedEnterEvent(this, head)).isCancelled()) {
+        if (server.getEventFactory().callEvent(new PlayerBedEnterEvent(this, head)).isCancelled()) {
             return;
         }
 
@@ -2029,7 +2029,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         teleported = true;
 
         // Call event
-        EventFactory.callEvent(new PlayerBedLeaveEvent(this, head));
+        server.getEventFactory().callEvent(new PlayerBedLeaveEvent(this, head));
 
         playAnimationToSelf(EntityAnimation.LEAVE_BED);
         playAnimation(EntityAnimation.LEAVE_BED);
@@ -2223,7 +2223,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                 try {
                     PlayerCommandPreprocessEvent event
                             = new PlayerCommandPreprocessEvent(this, text);
-                    if (!EventFactory.callEvent(event).isCancelled()) {
+                    if (!server.getEventFactory().callEvent(event).isCancelled()) {
                         server.dispatchCommand(this, event.getMessage().substring(1));
                     }
                 } catch (Exception ex) {
@@ -2242,7 +2242,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                 task.run();
             }
         } else {
-            AsyncPlayerChatEvent event = EventFactory.onPlayerChat(async, this, text);
+            AsyncPlayerChatEvent event = server.getEventFactory().onPlayerChat(async, this, text);
             if (event.isCancelled()) {
                 return;
             }
@@ -2819,7 +2819,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         }
 
         PlayerAchievementAwardedEvent event = new PlayerAchievementAwardedEvent(this, achievement);
-        if (EventFactory.callEvent(event).isCancelled()) {
+        if (server.getEventFactory().callEvent(event).isCancelled()) {
             return false; // event was cancelled
         }
 
@@ -3054,7 +3054,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         GlowItem dropping = super.drop(stack);
         if (dropping != null) {
             PlayerDropItemEvent event = new PlayerDropItemEvent(this, dropping);
-            EventFactory.callEvent(event);
+            server.getEventFactory().callEvent(event);
             if (event.isCancelled()) {
                 dropping.remove();
                 dropping = null;
@@ -3294,7 +3294,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
     public void addChannel(String channel) {
         checkArgument(listeningChannels.size() < 128, "Cannot add more than 127 channels!");
         if (listeningChannels.add(channel)) {
-            EventFactory.callEvent(new PlayerRegisterChannelEvent(this, channel));
+            server.getEventFactory().callEvent(new PlayerRegisterChannelEvent(this, channel));
         }
     }
 
@@ -3305,7 +3305,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
      */
     public void removeChannel(String channel) {
         if (listeningChannels.remove(channel)) {
-            EventFactory.callEvent(new PlayerUnregisterChannelEvent(this, channel));
+            server.getEventFactory().callEvent(new PlayerUnregisterChannelEvent(this, channel));
         }
     }
 

--- a/src/main/java/net/glowstone/entity/GlowTntPrimed.java
+++ b/src/main/java/net/glowstone/entity/GlowTntPrimed.java
@@ -98,7 +98,8 @@ public class GlowTntPrimed extends GlowExplosive implements TNTPrimed {
     }
 
     private void explode() {
-        ExplosionPrimeEvent event = EventFactory.getInstance().callEvent(new ExplosionPrimeEvent(this));
+        ExplosionPrimeEvent event = EventFactory.getInstance()
+                .callEvent(new ExplosionPrimeEvent(this));
 
         if (!event.isCancelled()) {
             Location location = getLocation();

--- a/src/main/java/net/glowstone/entity/GlowTntPrimed.java
+++ b/src/main/java/net/glowstone/entity/GlowTntPrimed.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.Getter;
 import lombok.Setter;
-import net.glowstone.EventFactory;
 import net.glowstone.Explosion;
 import net.glowstone.net.message.play.entity.SpawnObjectMessage;
 import org.bukkit.Effect;

--- a/src/main/java/net/glowstone/entity/GlowTntPrimed.java
+++ b/src/main/java/net/glowstone/entity/GlowTntPrimed.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.Getter;
 import lombok.Setter;
+import net.glowstone.EventFactory;
 import net.glowstone.Explosion;
 import net.glowstone.net.message.play.entity.SpawnObjectMessage;
 import org.bukkit.Effect;
@@ -97,7 +98,7 @@ public class GlowTntPrimed extends GlowExplosive implements TNTPrimed {
     }
 
     private void explode() {
-        ExplosionPrimeEvent event = eventFactory.callEvent(new ExplosionPrimeEvent(this));
+        ExplosionPrimeEvent event = EventFactory.getInstance().callEvent(new ExplosionPrimeEvent(this));
 
         if (!event.isCancelled()) {
             Location location = getLocation();

--- a/src/main/java/net/glowstone/entity/GlowTntPrimed.java
+++ b/src/main/java/net/glowstone/entity/GlowTntPrimed.java
@@ -98,7 +98,7 @@ public class GlowTntPrimed extends GlowExplosive implements TNTPrimed {
     }
 
     private void explode() {
-        ExplosionPrimeEvent event = EventFactory.callEvent(new ExplosionPrimeEvent(this));
+        ExplosionPrimeEvent event = eventFactory.callEvent(new ExplosionPrimeEvent(this));
 
         if (!event.isCancelled()) {
             Location location = getLocation();

--- a/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
@@ -115,21 +115,17 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
         if (source instanceof Projectile && !(source instanceof Arrow)) {
             return;
         }
-        EntityDamageEvent event;
-        if (source == null) {
-            event = EventFactory.getInstance().onEntityDamage(new EntityDamageEvent(this, cause, amount));
-        } else {
-            event = EventFactory.getInstance()
-                .onEntityDamage(new EntityDamageByEntityEvent(source, this, cause, amount));
-        }
+        EntityDamageEvent event = EventFactory.getInstance().onEntityDamage(source == null
+                ? new EntityDamageEvent(this, cause, amount)
+                : new EntityDamageByEntityEvent(source, this, cause, amount));
         if (event.isCancelled()) {
             return;
         }
         boolean drop = false;
         if (source instanceof GlowPlayer || source instanceof Arrow && ((Projectile) source)
-            .getShooter() instanceof GlowPlayer) {
+                .getShooter() instanceof GlowPlayer) {
             GlowPlayer damager = (GlowPlayer) (source instanceof GlowPlayer ? source
-                : ((Arrow) source).getShooter());
+                    : ((Arrow) source).getShooter());
             if (damager.getGameMode() == GameMode.ADVENTURE) {
                 return;
             } else if (damager.getGameMode() == GameMode.CREATIVE) {
@@ -159,7 +155,7 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
 
         metadata.set(MetadataIndex.HEALTH, (float) health);
         for (Objective objective : getServer().getScoreboardManager().getMainScoreboard()
-            .getObjectivesByCriteria(Criterias.HEALTH)) {
+                .getObjectivesByCriteria(Criterias.HEALTH)) {
             objective.getScore(getName()).setScore((int) health);
         }
 
@@ -171,8 +167,8 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
     private void kill(boolean dropArmorStand) {
         active = false;
         ((GlowWorld) location.getWorld())
-            .showParticle(location.clone().add(0, 1.317, 0), Effect.TILE_DUST,
-                Material.WOOD.getId(), 0, 0.125f, 0.494f, 0.125f, 0.1f, 10, 10);
+                .showParticle(location.clone().add(0, 1.317, 0), Effect.TILE_DUST,
+                        Material.WOOD.getId(), 0, 0.125f, 0.494f, 0.125f, 0.1f, 10, 10);
         for (ItemStack stack : equipment.getArmorContents()) {
             if (InventoryUtil.isEmpty(stack)) {
                 continue;
@@ -194,8 +190,8 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
                 EquipmentSlot slot = getEditSlot(msg.getTargetY());
 
                 PlayerArmorStandManipulateEvent event = new PlayerArmorStandManipulateEvent(player,
-                    this, InventoryUtil.itemOrEmpty(null),
-                    InventoryUtil.itemOrEmpty(equipment.getItem(slot)), slot);
+                        this, InventoryUtil.itemOrEmpty(null),
+                        InventoryUtil.itemOrEmpty(equipment.getItem(slot)), slot);
                 EventFactory.getInstance().callEvent(event);
 
                 if (event.isCancelled()) {
@@ -217,8 +213,8 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
                 }
 
                 PlayerArmorStandManipulateEvent event = new PlayerArmorStandManipulateEvent(player,
-                    this, player.getItemInHand(),
-                    InventoryUtil.itemOrEmpty(equipment.getItem(slot)), slot);
+                        this, player.getItemInHand(),
+                        InventoryUtil.itemOrEmpty(equipment.getItem(slot)), slot);
                 EventFactory.getInstance().callEvent(event);
 
                 if (event.isCancelled()) {
@@ -246,7 +242,7 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
                 }
                 equipment.setItem(slot, stack);
                 player.playSound(location, getEquipSound(stack.getType()), SoundCategory.NEUTRAL, 1,
-                    1);
+                        1);
                 return true;
             }
         }
@@ -318,13 +314,13 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
         }
 
         if (height >= 0.1 && height < 0.1 + (isSmall ? 0.8 : 0.45) && !isEmpty(
-            EquipmentSlot.FEET)) {
+                EquipmentSlot.FEET)) {
             return EquipmentSlot.FEET;
         } else if (height >= 0.9 + (isSmall ? 0.3 : 0) && height < 0.9 + (isSmall ? 1 : 0.7)
-            && !isEmpty(EquipmentSlot.CHEST)) {
+                && !isEmpty(EquipmentSlot.CHEST)) {
             return EquipmentSlot.CHEST;
         } else if (height >= 0.4 && height < 0.4 + (isSmall ? 1 : 0.8) && !isEmpty(
-            EquipmentSlot.LEGS)) {
+                EquipmentSlot.LEGS)) {
             return EquipmentSlot.LEGS;
         } else if (height >= 1.6 && !isEmpty(EquipmentSlot.HEAD)) {
             return EquipmentSlot.HEAD;
@@ -356,18 +352,20 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
     public List<Message> createSpawnMessage() {
 
         return Arrays.asList(
-            new SpawnObjectMessage(entityId, UUID.randomUUID(), 78, location),
-            // TODO: once UUID is documented, actually use the appropriate ID here
-            new EntityMetadataMessage(entityId, metadata.getEntryList()),
-            new EntityEquipmentMessage(entityId, EntityEquipmentMessage.HELD_ITEM, getItemInHand()),
-            new EntityEquipmentMessage(entityId, EntityEquipmentMessage.OFF_HAND,
-                equipment.getItemInOffHand()),
-            new EntityEquipmentMessage(entityId, EntityEquipmentMessage.BOOTS_SLOT, getBoots()),
-            new EntityEquipmentMessage(entityId, EntityEquipmentMessage.LEGGINGS_SLOT,
-                    getLeggings()),
-            new EntityEquipmentMessage(entityId, EntityEquipmentMessage.CHESTPLATE_SLOT,
-                    getChestplate()),
-            new EntityEquipmentMessage(entityId, EntityEquipmentMessage.HELMET_SLOT, getHelmet())
+                new SpawnObjectMessage(entityId, UUID.randomUUID(), 78, location),
+                // TODO: once UUID is documented, actually use the appropriate ID here
+                new EntityMetadataMessage(entityId, metadata.getEntryList()),
+                new EntityEquipmentMessage(entityId, EntityEquipmentMessage.HELD_ITEM,
+                        getItemInHand()),
+                new EntityEquipmentMessage(entityId, EntityEquipmentMessage.OFF_HAND,
+                        equipment.getItemInOffHand()),
+                new EntityEquipmentMessage(entityId, EntityEquipmentMessage.BOOTS_SLOT, getBoots()),
+                new EntityEquipmentMessage(entityId, EntityEquipmentMessage.LEGGINGS_SLOT,
+                        getLeggings()),
+                new EntityEquipmentMessage(entityId, EntityEquipmentMessage.CHESTPLATE_SLOT,
+                        getChestplate()),
+                new EntityEquipmentMessage(entityId, EntityEquipmentMessage.HELMET_SLOT,
+                        getHelmet())
         );
     }
 

--- a/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
@@ -117,9 +117,9 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
         }
         EntityDamageEvent event;
         if (source == null) {
-            event = EventFactory.onEntityDamage(new EntityDamageEvent(this, cause, amount));
+            event = eventFactory.onEntityDamage(new EntityDamageEvent(this, cause, amount));
         } else {
-            event = EventFactory
+            event = eventFactory
                 .onEntityDamage(new EntityDamageByEntityEvent(source, this, cause, amount));
         }
         if (event.isCancelled()) {
@@ -196,7 +196,7 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
                 PlayerArmorStandManipulateEvent event = new PlayerArmorStandManipulateEvent(player,
                     this, InventoryUtil.itemOrEmpty(null),
                     InventoryUtil.itemOrEmpty(equipment.getItem(slot)), slot);
-                EventFactory.callEvent(event);
+                eventFactory.callEvent(event);
 
                 if (event.isCancelled()) {
                     return false;
@@ -219,7 +219,7 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
                 PlayerArmorStandManipulateEvent event = new PlayerArmorStandManipulateEvent(player,
                     this, player.getItemInHand(),
                     InventoryUtil.itemOrEmpty(equipment.getItem(slot)), slot);
-                EventFactory.callEvent(event);
+                eventFactory.callEvent(event);
 
                 if (event.isCancelled()) {
                     return false;

--- a/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.entity.GlowLivingEntity;
 import net.glowstone.entity.GlowPlayer;

--- a/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowArmorStand.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.entity.GlowLivingEntity;
 import net.glowstone.entity.GlowPlayer;
@@ -116,9 +117,9 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
         }
         EntityDamageEvent event;
         if (source == null) {
-            event = eventFactory.onEntityDamage(new EntityDamageEvent(this, cause, amount));
+            event = EventFactory.getInstance().onEntityDamage(new EntityDamageEvent(this, cause, amount));
         } else {
-            event = eventFactory
+            event = EventFactory.getInstance()
                 .onEntityDamage(new EntityDamageByEntityEvent(source, this, cause, amount));
         }
         if (event.isCancelled()) {
@@ -195,7 +196,7 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
                 PlayerArmorStandManipulateEvent event = new PlayerArmorStandManipulateEvent(player,
                     this, InventoryUtil.itemOrEmpty(null),
                     InventoryUtil.itemOrEmpty(equipment.getItem(slot)), slot);
-                eventFactory.callEvent(event);
+                EventFactory.getInstance().callEvent(event);
 
                 if (event.isCancelled()) {
                     return false;
@@ -218,7 +219,7 @@ public class GlowArmorStand extends GlowLivingEntity implements ArmorStand {
                 PlayerArmorStandManipulateEvent event = new PlayerArmorStandManipulateEvent(player,
                     this, player.getItemInHand(),
                     InventoryUtil.itemOrEmpty(equipment.getItem(slot)), slot);
-                eventFactory.callEvent(event);
+                EventFactory.getInstance().callEvent(event);
 
                 if (event.isCancelled()) {
                     return false;

--- a/src/main/java/net/glowstone/entity/objects/GlowBoat.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowBoat.java
@@ -98,7 +98,8 @@ public class GlowBoat extends GlowEntity implements Boat {
 
         boolean isCreative = player.getGameMode() == GameMode.CREATIVE;
         if (getDamage() > 40.0 || isCreative) {
-            if (EventFactory.getInstance().callEvent(new VehicleDestroyEvent(this, player)).isCancelled()) {
+            if (EventFactory.getInstance()
+                    .callEvent(new VehicleDestroyEvent(this, player)).isCancelled()) {
                 return;
             }
             remove();

--- a/src/main/java/net/glowstone/entity/objects/GlowBoat.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowBoat.java
@@ -4,7 +4,6 @@ import com.flowpowered.network.Message;
 import java.util.Arrays;
 import java.util.List;
 import lombok.Getter;
-import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.meta.MetadataIndex;

--- a/src/main/java/net/glowstone/entity/objects/GlowBoat.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowBoat.java
@@ -4,6 +4,7 @@ import com.flowpowered.network.Message;
 import java.util.Arrays;
 import java.util.List;
 import lombok.Getter;
+import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.meta.MetadataIndex;
@@ -87,7 +88,7 @@ public class GlowBoat extends GlowEntity implements Boat {
     private void damage(GlowPlayer player) {
         //TODO: Do proper damage calculations, based upon the tool used
         VehicleDamageEvent damageEvent = new VehicleDamageEvent(this, player, 10);
-        if (eventFactory.callEvent(damageEvent).isCancelled()) {
+        if (EventFactory.getInstance().callEvent(damageEvent).isCancelled()) {
             return;
         }
 
@@ -97,7 +98,7 @@ public class GlowBoat extends GlowEntity implements Boat {
 
         boolean isCreative = player.getGameMode() == GameMode.CREATIVE;
         if (getDamage() > 40.0 || isCreative) {
-            if (eventFactory.callEvent(new VehicleDestroyEvent(this, player)).isCancelled()) {
+            if (EventFactory.getInstance().callEvent(new VehicleDestroyEvent(this, player)).isCancelled()) {
                 return;
             }
             remove();

--- a/src/main/java/net/glowstone/entity/objects/GlowBoat.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowBoat.java
@@ -88,7 +88,7 @@ public class GlowBoat extends GlowEntity implements Boat {
     private void damage(GlowPlayer player) {
         //TODO: Do proper damage calculations, based upon the tool used
         VehicleDamageEvent damageEvent = new VehicleDamageEvent(this, player, 10);
-        if (EventFactory.callEvent(damageEvent).isCancelled()) {
+        if (eventFactory.callEvent(damageEvent).isCancelled()) {
             return;
         }
 
@@ -98,7 +98,7 @@ public class GlowBoat extends GlowEntity implements Boat {
 
         boolean isCreative = player.getGameMode() == GameMode.CREATIVE;
         if (getDamage() > 40.0 || isCreative) {
-            if (EventFactory.callEvent(new VehicleDestroyEvent(this, player)).isCancelled()) {
+            if (eventFactory.callEvent(new VehicleDestroyEvent(this, player)).isCancelled()) {
                 return;
             }
             remove();

--- a/src/main/java/net/glowstone/entity/objects/GlowEnderCrystal.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowEnderCrystal.java
@@ -83,7 +83,7 @@ public class GlowEnderCrystal extends GlowEntity implements EnderCrystal {
         }
 
         if (cause != DamageCause.ENTITY_EXPLOSION) {
-            ExplosionPrimeEvent event = EventFactory
+            ExplosionPrimeEvent event = eventFactory
                 .callEvent(new ExplosionPrimeEvent(this, Explosion.POWER_ENDER_CRYSTAL, true));
 
             if (!event.isCancelled()) {

--- a/src/main/java/net/glowstone/entity/objects/GlowEnderCrystal.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowEnderCrystal.java
@@ -3,7 +3,6 @@ package net.glowstone.entity.objects;
 import com.flowpowered.network.Message;
 import java.util.Arrays;
 import java.util.List;
-import net.glowstone.EventFactory;
 import net.glowstone.Explosion;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.GlowPlayer;

--- a/src/main/java/net/glowstone/entity/objects/GlowEnderCrystal.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowEnderCrystal.java
@@ -3,6 +3,7 @@ package net.glowstone.entity.objects;
 import com.flowpowered.network.Message;
 import java.util.Arrays;
 import java.util.List;
+import net.glowstone.EventFactory;
 import net.glowstone.Explosion;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.GlowPlayer;
@@ -82,7 +83,7 @@ public class GlowEnderCrystal extends GlowEntity implements EnderCrystal {
         }
 
         if (cause != DamageCause.ENTITY_EXPLOSION) {
-            ExplosionPrimeEvent event = eventFactory
+            ExplosionPrimeEvent event = EventFactory.getInstance()
                 .callEvent(new ExplosionPrimeEvent(this, Explosion.POWER_ENDER_CRYSTAL, true));
 
             if (!event.isCancelled()) {

--- a/src/main/java/net/glowstone/entity/objects/GlowItem.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItem.java
@@ -4,7 +4,6 @@ import com.flowpowered.network.Message;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.meta.MetadataIndex;

--- a/src/main/java/net/glowstone/entity/objects/GlowItem.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItem.java
@@ -4,6 +4,7 @@ import com.flowpowered.network.Message;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.meta.MetadataIndex;
@@ -137,7 +138,7 @@ public class GlowItem extends GlowEntity implements Item {
 
         // disappear if we've lived too long
         if (getTicksLived() >= LIFETIME) {
-            ItemDespawnEvent event = eventFactory
+            ItemDespawnEvent event = EventFactory.getInstance()
                     .callEvent(new ItemDespawnEvent(this, getLocation()));
             if (event.isCancelled()) {
                 // Allow it to live for 5 more minutes, according to docs

--- a/src/main/java/net/glowstone/entity/objects/GlowItem.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItem.java
@@ -138,7 +138,7 @@ public class GlowItem extends GlowEntity implements Item {
 
         // disappear if we've lived too long
         if (getTicksLived() >= LIFETIME) {
-            ItemDespawnEvent event = EventFactory
+            ItemDespawnEvent event = eventFactory
                     .callEvent(new ItemDespawnEvent(this, getLocation()));
             if (event.isCancelled()) {
                 // Allow it to live for 5 more minutes, according to docs

--- a/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
@@ -3,7 +3,6 @@ package net.glowstone.entity.objects;
 import com.flowpowered.network.Message;
 import java.util.Arrays;
 import java.util.List;
-import net.glowstone.EventFactory;
 import net.glowstone.chunk.GlowChunk;
 import net.glowstone.chunk.GlowChunk.Key;
 import net.glowstone.entity.GlowHangingEntity;

--- a/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
@@ -87,7 +87,7 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
         }
         if (message.getAction() == Action.ATTACK.ordinal()) {
             if (isEmpty()) {
-                if (EventFactory.callEvent(new HangingBreakByEntityEvent(this, player))
+                if (eventFactory.callEvent(new HangingBreakByEntityEvent(this, player))
                     .isCancelled()) {
                     return false;
                 }
@@ -96,7 +96,7 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
                 }
                 remove();
             } else {
-                if (EventFactory.callEvent(new EntityDamageByEntityEvent(
+                if (eventFactory.callEvent(new EntityDamageByEntityEvent(
                         player, this, DamageCause.ENTITY_ATTACK, 0)).isCancelled()) {
                     return false;
                 }
@@ -116,7 +116,7 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
         if (ticksLived % (20 * 5) == 0) {
 
             if (location.getBlock().getRelative(getAttachedFace()).getType() == Material.AIR) {
-                if (EventFactory.callEvent(new HangingBreakEvent(this, RemoveCause.PHYSICS))
+                if (eventFactory.callEvent(new HangingBreakEvent(this, RemoveCause.PHYSICS))
                     .isCancelled()) {
                     return;
                 }

--- a/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
@@ -3,6 +3,7 @@ package net.glowstone.entity.objects;
 import com.flowpowered.network.Message;
 import java.util.Arrays;
 import java.util.List;
+import net.glowstone.EventFactory;
 import net.glowstone.chunk.GlowChunk;
 import net.glowstone.chunk.GlowChunk.Key;
 import net.glowstone.entity.GlowHangingEntity;
@@ -86,7 +87,7 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
         }
         if (message.getAction() == Action.ATTACK.ordinal()) {
             if (isEmpty()) {
-                if (eventFactory.callEvent(new HangingBreakByEntityEvent(this, player))
+                if (EventFactory.getInstance().callEvent(new HangingBreakByEntityEvent(this, player))
                     .isCancelled()) {
                     return false;
                 }
@@ -95,7 +96,7 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
                 }
                 remove();
             } else {
-                if (eventFactory.callEvent(new EntityDamageByEntityEvent(
+                if (EventFactory.getInstance().callEvent(new EntityDamageByEntityEvent(
                         player, this, DamageCause.ENTITY_ATTACK, 0)).isCancelled()) {
                     return false;
                 }
@@ -115,7 +116,7 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
         if (ticksLived % (20 * 5) == 0) {
 
             if (location.getBlock().getRelative(getAttachedFace()).getType() == Material.AIR) {
-                if (eventFactory.callEvent(new HangingBreakEvent(this, RemoveCause.PHYSICS))
+                if (EventFactory.getInstance().callEvent(new HangingBreakEvent(this, RemoveCause.PHYSICS))
                     .isCancelled()) {
                     return;
                 }

--- a/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItemFrame.java
@@ -87,8 +87,8 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
         }
         if (message.getAction() == Action.ATTACK.ordinal()) {
             if (isEmpty()) {
-                if (EventFactory.getInstance().callEvent(new HangingBreakByEntityEvent(this, player))
-                    .isCancelled()) {
+                if (EventFactory.getInstance()
+                        .callEvent(new HangingBreakByEntityEvent(this, player)).isCancelled()) {
                     return false;
                 }
                 if (player.getGameMode() != GameMode.CREATIVE) {
@@ -116,8 +116,9 @@ public class GlowItemFrame extends GlowHangingEntity implements ItemFrame {
         if (ticksLived % (20 * 5) == 0) {
 
             if (location.getBlock().getRelative(getAttachedFace()).getType() == Material.AIR) {
-                if (EventFactory.getInstance().callEvent(new HangingBreakEvent(this, RemoveCause.PHYSICS))
-                    .isCancelled()) {
+                if (EventFactory.getInstance()
+                        .callEvent(new HangingBreakEvent(this, RemoveCause.PHYSICS))
+                        .isCancelled()) {
                     return;
                 }
                 world.dropItemNaturally(location, new ItemStack(Material.ITEM_FRAME));

--- a/src/main/java/net/glowstone/entity/objects/GlowLeashHitch.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowLeashHitch.java
@@ -164,7 +164,7 @@ public class GlowLeashHitch extends GlowHangingEntity implements LeashHitch {
 
         if ((message.getAction() == Action.INTERACT.ordinal())
                 && message.getHandSlot() == EquipmentSlot.HAND) {
-            EventFactory eventFactory = player.getServer().getEventFactory();
+            EventFactory eventFactory = EventFactory.getInstance();
             if (player.getLeashedEntities().isEmpty()) {
                 List<GlowEntity> entities = ImmutableList.copyOf(getLeashedEntities());
                 for (GlowEntity leashedEntity : entities) {

--- a/src/main/java/net/glowstone/entity/objects/GlowLeashHitch.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowLeashHitch.java
@@ -163,12 +163,13 @@ public class GlowLeashHitch extends GlowHangingEntity implements LeashHitch {
         }
 
         if ((message.getAction() == Action.INTERACT.ordinal())
-            && message.getHandSlot() == EquipmentSlot.HAND) {
+                && message.getHandSlot() == EquipmentSlot.HAND) {
+            EventFactory eventFactory = player.getServer().getEventFactory();
             if (player.getLeashedEntities().isEmpty()) {
                 List<GlowEntity> entities = ImmutableList.copyOf(getLeashedEntities());
                 for (GlowEntity leashedEntity : entities) {
-                    if (EventFactory.callEvent(
-                        EventFactory.callEvent(new PlayerUnleashEntityEvent(leashedEntity, player)))
+                    if (eventFactory.callEvent(
+                        eventFactory.callEvent(new PlayerUnleashEntityEvent(leashedEntity, player)))
                         .isCancelled()) {
                         continue;
                     }
@@ -183,7 +184,7 @@ public class GlowLeashHitch extends GlowHangingEntity implements LeashHitch {
             } else {
                 List<GlowEntity> entities = ImmutableList.copyOf(player.getLeashedEntities());
                 for (GlowEntity leashedEntity : entities) {
-                    if (EventFactory.callEvent(EventFactory
+                    if (eventFactory.callEvent(eventFactory
                         .callEvent(new PlayerLeashEntityEvent(leashedEntity, this, player)))
                         .isCancelled()) {
                         continue;

--- a/src/main/java/net/glowstone/entity/objects/GlowPainting.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowPainting.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.Getter;
-import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowHangingEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.physics.EntityBoundingBox;

--- a/src/main/java/net/glowstone/entity/objects/GlowPainting.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowPainting.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.Getter;
+import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowHangingEntity;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.physics.EntityBoundingBox;
@@ -103,7 +104,7 @@ public class GlowPainting extends GlowHangingEntity implements Painting {
     @Override
     public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
         if (message.getAction() == Action.ATTACK.ordinal()) {
-            if (eventFactory.callEvent(new HangingBreakByEntityEvent(this, player))
+            if (EventFactory.getInstance().callEvent(new HangingBreakByEntityEvent(this, player))
                 .isCancelled()) {
                 return false;
             }
@@ -242,7 +243,7 @@ public class GlowPainting extends GlowHangingEntity implements Painting {
         super.pulse();
 
         if (ticksLived % (20 * 5) == 0 && isObstructed()) {
-            if (eventFactory.callEvent(new HangingBreakEvent(this, RemoveCause.PHYSICS))
+            if (EventFactory.getInstance().callEvent(new HangingBreakEvent(this, RemoveCause.PHYSICS))
                 .isCancelled()) {
                 return;
             }

--- a/src/main/java/net/glowstone/entity/objects/GlowPainting.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowPainting.java
@@ -104,7 +104,7 @@ public class GlowPainting extends GlowHangingEntity implements Painting {
     @Override
     public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
         if (message.getAction() == Action.ATTACK.ordinal()) {
-            if (EventFactory.callEvent(new HangingBreakByEntityEvent(this, player))
+            if (eventFactory.callEvent(new HangingBreakByEntityEvent(this, player))
                 .isCancelled()) {
                 return false;
             }
@@ -243,7 +243,7 @@ public class GlowPainting extends GlowHangingEntity implements Painting {
         super.pulse();
 
         if (ticksLived % (20 * 5) == 0 && isObstructed()) {
-            if (EventFactory.callEvent(new HangingBreakEvent(this, RemoveCause.PHYSICS))
+            if (eventFactory.callEvent(new HangingBreakEvent(this, RemoveCause.PHYSICS))
                 .isCancelled()) {
                 return;
             }

--- a/src/main/java/net/glowstone/entity/objects/GlowPainting.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowPainting.java
@@ -243,8 +243,8 @@ public class GlowPainting extends GlowHangingEntity implements Painting {
         super.pulse();
 
         if (ticksLived % (20 * 5) == 0 && isObstructed()) {
-            if (EventFactory.getInstance().callEvent(new HangingBreakEvent(this, RemoveCause.PHYSICS))
-                .isCancelled()) {
+            if (EventFactory.getInstance()
+                    .callEvent(new HangingBreakEvent(this, RemoveCause.PHYSICS)).isCancelled()) {
                 return;
             }
 

--- a/src/main/java/net/glowstone/entity/passive/GlowFirework.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowFirework.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.Getter;
 import lombok.Setter;
-import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.Summonable;
 import net.glowstone.entity.meta.MetadataIndex;

--- a/src/main/java/net/glowstone/entity/passive/GlowFirework.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowFirework.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.Getter;
 import lombok.Setter;
+import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowEntity;
 import net.glowstone.entity.Summonable;
 import net.glowstone.entity.meta.MetadataIndex;
@@ -160,7 +161,7 @@ public class GlowFirework extends GlowEntity implements Firework, Summonable {
     }
 
     private void explode() {
-        if (!eventFactory.callEvent(new FireworkExplodeEvent(this)).isCancelled()) {
+        if (!EventFactory.getInstance().callEvent(new FireworkExplodeEvent(this)).isCancelled()) {
             this.playEffect(EntityEffect.FIREWORK_EXPLODE);
 
             int effectsSize = getFireworkMeta().getEffectsSize();

--- a/src/main/java/net/glowstone/entity/passive/GlowFirework.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowFirework.java
@@ -161,7 +161,7 @@ public class GlowFirework extends GlowEntity implements Firework, Summonable {
     }
 
     private void explode() {
-        if (!EventFactory.callEvent(new FireworkExplodeEvent(this)).isCancelled()) {
+        if (!eventFactory.callEvent(new FireworkExplodeEvent(this)).isCancelled()) {
             this.playEffect(EntityEffect.FIREWORK_EXPLODE);
 
             int effectsSize = getFireworkMeta().getEffectsSize();

--- a/src/main/java/net/glowstone/entity/passive/GlowFishingHook.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowFishingHook.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.constants.GlowBiomeClimate;
 import net.glowstone.entity.FishingRewardManager.RewardCategory;

--- a/src/main/java/net/glowstone/entity/passive/GlowFishingHook.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowFishingHook.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import net.glowstone.EventFactory;
 import net.glowstone.GlowWorld;
 import net.glowstone.constants.GlowBiomeClimate;
 import net.glowstone.entity.FishingRewardManager.RewardCategory;
@@ -247,7 +248,7 @@ public class GlowFishingHook extends GlowProjectile implements FishHook {
                 PlayerFishEvent fishEvent
                         = new PlayerFishEvent((Player) shooter, this, null, CAUGHT_FISH);
                 fishEvent.setExpToDrop(ThreadLocalRandom.current().nextInt(1, 7));
-                fishEvent = eventFactory.callEvent(fishEvent);
+                fishEvent = EventFactory.getInstance().callEvent(fishEvent);
                 if (!fishEvent.isCancelled()) {
                     // TODO: Item should "fly" towards player
                     world.dropItemNaturally(((Player) getShooter()).getLocation(), getRewardItem());

--- a/src/main/java/net/glowstone/entity/passive/GlowFishingHook.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowFishingHook.java
@@ -248,7 +248,7 @@ public class GlowFishingHook extends GlowProjectile implements FishHook {
                 PlayerFishEvent fishEvent
                         = new PlayerFishEvent((Player) shooter, this, null, CAUGHT_FISH);
                 fishEvent.setExpToDrop(ThreadLocalRandom.current().nextInt(1, 7));
-                fishEvent = EventFactory.callEvent(fishEvent);
+                fishEvent = eventFactory.callEvent(fishEvent);
                 if (!fishEvent.isCancelled()) {
                     // TODO: Item should "fly" towards player
                     world.dropItemNaturally(((Player) getShooter()).getLocation(), getRewardItem());

--- a/src/main/java/net/glowstone/inventory/EnchantmentManager.java
+++ b/src/main/java/net/glowstone/inventory/EnchantmentManager.java
@@ -29,7 +29,6 @@ public class EnchantmentManager {
 
     private final Random random = new Random();
     private final GlowPlayer player;
-    private final EventFactory eventFactory;
     private final GlowEnchantingInventory inventory;
     private final int[] enchLevelCosts = new int[3];
     private final int[] enchId = new int[3];
@@ -44,7 +43,6 @@ public class EnchantmentManager {
      */
     public EnchantmentManager(GlowEnchantingInventory inventory, GlowPlayer player) {
         this.player = player;
-        eventFactory = EventFactory.getInstance();
         this.inventory = inventory;
         xpSeed = player.getXpSeed();
     }
@@ -235,7 +233,7 @@ public class EnchantmentManager {
             enchants = new ArrayList<>();
         }
 
-        EnchantItemEvent event = eventFactory.callEvent(
+        EnchantItemEvent event = EventFactory.getInstance().callEvent(
             new EnchantItemEvent(player, player.getOpenInventory(),
                 inventory.getLocation().getBlock(), item.clone(), enchLevelCosts[clicked],
                 toMap(enchants), clicked));
@@ -323,7 +321,7 @@ public class EnchantmentManager {
             player.getOpenInventory(), inventory.getLocation().getBlock(), item, offers,
             realBookshelfs);
         event.setCancelled(!canEnchant(item));
-        eventFactory.callEvent(event);
+        EventFactory.getInstance().callEvent(event);
         if (event.isCancelled()) {
             for (int i = 0; i < enchLevelCosts.length; i++) {
                 enchLevelCosts[i] = 0;

--- a/src/main/java/net/glowstone/inventory/EnchantmentManager.java
+++ b/src/main/java/net/glowstone/inventory/EnchantmentManager.java
@@ -44,7 +44,7 @@ public class EnchantmentManager {
      */
     public EnchantmentManager(GlowEnchantingInventory inventory, GlowPlayer player) {
         this.player = player;
-        eventFactory = player.getServer().getEventFactory();
+        eventFactory = EventFactory.getInstance();
         this.inventory = inventory;
         xpSeed = player.getXpSeed();
     }

--- a/src/main/java/net/glowstone/inventory/EnchantmentManager.java
+++ b/src/main/java/net/glowstone/inventory/EnchantmentManager.java
@@ -29,6 +29,7 @@ public class EnchantmentManager {
 
     private final Random random = new Random();
     private final GlowPlayer player;
+    private final EventFactory eventFactory;
     private final GlowEnchantingInventory inventory;
     private final int[] enchLevelCosts = new int[3];
     private final int[] enchId = new int[3];
@@ -43,6 +44,7 @@ public class EnchantmentManager {
      */
     public EnchantmentManager(GlowEnchantingInventory inventory, GlowPlayer player) {
         this.player = player;
+        eventFactory = player.getServer().getEventFactory();
         this.inventory = inventory;
         xpSeed = player.getXpSeed();
     }
@@ -233,7 +235,7 @@ public class EnchantmentManager {
             enchants = new ArrayList<>();
         }
 
-        EnchantItemEvent event = EventFactory.callEvent(
+        EnchantItemEvent event = eventFactory.callEvent(
             new EnchantItemEvent(player, player.getOpenInventory(),
                 inventory.getLocation().getBlock(), item.clone(), enchLevelCosts[clicked],
                 toMap(enchants), clicked));
@@ -321,7 +323,7 @@ public class EnchantmentManager {
             player.getOpenInventory(), inventory.getLocation().getBlock(), item, offers,
             realBookshelfs);
         event.setCancelled(!canEnchant(item));
-        EventFactory.callEvent(event);
+        eventFactory.callEvent(event);
         if (event.isCancelled()) {
             for (int i = 0; i < enchLevelCosts.length; i++) {
                 enchLevelCosts[i] = 0;

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -265,7 +265,8 @@ public class GlowSession extends BasicSession {
         }
 
         // login event
-        PlayerLoginEvent event = EventFactory.getInstance().onPlayerLogin(player, virtualHost.toString());
+        PlayerLoginEvent event = EventFactory.getInstance()
+                .onPlayerLogin(player, virtualHost.toString());
         if (event.getResult() != Result.ALLOWED) {
             disconnect(event.getKickMessage(), true);
             return;

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -156,8 +156,6 @@ public class GlowSession extends BasicSession {
      */
     private volatile boolean compresssionSent;
 
-    private final EventFactory eventFactory;
-
     /**
      * Creates a new session.
      *
@@ -169,7 +167,6 @@ public class GlowSession extends BasicSession {
     public GlowSession(GlowServer server, Channel channel, ConnectionManager connectionManager) {
         super(channel, ProtocolType.HANDSHAKE.getProtocol());
         this.server = server;
-        this.eventFactory = EventFactory.getInstance();
         this.connectionManager = connectionManager;
         address = super.getAddress();
     }
@@ -268,7 +265,7 @@ public class GlowSession extends BasicSession {
         }
 
         // login event
-        PlayerLoginEvent event = eventFactory.onPlayerLogin(player, virtualHost.toString());
+        PlayerLoginEvent event = EventFactory.getInstance().onPlayerLogin(player, virtualHost.toString());
         if (event.getResult() != Result.ALLOWED) {
             disconnect(event.getKickMessage(), true);
             return;
@@ -285,7 +282,7 @@ public class GlowSession extends BasicSession {
                 .getUniqueId());
 
         // message and user list
-        String message = eventFactory.onPlayerJoin(player).getJoinMessage();
+        String message = EventFactory.getInstance().onPlayerJoin(player).getJoinMessage();
         if (message != null && !message.isEmpty()) {
             server.broadcastMessage(message);
         }
@@ -364,7 +361,7 @@ public class GlowSession extends BasicSession {
      */
     public void disconnect(String reason, boolean overrideKick) {
         if (player != null && !overrideKick) {
-            PlayerKickEvent event = eventFactory.onPlayerKick(player, reason);
+            PlayerKickEvent event = EventFactory.getInstance().onPlayerKick(player, reason);
             if (event.isCancelled()) {
                 return;
             }
@@ -446,7 +443,7 @@ public class GlowSession extends BasicSession {
                 }
             } while (!bars.isEmpty());
 
-            String text = eventFactory.onPlayerQuit(player).getQuitMessage();
+            String text = EventFactory.getInstance().onPlayerQuit(player).getQuitMessage();
             if (online && text != null && !text.isEmpty()) {
                 server.broadcastMessage(text);
             }

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -156,6 +156,8 @@ public class GlowSession extends BasicSession {
      */
     private volatile boolean compresssionSent;
 
+    private final EventFactory eventFactory;
+
     /**
      * Creates a new session.
      *
@@ -167,6 +169,7 @@ public class GlowSession extends BasicSession {
     public GlowSession(GlowServer server, Channel channel, ConnectionManager connectionManager) {
         super(channel, ProtocolType.HANDSHAKE.getProtocol());
         this.server = server;
+        this.eventFactory = server.getEventFactory();
         this.connectionManager = connectionManager;
         address = super.getAddress();
     }
@@ -265,7 +268,7 @@ public class GlowSession extends BasicSession {
         }
 
         // login event
-        PlayerLoginEvent event = EventFactory.onPlayerLogin(player, virtualHost.toString());
+        PlayerLoginEvent event = eventFactory.onPlayerLogin(player, virtualHost.toString());
         if (event.getResult() != Result.ALLOWED) {
             disconnect(event.getKickMessage(), true);
             return;
@@ -282,7 +285,7 @@ public class GlowSession extends BasicSession {
                 .getUniqueId());
 
         // message and user list
-        String message = EventFactory.onPlayerJoin(player).getJoinMessage();
+        String message = eventFactory.onPlayerJoin(player).getJoinMessage();
         if (message != null && !message.isEmpty()) {
             server.broadcastMessage(message);
         }
@@ -361,7 +364,7 @@ public class GlowSession extends BasicSession {
      */
     public void disconnect(String reason, boolean overrideKick) {
         if (player != null && !overrideKick) {
-            PlayerKickEvent event = EventFactory.onPlayerKick(player, reason);
+            PlayerKickEvent event = eventFactory.onPlayerKick(player, reason);
             if (event.isCancelled()) {
                 return;
             }
@@ -443,7 +446,7 @@ public class GlowSession extends BasicSession {
                 }
             } while (!bars.isEmpty());
 
-            String text = EventFactory.onPlayerQuit(player).getQuitMessage();
+            String text = eventFactory.onPlayerQuit(player).getQuitMessage();
             if (online && text != null && !text.isEmpty()) {
                 server.broadcastMessage(text);
             }

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -169,7 +169,7 @@ public class GlowSession extends BasicSession {
     public GlowSession(GlowServer server, Channel channel, ConnectionManager connectionManager) {
         super(channel, ProtocolType.HANDSHAKE.getProtocol());
         this.server = server;
-        this.eventFactory = server.getEventFactory();
+        this.eventFactory = EventFactory.getInstance();
         this.connectionManager = connectionManager;
         address = super.getAddress();
     }

--- a/src/main/java/net/glowstone/net/handler/legacyping/LegacyPingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/legacyping/LegacyPingHandler.java
@@ -38,7 +38,7 @@ public class LegacyPingHandler extends ChannelInboundHandlerAdapter {
                 ServerListPingEvent legacyPingEvent = new ServerListPingEvent(
                     inetsocketaddress.getAddress(), server.getMotd(),
                     server.getOnlinePlayers().size(), server.getMaxPlayers());
-                server.getEventFactory().callEvent(legacyPingEvent);
+                EventFactory.getInstance().callEvent(legacyPingEvent);
 
                 switch (readableBytes) {
                     case 0:

--- a/src/main/java/net/glowstone/net/handler/legacyping/LegacyPingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/legacyping/LegacyPingHandler.java
@@ -38,7 +38,7 @@ public class LegacyPingHandler extends ChannelInboundHandlerAdapter {
                 ServerListPingEvent legacyPingEvent = new ServerListPingEvent(
                     inetsocketaddress.getAddress(), server.getMotd(),
                     server.getOnlinePlayers().size(), server.getMaxPlayers());
-                EventFactory.callEvent(legacyPingEvent);
+                server.getEventFactory().callEvent(legacyPingEvent);
 
                 switch (readableBytes) {
                     case 0:

--- a/src/main/java/net/glowstone/net/handler/login/EncryptionKeyResponseHandler.java
+++ b/src/main/java/net/glowstone/net/handler/login/EncryptionKeyResponseHandler.java
@@ -163,7 +163,7 @@ public final class EncryptionKeyResponseHandler implements
                 properties.add(new ProfileProperty(propName, value, signature));
             }
 
-            AsyncPlayerPreLoginEvent event = session.getServer().getEventFactory()
+            AsyncPlayerPreLoginEvent event = EventFactory.getInstance()
                 .onPlayerPreLogin(name, session.getAddress(), uuid);
             if (event.getLoginResult() != Result.ALLOWED) {
                 session.disconnect(event.getKickMessage(), true);

--- a/src/main/java/net/glowstone/net/handler/login/EncryptionKeyResponseHandler.java
+++ b/src/main/java/net/glowstone/net/handler/login/EncryptionKeyResponseHandler.java
@@ -163,7 +163,7 @@ public final class EncryptionKeyResponseHandler implements
                 properties.add(new ProfileProperty(propName, value, signature));
             }
 
-            AsyncPlayerPreLoginEvent event = EventFactory
+            AsyncPlayerPreLoginEvent event = session.getServer().getEventFactory()
                 .onPlayerPreLogin(name, session.getAddress(), uuid);
             if (event.getLoginResult() != Result.ALLOWED) {
                 session.disconnect(event.getKickMessage(), true);

--- a/src/main/java/net/glowstone/net/handler/login/LoginStartHandler.java
+++ b/src/main/java/net/glowstone/net/handler/login/LoginStartHandler.java
@@ -50,7 +50,7 @@ public final class LoginStartHandler implements MessageHandler<GlowSession, Logi
                 }
             }
 
-            AsyncPlayerPreLoginEvent event = server.getEventFactory()
+            AsyncPlayerPreLoginEvent event = EventFactory.getInstance()
                 .onPlayerPreLogin(profile.getName(), session.getAddress(), profile.getUniqueId());
             if (event.getLoginResult() != Result.ALLOWED) {
                 session.disconnect(event.getKickMessage(), true);

--- a/src/main/java/net/glowstone/net/handler/login/LoginStartHandler.java
+++ b/src/main/java/net/glowstone/net/handler/login/LoginStartHandler.java
@@ -4,6 +4,7 @@ import com.flowpowered.network.MessageHandler;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import net.glowstone.EventFactory;
+import net.glowstone.GlowServer;
 import net.glowstone.entity.meta.profile.GlowPlayerProfile;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.ProxyData;
@@ -18,12 +19,13 @@ public final class LoginStartHandler implements MessageHandler<GlowSession, Logi
     @Override
     public void handle(GlowSession session, LoginStartMessage message) {
         String name = message.getUsername();
+        GlowServer server = session.getServer();
 
-        if (session.getServer().getOnlineMode()) {
+        if (server.getOnlineMode()) {
             // Get necessary information to create our request message
             String sessionId = session.getSessionId();
             byte[] publicKey = SecurityUtils
-                .generateX509Key(session.getServer().getKeyPair().getPublic())
+                .generateX509Key(server.getKeyPair().getPublic())
                 .getEncoded(); //Convert to X509 format
             byte[] verifyToken = SecurityUtils.generateVerifyToken();
 
@@ -48,7 +50,7 @@ public final class LoginStartHandler implements MessageHandler<GlowSession, Logi
                 }
             }
 
-            AsyncPlayerPreLoginEvent event = EventFactory
+            AsyncPlayerPreLoginEvent event = server.getEventFactory()
                 .onPlayerPreLogin(profile.getName(), session.getAddress(), profile.getUniqueId());
             if (event.getLoginResult() != Result.ALLOWED) {
                 session.disconnect(event.getKickMessage(), true);
@@ -56,7 +58,7 @@ public final class LoginStartHandler implements MessageHandler<GlowSession, Logi
             }
 
             GlowPlayerProfile finalProfile = profile;
-            session.getServer().getScheduler().runTask(null, () -> session.setPlayer(finalProfile));
+            server.getScheduler().runTask(null, () -> session.setPlayer(finalProfile));
         }
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/game/UpdateSignHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/game/UpdateSignHandler.java
@@ -29,7 +29,7 @@ public final class UpdateSignHandler implements MessageHandler<GlowSession, Upda
             lines[i] = message.getMessage()[i].asPlaintext();
         }
         SignChangeEvent event = new SignChangeEvent(location.getBlock(), player, lines);
-        session.getServer().getEventFactory().callEvent(event);
+        EventFactory.getInstance().callEvent(event);
         if (event.isCancelled()) {
             GlowServer.logger.warning("Sign was cancelled");
             return;

--- a/src/main/java/net/glowstone/net/handler/play/game/UpdateSignHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/game/UpdateSignHandler.java
@@ -29,7 +29,7 @@ public final class UpdateSignHandler implements MessageHandler<GlowSession, Upda
             lines[i] = message.getMessage()[i].asPlaintext();
         }
         SignChangeEvent event = new SignChangeEvent(location.getBlock(), player, lines);
-        EventFactory.callEvent(event);
+        session.getServer().getEventFactory().callEvent(event);
         if (event.isCancelled()) {
             GlowServer.logger.warning("Sign was cancelled");
             return;

--- a/src/main/java/net/glowstone/net/handler/play/inv/CreativeItemHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/CreativeItemHandler.java
@@ -40,8 +40,9 @@ public final class CreativeItemHandler implements MessageHandler<GlowSession, Cr
         ItemStack stack = ItemIds.sanitize(message.getItem());
 
         // clicking outside drops the item
+        EventFactory eventFactory = player.getServer().getEventFactory();
         if (message.getSlot() < 0) {
-            InventoryCreativeEvent event = EventFactory
+            InventoryCreativeEvent event = eventFactory
                 .callEvent(new InventoryCreativeEvent(view, SlotType.OUTSIDE, -999, stack));
             if (event.isCancelled()) {
                 session.send(new SetWindowSlotMessage(-1, -1, stack));
@@ -60,7 +61,7 @@ public final class CreativeItemHandler implements MessageHandler<GlowSession, Cr
         GlowInventory inv = player.getInventory();
         int slot = view.convertSlot(viewSlot);
         SlotType type = inv.getSlotType(slot);
-        InventoryCreativeEvent event = EventFactory
+        InventoryCreativeEvent event = eventFactory
             .callEvent(new InventoryCreativeEvent(view, type, viewSlot, stack));
         if (event.isCancelled()) {
             // send original slot to player to prevent async inventories

--- a/src/main/java/net/glowstone/net/handler/play/inv/CreativeItemHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/CreativeItemHandler.java
@@ -40,7 +40,7 @@ public final class CreativeItemHandler implements MessageHandler<GlowSession, Cr
         ItemStack stack = ItemIds.sanitize(message.getItem());
 
         // clicking outside drops the item
-        EventFactory eventFactory = player.getServer().getEventFactory();
+        EventFactory eventFactory = EventFactory.getInstance();
         if (message.getSlot() < 0) {
             InventoryCreativeEvent event = eventFactory
                 .callEvent(new InventoryCreativeEvent(view, SlotType.OUTSIDE, -999, stack));

--- a/src/main/java/net/glowstone/net/handler/play/inv/HeldItemHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/HeldItemHandler.java
@@ -25,7 +25,7 @@ public final class HeldItemHandler implements MessageHandler<GlowSession, HeldIt
         }
 
         PlayerItemHeldEvent event = new PlayerItemHeldEvent(player, oldSlot, slot);
-        player.getServer().getEventFactory().callEvent(event);
+        EventFactory.getInstance().callEvent(event);
 
         if (!event.isCancelled()) {
             player.getInventory().setRawHeldItemSlot(slot);

--- a/src/main/java/net/glowstone/net/handler/play/inv/HeldItemHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/HeldItemHandler.java
@@ -25,7 +25,7 @@ public final class HeldItemHandler implements MessageHandler<GlowSession, HeldIt
         }
 
         PlayerItemHeldEvent event = new PlayerItemHeldEvent(player, oldSlot, slot);
-        EventFactory.callEvent(event);
+        player.getServer().getEventFactory().callEvent(event);
 
         if (!event.isCancelled()) {
             player.getInventory().setRawHeldItemSlot(slot);

--- a/src/main/java/net/glowstone/net/handler/play/inv/VehicleMoveHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/VehicleMoveHandler.java
@@ -66,7 +66,7 @@ public class VehicleMoveHandler implements MessageHandler<GlowSession, VehicleMo
         // call move event if movement actually occurred and there are handlers registered
         if (!oldLocation.equals(newLocation)
             && VehicleMoveEvent.getHandlerList().getRegisteredListeners().length > 0) {
-            EventFactory.callEvent(
+            session.getServer().getEventFactory().callEvent(
                 new VehicleMoveEvent((Vehicle) vehicle, oldLocation, newLocation.clone()));
         }
 

--- a/src/main/java/net/glowstone/net/handler/play/inv/VehicleMoveHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/VehicleMoveHandler.java
@@ -66,7 +66,7 @@ public class VehicleMoveHandler implements MessageHandler<GlowSession, VehicleMo
         // call move event if movement actually occurred and there are handlers registered
         if (!oldLocation.equals(newLocation)
             && VehicleMoveEvent.getHandlerList().getRegisteredListeners().length > 0) {
-            session.getServer().getEventFactory().callEvent(
+            EventFactory.getInstance().callEvent(
                 new VehicleMoveEvent((Vehicle) vehicle, oldLocation, newLocation.clone()));
         }
 

--- a/src/main/java/net/glowstone/net/handler/play/inv/WindowClickHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/WindowClickHandler.java
@@ -152,7 +152,7 @@ public final class WindowClickHandler implements MessageHandler<GlowSession, Win
 
                     InventoryDragEvent event = new InventoryDragEvent(view, newCursor, cursor,
                             right, newSlots);
-                    EventFactory.callEvent(event);
+                    player.getServer().getEventFactory().callEvent(event);
                     if (event.isCancelled()) {
                         return false;
                     }
@@ -268,7 +268,7 @@ public final class WindowClickHandler implements MessageHandler<GlowSession, Win
             }
         }
 
-        EventFactory.callEvent(event);
+        player.getServer().getEventFactory().callEvent(event);
         if (event.isCancelled()) {
             int slot = event.getSlot();
             player.getSession().send(new SetWindowSlotMessage(player.getOpenWindowId(),

--- a/src/main/java/net/glowstone/net/handler/play/inv/WindowClickHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/inv/WindowClickHandler.java
@@ -152,7 +152,7 @@ public final class WindowClickHandler implements MessageHandler<GlowSession, Win
 
                     InventoryDragEvent event = new InventoryDragEvent(view, newCursor, cursor,
                             right, newSlots);
-                    player.getServer().getEventFactory().callEvent(event);
+                    EventFactory.getInstance().callEvent(event);
                     if (event.isCancelled()) {
                         return false;
                     }
@@ -268,7 +268,7 @@ public final class WindowClickHandler implements MessageHandler<GlowSession, Win
             }
         }
 
-        player.getServer().getEventFactory().callEvent(event);
+        EventFactory.getInstance().callEvent(event);
         if (event.isCancelled()) {
             int slot = event.getSlot();
             player.getSession().send(new SetWindowSlotMessage(player.getOpenWindowId(),

--- a/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
@@ -104,7 +104,7 @@ public final class BlockPlacementHandler implements
             GlowPlayer player, ItemStack holding, EquipmentSlot slot, GlowBlock clicked,
             BlockFace face, Vector clickedLoc) {
         // call interact event
-        PlayerInteractEvent event = EventFactory.onPlayerInteract(
+        PlayerInteractEvent event = player.getServer().getEventFactory().onPlayerInteract(
                 player, Action.RIGHT_CLICK_BLOCK, slot, clicked, face);
 
         // attempt to use interacted block

--- a/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
@@ -104,7 +104,7 @@ public final class BlockPlacementHandler implements
             GlowPlayer player, ItemStack holding, EquipmentSlot slot, GlowBlock clicked,
             BlockFace face, Vector clickedLoc) {
         // call interact event
-        PlayerInteractEvent event = player.getServer().getEventFactory().onPlayerInteract(
+        PlayerInteractEvent event = EventFactory.getInstance().onPlayerInteract(
                 player, Action.RIGHT_CLICK_BLOCK, slot, clicked, face);
 
         // attempt to use interacted block

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -38,6 +38,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
     public void handle(GlowSession session, DiggingMessage message) {
         GlowPlayer player = session.getPlayer();
         GlowWorld world = player.getWorld();
+        EventFactory eventFactory = world.getServer().getEventFactory();
         GlowBlock block = world.getBlockAt(message.getX(), message.getY(), message.getZ());
         BlockFace face = BlockPlacementHandler.convertFace(message.getFace());
         ItemStack holding = player.getItemInHand();
@@ -58,7 +59,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
                 action = Action.LEFT_CLICK_AIR;
                 eventBlock = null;
             }
-            PlayerInteractEvent interactEvent = EventFactory
+            PlayerInteractEvent interactEvent = eventFactory
                 .onPlayerInteract(player, action, EquipmentSlot.HAND, eventBlock, face);
 
             // blocks don't get interacted with on left click, so ignore that
@@ -77,7 +78,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
                     && EnchantmentTarget.WEAPON.includes(holding.getType())) {
                     damageEvent.setCancelled(true);
                 }
-                EventFactory.callEvent(damageEvent);
+                eventFactory.callEvent(damageEvent);
 
                 // follow orders
                 if (damageEvent.isCancelled()) {
@@ -200,7 +201,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
 
         if (blockBroken && !revert) {
             // fire the block break event
-            BlockBreakEvent breakEvent = EventFactory.callEvent(new BlockBreakEvent(block, player));
+            BlockBreakEvent breakEvent = eventFactory.callEvent(new BlockBreakEvent(block, player));
             if (breakEvent.isCancelled()) {
                 BlockPlacementHandler.revert(player, block);
                 return;

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -38,7 +38,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
     public void handle(GlowSession session, DiggingMessage message) {
         GlowPlayer player = session.getPlayer();
         GlowWorld world = player.getWorld();
-        EventFactory eventFactory = world.getServer().getEventFactory();
+        EventFactory eventFactory = EventFactory.getInstance();
         GlowBlock block = world.getBlockAt(message.getX(), message.getY(), message.getZ());
         BlockFace face = BlockPlacementHandler.convertFace(message.getFace());
         ItemStack holding = player.getItemInHand();

--- a/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
@@ -31,7 +31,7 @@ public final class InteractEntityHandler implements
     @Override
     public void handle(GlowSession session, InteractEntityMessage message) {
         GlowPlayer player = session.getPlayer();
-        EventFactory eventFactory = player.getServer().getEventFactory();
+        EventFactory eventFactory = EventFactory.getInstance();
 
         // You can't do anything when you're dead
         if (player.isDead()) {

--- a/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/InteractEntityHandler.java
@@ -31,6 +31,7 @@ public final class InteractEntityHandler implements
     @Override
     public void handle(GlowSession session, InteractEntityMessage message) {
         GlowPlayer player = session.getPlayer();
+        EventFactory eventFactory = player.getServer().getEventFactory();
 
         // You can't do anything when you're dead
         if (player.isDead()) {
@@ -138,7 +139,7 @@ public final class InteractEntityHandler implements
             PlayerInteractAtEntityEvent event = new PlayerInteractAtEntityEvent(player,
                 possibleTarget,
                 new Vector(message.getTargetX(), message.getTargetY(), message.getTargetZ()), hand);
-            EventFactory.callEvent(event);
+            eventFactory.callEvent(event);
 
             if (!event.isCancelled()) {
                 possibleTarget.entityInteract(player, message);
@@ -147,7 +148,7 @@ public final class InteractEntityHandler implements
             //Todo: Handle hand variable
             PlayerInteractEntityEvent event = new PlayerInteractEntityEvent(player, possibleTarget,
                 hand);
-            EventFactory.callEvent(event);
+            eventFactory.callEvent(event);
 
             if (!event.isCancelled()) {
                 possibleTarget.entityInteract(player, message);

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
@@ -19,11 +19,11 @@ public final class PlayerSwingArmHandler implements
     @Override
     public void handle(GlowSession session, PlayerSwingArmMessage message) {
         GlowPlayer player = session.getPlayer();
-
+        EventFactory eventFactory = player.getServer().getEventFactory();
         Block block = player.getTargetBlock((Set<Material>) null, 6);
 
         if (block == null || block.isEmpty()) {
-            if (EventFactory.onPlayerInteract(
+            if (eventFactory.onPlayerInteract(
                     player, Action.LEFT_CLICK_AIR, message.getHandSlot()).useItemInHand()
                     == Result.DENY) {
                 return;
@@ -31,7 +31,7 @@ public final class PlayerSwingArmHandler implements
             // todo: item interactions with air
         }
 
-        if (!EventFactory.callEvent(new PlayerAnimationEvent(player)).isCancelled()) {
+        if (!eventFactory.callEvent(new PlayerAnimationEvent(player)).isCancelled()) {
             // play the animation to others
             player.playAnimation(message.getHand() == 1 ? EntityAnimation.SWING_OFF_HAND
                     : EntityAnimation.SWING_MAIN_HAND);

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerSwingArmHandler.java
@@ -19,7 +19,7 @@ public final class PlayerSwingArmHandler implements
     @Override
     public void handle(GlowSession session, PlayerSwingArmMessage message) {
         GlowPlayer player = session.getPlayer();
-        EventFactory eventFactory = player.getServer().getEventFactory();
+        EventFactory eventFactory = EventFactory.getInstance();
         Block block = player.getTargetBlock((Set<Material>) null, 6);
 
         if (block == null || block.isEmpty()) {

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
@@ -64,7 +64,7 @@ public final class PlayerUpdateHandler implements MessageHandler<GlowSession, Pl
         // call move event if movement actually occurred and there are handlers registered
         if (!oldLocation.equals(newLocation)
             && PlayerMoveEvent.getHandlerList().getRegisteredListeners().length > 0) {
-            PlayerMoveEvent event = EventFactory
+            PlayerMoveEvent event = player.getServer().getEventFactory()
                 .callEvent(new PlayerMoveEvent(player, oldLocation, newLocation));
             if (event.isCancelled()) {
                 // tell client they're back where they started

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerUpdateHandler.java
@@ -64,7 +64,7 @@ public final class PlayerUpdateHandler implements MessageHandler<GlowSession, Pl
         // call move event if movement actually occurred and there are handlers registered
         if (!oldLocation.equals(newLocation)
             && PlayerMoveEvent.getHandlerList().getRegisteredListeners().length > 0) {
-            PlayerMoveEvent event = player.getServer().getEventFactory()
+            PlayerMoveEvent event = EventFactory.getInstance()
                 .callEvent(new PlayerMoveEvent(player, oldLocation, newLocation));
             if (event.isCancelled()) {
                 // tell client they're back where they started

--- a/src/main/java/net/glowstone/net/handler/play/player/ResourcePackStatusHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/ResourcePackStatusHandler.java
@@ -3,6 +3,7 @@ package net.glowstone.net.handler.play.player;
 import com.flowpowered.network.MessageHandler;
 import net.glowstone.EventFactory;
 import net.glowstone.constants.ResourcePackStatus;
+import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.ResourcePackStatusMessage;
 import org.bukkit.entity.Player;
@@ -13,11 +14,11 @@ public final class ResourcePackStatusHandler implements
 
     @Override
     public void handle(GlowSession session, ResourcePackStatusMessage message) {
-        Player player = session.getPlayer();
+        GlowPlayer player = session.getPlayer();
         PlayerResourcePackStatusEvent.Status status = ResourcePackStatus
             .getStatus(message.getResult());
-        session.getPlayer().setResourcePackStatus(status);
-        EventFactory.callEvent(
+        player.setResourcePackStatus(status);
+        player.getServer().getEventFactory().callEvent(
             new PlayerResourcePackStatusEvent(player, status, player.getResourcePackHash()));
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/ResourcePackStatusHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/ResourcePackStatusHandler.java
@@ -6,7 +6,6 @@ import net.glowstone.constants.ResourcePackStatus;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.ResourcePackStatusMessage;
-import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerResourcePackStatusEvent;
 
 public final class ResourcePackStatusHandler implements
@@ -18,7 +17,7 @@ public final class ResourcePackStatusHandler implements
         PlayerResourcePackStatusEvent.Status status = ResourcePackStatus
             .getStatus(message.getResult());
         player.setResourcePackStatus(status);
-        player.getServer().getEventFactory().callEvent(
+        EventFactory.getInstance().callEvent(
             new PlayerResourcePackStatusEvent(player, status, player.getResourcePackHash()));
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/TabCompleteHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/TabCompleteHandler.java
@@ -52,7 +52,7 @@ public final class TabCompleteHandler implements MessageHandler<GlowSession, Tab
         }
 
         // call event and send response
-        sender.getServer().getEventFactory()
+        EventFactory.getInstance()
                 .callEvent(new PlayerChatTabCompleteEvent(sender, buffer, completions));
         session.send(new TabCompleteResponseMessage(completions));
     }

--- a/src/main/java/net/glowstone/net/handler/play/player/TabCompleteHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/TabCompleteHandler.java
@@ -4,6 +4,7 @@ import com.flowpowered.network.MessageHandler;
 import java.util.ArrayList;
 import java.util.List;
 import net.glowstone.EventFactory;
+import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.TabCompleteMessage;
 import net.glowstone.net.message.play.player.TabCompleteResponseMessage;
@@ -15,7 +16,7 @@ public final class TabCompleteHandler implements MessageHandler<GlowSession, Tab
 
     @Override
     public void handle(GlowSession session, TabCompleteMessage message) {
-        Player sender = session.getPlayer();
+        GlowPlayer sender = session.getPlayer();
         String buffer = message.getText();
         List<String> completions = new ArrayList<>();
 
@@ -51,7 +52,8 @@ public final class TabCompleteHandler implements MessageHandler<GlowSession, Tab
         }
 
         // call event and send response
-        EventFactory.callEvent(new PlayerChatTabCompleteEvent(sender, buffer, completions));
+        sender.getServer().getEventFactory()
+                .callEvent(new PlayerChatTabCompleteEvent(sender, buffer, completions));
         session.send(new TabCompleteResponseMessage(completions));
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/UseItemHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/UseItemHandler.java
@@ -78,7 +78,7 @@ public class UseItemHandler implements MessageHandler<GlowSession, UseItemMessag
     }
 
     static void handleRightClickAir(GlowPlayer player, ItemStack holding, EquipmentSlot slot) {
-        PlayerInteractEvent event = EventFactory.onPlayerInteract(
+        PlayerInteractEvent event = player.getServer().getEventFactory().onPlayerInteract(
                 player, Action.RIGHT_CLICK_AIR, slot);
 
         if (event.useItemInHand() == null || event.useItemInHand() == Event.Result.DENY) {

--- a/src/main/java/net/glowstone/net/handler/play/player/UseItemHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/UseItemHandler.java
@@ -78,7 +78,7 @@ public class UseItemHandler implements MessageHandler<GlowSession, UseItemMessag
     }
 
     static void handleRightClickAir(GlowPlayer player, ItemStack holding, EquipmentSlot slot) {
-        PlayerInteractEvent event = player.getServer().getEventFactory().onPlayerInteract(
+        PlayerInteractEvent event = EventFactory.getInstance().onPlayerInteract(
                 player, Action.RIGHT_CLICK_AIR, slot);
 
         if (event.useItemInHand() == null || event.useItemInHand() == Event.Result.DENY) {

--- a/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
+++ b/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
@@ -35,7 +35,7 @@ public final class StatusRequestHandler implements
         event.icon = server.getServerIcon();
         event.serverType = server.getServerType();
         event.clientModsAllowed = server.getAllowClientMods();
-        EventFactory.callEvent(event);
+        server.getEventFactory().callEvent(event);
 
         // build the json
         JSONObject json = new JSONObject();

--- a/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
+++ b/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
@@ -35,7 +35,7 @@ public final class StatusRequestHandler implements
         event.icon = server.getServerIcon();
         event.serverType = server.getServerType();
         event.clientModsAllowed = server.getAllowClientMods();
-        server.getEventFactory().callEvent(event);
+        EventFactory.getInstance().callEvent(event);
 
         // build the json
         JSONObject json = new JSONObject();

--- a/src/main/java/net/glowstone/net/rcon/RconHandler.java
+++ b/src/main/java/net/glowstone/net/rcon/RconHandler.java
@@ -92,7 +92,7 @@ public class RconHandler extends SimpleChannelInboundHandler<ByteBuf> {
         }
 
         try {
-            RemoteServerCommandEvent event = rconServer.getServer().getEventFactory()
+            RemoteServerCommandEvent event = EventFactory.getInstance()
                 .callEvent(new RemoteServerCommandEvent(commandSender, payload));
             if (event.isCancelled()) {
                 return;

--- a/src/main/java/net/glowstone/net/rcon/RconHandler.java
+++ b/src/main/java/net/glowstone/net/rcon/RconHandler.java
@@ -92,7 +92,7 @@ public class RconHandler extends SimpleChannelInboundHandler<ByteBuf> {
         }
 
         try {
-            RemoteServerCommandEvent event = EventFactory
+            RemoteServerCommandEvent event = rconServer.getServer().getEventFactory()
                 .callEvent(new RemoteServerCommandEvent(commandSender, payload));
             if (event.isCancelled()) {
                 return;

--- a/src/main/java/net/glowstone/scoreboard/GlowScoreboardManager.java
+++ b/src/main/java/net/glowstone/scoreboard/GlowScoreboardManager.java
@@ -7,7 +7,7 @@ import org.bukkit.scoreboard.ScoreboardManager;
 /**
  * ScoreboardManager implementation.
  */
-public final class GlowScoreboardManager implements ScoreboardManager {
+public class GlowScoreboardManager implements ScoreboardManager {
 
     private final GlowServer server;
     private GlowScoreboard mainScoreboard;

--- a/src/main/java/net/glowstone/util/InventoryUtil.java
+++ b/src/main/java/net/glowstone/util/InventoryUtil.java
@@ -98,7 +98,8 @@ public class InventoryUtil {
         holding.setDurability((short) (holding.getDurability() + 1));
         if (holding.getDurability() == holding.getType().getMaxDurability() + 1) {
             if (player != null) {
-                EventFactory.callEvent(new PlayerItemBreakEvent(player, holding));
+                player.getServer().getEventFactory()
+                        .callEvent(new PlayerItemBreakEvent(player, holding));
             }
             return createEmptyStack();
         }

--- a/src/main/java/net/glowstone/util/InventoryUtil.java
+++ b/src/main/java/net/glowstone/util/InventoryUtil.java
@@ -98,7 +98,7 @@ public class InventoryUtil {
         holding.setDurability((short) (holding.getDurability() + 1));
         if (holding.getDurability() == holding.getType().getMaxDurability() + 1) {
             if (player != null) {
-                player.getServer().getEventFactory()
+                EventFactory.getInstance()
                         .callEvent(new PlayerItemBreakEvent(player, holding));
             }
             return createEmptyStack();

--- a/src/test/java/net/glowstone/command/minecraft/PlaySoundCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/PlaySoundCommandTest.java
@@ -30,7 +30,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Bukkit.class, CommandUtils.class, GlowServer.class, GlowWorld.class})
+@PrepareForTest({Bukkit.class, CommandUtils.class})
 public class PlaySoundCommandTest {
 
     private Player fakePlayer1, fakePlayer2, fakePlayer3;

--- a/src/test/java/net/glowstone/command/minecraft/SetWorldSpawnCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SetWorldSpawnCommandTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.eq;
 
 import java.util.Collections;
-import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
 import net.glowstone.command.CommandUtils;
 import org.bukkit.ChatColor;
@@ -23,7 +22,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({CommandUtils.class, GlowServer.class, GlowWorld.class})
+@PrepareForTest({CommandUtils.class})
 public class SetWorldSpawnCommandTest {
 
     private CommandSender sender, opSender, opPlayer;

--- a/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
@@ -26,7 +26,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Bukkit.class, CommandUtils.class, GlowServer.class, GlowWorld.class})
+@PrepareForTest({Bukkit.class, CommandUtils.class})
 public class SpawnPointCommandTest {
 
     private CommandSender sender, opSender, opPlayer;

--- a/src/test/java/net/glowstone/command/minecraft/TestForBlocksCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/TestForBlocksCommandTest.java
@@ -12,22 +12,17 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({GlowWorld.class})
 public class TestForBlocksCommandTest {
     private TestForBlocksCommand command;
     private InMemoryBlockStorage blockStorage;
     private Player opPlayer;
     private GlowWorld world;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         command = new TestForBlocksCommand();
         blockStorage = new InMemoryBlockStorage();

--- a/src/test/java/net/glowstone/command/minecraft/ToggleDownfallCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/ToggleDownfallCommandTest.java
@@ -19,7 +19,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({CommandUtils.class, GlowWorld.class})
+@PrepareForTest({CommandUtils.class})
 public class ToggleDownfallCommandTest {
 
     private World world;

--- a/src/test/java/net/glowstone/entity/GlowAgeableTest.java
+++ b/src/test/java/net/glowstone/entity/GlowAgeableTest.java
@@ -3,19 +3,17 @@ package net.glowstone.entity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
-import java.io.IOException;
 import java.util.function.Function;
 import org.bukkit.Location;
 import org.bukkit.entity.Ageable;
-import org.bukkit.entity.Entity;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 public abstract class GlowAgeableTest<T extends GlowAgeable> extends GlowLivingEntityTest<T> {
@@ -145,6 +143,7 @@ public abstract class GlowAgeableTest<T extends GlowAgeable> extends GlowLivingE
                 eq(CreatureSpawnEvent.SpawnReason.SPAWNER_EGG)))
                 .thenCallRealMethod();
         T baby = (T) entity.createBaby();
+        assertNotNull(baby);
         assertNotEquals(entity, baby);
         assertEquals(entity.getClass(), baby.getClass());
         assertEquals(entity, baby.getParent());

--- a/src/test/java/net/glowstone/entity/GlowEntityTest.java
+++ b/src/test/java/net/glowstone/entity/GlowEntityTest.java
@@ -6,18 +6,10 @@ import static org.mockito.Answers.RETURNS_SMART_NULLS;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 import com.flowpowered.network.Message;
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ClassToInstanceMap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
-import com.google.common.collect.MutableClassToInstanceMap;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.logging.Logger;
 import net.glowstone.EventFactory;
@@ -46,8 +38,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
@@ -132,7 +122,7 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
         log = Logger.getLogger(getClass().getSimpleName());
         when(server.getLogger()).thenReturn(log);
         MockitoAnnotations.initMocks(this);
-        when(server.getEventFactory()).thenReturn(eventFactory);
+        EventFactory.setInstance(eventFactory);
         if (createEntityInSuperSetUp()) {
             entity = entityCreator.apply(location);
         }

--- a/src/test/java/net/glowstone/entity/GlowEntityTest.java
+++ b/src/test/java/net/glowstone/entity/GlowEntityTest.java
@@ -2,7 +2,6 @@ package net.glowstone.entity;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Answers.RETURNS_SMART_NULLS;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.when;

--- a/src/test/java/net/glowstone/entity/GlowEntityTest.java
+++ b/src/test/java/net/glowstone/entity/GlowEntityTest.java
@@ -37,6 +37,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
@@ -46,6 +48,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
  *
  * @param <T> the class under test
  */
+@PrepareForTest(Bukkit.class)
+@RunWith(PowerMockRunner.class)
 public abstract class GlowEntityTest<T extends GlowEntity> {
 
     public static final Answer<Object> RETURN_FIRST_ARG = invocation -> invocation.getArgument(0);
@@ -88,11 +92,10 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
+        PowerMockito.mockStatic(Bukkit.class);
+        when(Bukkit.getServer()).thenReturn(server);
         log = Logger.getLogger(getClass().getSimpleName());
         when(server.getLogger()).thenReturn(log);
-        if (Bukkit.getServer() == null) {
-            Bukkit.setServer(server);
-        }
         location = new Location(world, 0, 0, 0);
         when(world.getServer()).thenReturn(server);
         when(world.getDifficulty()).thenReturn(Difficulty.NORMAL);

--- a/src/test/java/net/glowstone/entity/GlowEntityTest.java
+++ b/src/test/java/net/glowstone/entity/GlowEntityTest.java
@@ -57,21 +57,19 @@ import org.powermock.modules.junit4.PowerMockRunner;
  *
  * @param <T> the class under test
  */
-@PrepareForTest({GlowWorld.class, GlowServer.class, EventFactory.class, GlowScoreboardManager.class})
 @RunWith(PowerMockRunner.class)
 public abstract class GlowEntityTest<T extends GlowEntity> {
 
     public static final Answer<Object> RETURN_FIRST_ARG = invocation -> invocation.getArgument(0);
 
-    // PowerMock mocks
-    protected static GlowWorld world;
-    protected static GlowServer server;
-    protected static GlowScoreboardManager scoreboardManager;
-
     // Mockito mocks
     protected static ItemFactory itemFactory;
     protected static GlowChunk chunk;
     protected static GlowBlock block;
+    protected static GlowWorld world;
+    protected static GlowServer server;
+    protected static GlowScoreboardManager scoreboardManager;
+    @Mock protected EventFactory eventFactory;
 
     // Real objects
     protected static Location location;
@@ -100,9 +98,9 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
 
     @BeforeClass
     public static void staticSetUp() throws Exception {
-        server = PowerMockito.mock(GlowServer.class, Mockito.RETURNS_DEEP_STUBS);
+        server = Mockito.mock(GlowServer.class, Mockito.RETURNS_DEEP_STUBS);
         Bukkit.setServer(server);
-        world = PowerMockito.mock(GlowWorld.class, Mockito.RETURNS_SMART_NULLS);
+        world = Mockito.mock(GlowWorld.class, Mockito.RETURNS_SMART_NULLS);
         when(world.getServer()).thenReturn(server);
         when(world.getDifficulty()).thenReturn(Difficulty.NORMAL);
         when(server.getWorlds()).thenReturn(Collections.singletonList(world));
@@ -121,7 +119,7 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
         when(world.getEntityManager()).thenReturn(entityManager);
         idManager = new EntityIdManager();
         when(server.getEntityIdManager()).thenReturn(idManager);
-        scoreboardManager = PowerMockito.mock(GlowScoreboardManager.class, RETURNS_SMART_NULLS);
+        scoreboardManager = Mockito.mock(GlowScoreboardManager.class, RETURNS_SMART_NULLS);
         when(server.getScoreboardManager()).thenReturn(scoreboardManager);
         scoreboard = new GlowScoreboard();
         when(scoreboardManager.getMainScoreboard()).thenReturn(scoreboard);
@@ -134,12 +132,12 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
         log = Logger.getLogger(getClass().getSimpleName());
         when(server.getLogger()).thenReturn(log);
         MockitoAnnotations.initMocks(this);
+        when(server.getEventFactory()).thenReturn(eventFactory);
         if (createEntityInSuperSetUp()) {
             entity = entityCreator.apply(location);
         }
-        mockStatic(EventFactory.class);
-        when(EventFactory.callEvent(any(Event.class))).thenAnswer(RETURN_FIRST_ARG);
-        when(EventFactory.onEntityDamage(any(EntityDamageEvent.class))).thenAnswer(
+        when(eventFactory.callEvent(any(Event.class))).thenAnswer(RETURN_FIRST_ARG);
+        when(eventFactory.onEntityDamage(any(EntityDamageEvent.class))).thenAnswer(
                 RETURN_FIRST_ARG);
     }
 

--- a/src/test/java/net/glowstone/entity/GlowEntityTest.java
+++ b/src/test/java/net/glowstone/entity/GlowEntityTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.when;
 
+import com.binarytweed.test.Quarantine;
+import com.binarytweed.test.QuarantiningRunner;
 import com.flowpowered.network.Message;
 import java.util.Collections;
 import java.util.List;
@@ -48,8 +50,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
  *
  * @param <T> the class under test
  */
-@PrepareForTest(Bukkit.class)
-@RunWith(PowerMockRunner.class)
+@RunWith(QuarantiningRunner.class)
+@Quarantine("net.glowstone.entity")
 public abstract class GlowEntityTest<T extends GlowEntity> {
 
     public static final Answer<Object> RETURN_FIRST_ARG = invocation -> invocation.getArgument(0);
@@ -92,8 +94,7 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        PowerMockito.mockStatic(Bukkit.class);
-        when(Bukkit.getServer()).thenReturn(server);
+        Bukkit.setServer(server);
         log = Logger.getLogger(getClass().getSimpleName());
         when(server.getLogger()).thenReturn(log);
         location = new Location(world, 0, 0, 0);

--- a/src/test/java/net/glowstone/entity/GlowEntityTest.java
+++ b/src/test/java/net/glowstone/entity/GlowEntityTest.java
@@ -7,8 +7,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.when;
 
-import com.binarytweed.test.Quarantine;
-import com.binarytweed.test.QuarantiningRunner;
 import com.flowpowered.network.Message;
 import java.util.Collections;
 import java.util.List;
@@ -50,8 +48,8 @@ import org.powermock.modules.junit4.PowerMockRunner;
  *
  * @param <T> the class under test
  */
-@RunWith(QuarantiningRunner.class)
-@Quarantine("net.glowstone.entity")
+@PrepareForTest(Bukkit.class)
+@RunWith(PowerMockRunner.class)
 public abstract class GlowEntityTest<T extends GlowEntity> {
 
     public static final Answer<Object> RETURN_FIRST_ARG = invocation -> invocation.getArgument(0);
@@ -94,7 +92,8 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        Bukkit.setServer(server);
+        PowerMockito.mockStatic(Bukkit.class);
+        when(Bukkit.getServer()).thenReturn(server);
         log = Logger.getLogger(getClass().getSimpleName());
         when(server.getLogger()).thenReturn(log);
         location = new Location(world, 0, 0, 0);

--- a/src/test/java/net/glowstone/entity/GlowEntityTest.java
+++ b/src/test/java/net/glowstone/entity/GlowEntityTest.java
@@ -31,7 +31,6 @@ import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.ItemStack;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -47,25 +46,24 @@ import org.powermock.modules.junit4.PowerMockRunner;
  *
  * @param <T> the class under test
  */
-@RunWith(PowerMockRunner.class)
 public abstract class GlowEntityTest<T extends GlowEntity> {
 
     public static final Answer<Object> RETURN_FIRST_ARG = invocation -> invocation.getArgument(0);
 
     // Mockito mocks
-    protected static ItemFactory itemFactory;
-    protected static GlowChunk chunk;
-    protected static GlowBlock block;
-    protected static GlowWorld world;
-    protected static GlowServer server;
-    protected static GlowScoreboardManager scoreboardManager;
+    @Mock protected ItemFactory itemFactory;
+    @Mock protected GlowChunk chunk;
+    @Mock protected GlowBlock block;
+    @Mock protected GlowWorld world;
+    @Mock protected GlowServer server;
+    @Mock protected GlowScoreboardManager scoreboardManager;
     @Mock protected EventFactory eventFactory;
 
     // Real objects
-    protected static Location location;
-    protected static EntityIdManager idManager;
-    protected static EntityManager entityManager;
-    protected static GlowScoreboard scoreboard;
+    protected Location location;
+    protected EntityIdManager idManager;
+    protected EntityManager entityManager;
+    protected GlowScoreboard scoreboard;
     protected Logger log;
     protected final Function<? super Location, ? extends T> entityCreator;
     protected T entity;
@@ -86,17 +84,19 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
         return true;
     }
 
-    @BeforeClass
-    public static void staticSetUp() throws Exception {
-        server = Mockito.mock(GlowServer.class, Mockito.RETURNS_DEEP_STUBS);
-        Bukkit.setServer(server);
-        world = Mockito.mock(GlowWorld.class, Mockito.RETURNS_SMART_NULLS);
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        log = Logger.getLogger(getClass().getSimpleName());
+        when(server.getLogger()).thenReturn(log);
+        if (Bukkit.getServer() == null) {
+            Bukkit.setServer(server);
+        }
+        location = new Location(world, 0, 0, 0);
         when(world.getServer()).thenReturn(server);
         when(world.getDifficulty()).thenReturn(Difficulty.NORMAL);
         when(server.getWorlds()).thenReturn(Collections.singletonList(world));
-        itemFactory = Mockito.mock(ItemFactory.class);
-        chunk = Mockito.mock(GlowChunk.class);
-        block = Mockito.mock(GlowBlock.class);
         when(world.getBlockAt(any(Location.class))).thenReturn(block);
         when(block.getType()).thenReturn(Material.DIRT);
         when(block.getRelative(any(BlockFace.class))).thenReturn(block);
@@ -104,24 +104,15 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
         when(world.getChunkAt(any(Block.class))).thenReturn(chunk);
         when(world.getChunkAt(anyInt(),anyInt())).thenReturn(chunk);
         when(server.getItemFactory()).thenReturn(itemFactory);
-        location = new Location(world, 0, 0, 0);
         entityManager = Mockito.spy(new EntityManager());
         when(world.getEntityManager()).thenReturn(entityManager);
         idManager = new EntityIdManager();
         when(server.getEntityIdManager()).thenReturn(idManager);
-        scoreboardManager = Mockito.mock(GlowScoreboardManager.class, RETURNS_SMART_NULLS);
         when(server.getScoreboardManager()).thenReturn(scoreboardManager);
         scoreboard = new GlowScoreboard();
         when(scoreboardManager.getMainScoreboard()).thenReturn(scoreboard);
         when(itemFactory.ensureServerConversions(any(ItemStack.class)))
                 .thenAnswer(RETURN_FIRST_ARG);
-    }
-
-    @Before
-    public void setUp() throws Exception {
-        log = Logger.getLogger(getClass().getSimpleName());
-        when(server.getLogger()).thenReturn(log);
-        MockitoAnnotations.initMocks(this);
         EventFactory.setInstance(eventFactory);
         if (createEntityInSuperSetUp()) {
             entity = entityCreator.apply(location);
@@ -134,6 +125,12 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
     @After
     public void tearDown() {
         // https://www.atlassian.com/blog/archives/reducing_junit_memory_usage
+        world = null;
+        server = null;
+        scoreboardManager = null;
+        itemFactory = null;
+        chunk = null;
+        block = null;
         log = null;
         entity = null;
     }

--- a/src/test/java/net/glowstone/entity/GlowEntityTest.java
+++ b/src/test/java/net/glowstone/entity/GlowEntityTest.java
@@ -70,6 +70,7 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
     protected Logger log;
     protected final Function<? super Location, ? extends T> entityCreator;
     protected T entity;
+    private EventFactory oldEventFactory;
 
 
     protected GlowEntityTest(Function<? super Location, ? extends T> entityCreator) {
@@ -116,6 +117,7 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
         when(scoreboardManager.getMainScoreboard()).thenReturn(scoreboard);
         when(itemFactory.ensureServerConversions(any(ItemStack.class)))
                 .thenAnswer(RETURN_FIRST_ARG);
+        oldEventFactory = EventFactory.getInstance();
         EventFactory.setInstance(eventFactory);
         if (createEntityInSuperSetUp()) {
             entity = entityCreator.apply(location);
@@ -127,6 +129,7 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
 
     @After
     public void tearDown() {
+        EventFactory.setInstance(oldEventFactory);
         // https://www.atlassian.com/blog/archives/reducing_junit_memory_usage
         world = null;
         server = null;

--- a/src/test/java/net/glowstone/entity/GlowEntityTest.java
+++ b/src/test/java/net/glowstone/entity/GlowEntityTest.java
@@ -93,6 +93,7 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         PowerMockito.mockStatic(Bukkit.class);
+        when(Bukkit.getItemFactory()).thenReturn(itemFactory);
         when(Bukkit.getServer()).thenReturn(server);
         log = Logger.getLogger(getClass().getSimpleName());
         when(server.getLogger()).thenReturn(log);

--- a/src/test/java/net/glowstone/entity/GlowPlayerTest.java
+++ b/src/test/java/net/glowstone/entity/GlowPlayerTest.java
@@ -23,6 +23,7 @@ import net.glowstone.scheduler.GlowScheduler;
 import net.glowstone.scheduler.WorldScheduler;
 import net.glowstone.util.InventoryUtil;
 import net.glowstone.util.bans.UuidListFile;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
@@ -37,7 +38,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-@PrepareForTest({ChunkManager.class})
+@PrepareForTest({Bukkit.class, ChunkManager.class})
 @RunWith(PowerMockRunner.class)
 public class GlowPlayerTest extends GlowHumanEntityTest<GlowPlayer> {
 

--- a/src/test/java/net/glowstone/entity/GlowPlayerTest.java
+++ b/src/test/java/net/glowstone/entity/GlowPlayerTest.java
@@ -46,9 +46,9 @@ public class GlowPlayerTest extends GlowHumanEntityTest<GlowPlayer> {
 
     // Mockito mocks
     @Mock(answer = RETURNS_SMART_NULLS)
-    private GlowSession session;
+    private static GlowSession session;
     @Mock(answer = RETURNS_SMART_NULLS)
-    private PlayerReader reader;
+    private static PlayerReader reader;
     @Mock(answer = RETURNS_SMART_NULLS)
     private GlowBlock block;
     @Mock(answer = RETURNS_SMART_NULLS)

--- a/src/test/java/net/glowstone/entity/GlowPlayerTest.java
+++ b/src/test/java/net/glowstone/entity/GlowPlayerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.UUID;
 import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;

--- a/src/test/java/net/glowstone/entity/GlowPlayerTest.java
+++ b/src/test/java/net/glowstone/entity/GlowPlayerTest.java
@@ -10,8 +10,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.UUID;
-import net.glowstone.GlowServer;
-import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.chunk.ChunkManager;
 import net.glowstone.chunk.ChunkManager.ChunkLock;
@@ -32,12 +30,15 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.PluginManager;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-@PrepareForTest({GlowServer.class, GlowWorld.class, ChunkManager.class})
+@PrepareForTest({ChunkManager.class})
+@RunWith(PowerMockRunner.class)
 public class GlowPlayerTest extends GlowHumanEntityTest<GlowPlayer> {
 
     private final ChunkManager chunkManager

--- a/src/test/java/net/glowstone/entity/GlowPlayerTest.java
+++ b/src/test/java/net/glowstone/entity/GlowPlayerTest.java
@@ -46,9 +46,9 @@ public class GlowPlayerTest extends GlowHumanEntityTest<GlowPlayer> {
 
     // Mockito mocks
     @Mock(answer = RETURNS_SMART_NULLS)
-    private static GlowSession session;
+    private GlowSession session;
     @Mock(answer = RETURNS_SMART_NULLS)
-    private static PlayerReader reader;
+    private PlayerReader reader;
     @Mock(answer = RETURNS_SMART_NULLS)
     private GlowBlock block;
     @Mock(answer = RETURNS_SMART_NULLS)

--- a/src/test/java/net/glowstone/entity/monster/GlowBlazeTest.java
+++ b/src/test/java/net/glowstone/entity/monster/GlowBlazeTest.java
@@ -1,6 +1,7 @@
 package net.glowstone.entity.monster;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.Test;
 

--- a/src/test/java/net/glowstone/entity/monster/GlowBossTest.java
+++ b/src/test/java/net/glowstone/entity/monster/GlowBossTest.java
@@ -10,7 +10,6 @@ import static org.powermock.api.mockito.PowerMockito.doAnswer;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.when;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;

--- a/src/test/java/net/glowstone/entity/monster/GlowSpiderTest.java
+++ b/src/test/java/net/glowstone/entity/monster/GlowSpiderTest.java
@@ -1,8 +1,5 @@
 package net.glowstone.entity.monster;
 
-import java.util.function.Function;
-import org.bukkit.Location;
-
 public class GlowSpiderTest extends GlowAbstractSpiderTest<GlowSpider> {
 
     public GlowSpiderTest() {

--- a/src/test/java/net/glowstone/entity/monster/complex/GlowEnderDragonPartTest.java
+++ b/src/test/java/net/glowstone/entity/monster/complex/GlowEnderDragonPartTest.java
@@ -1,13 +1,34 @@
 package net.glowstone.entity.monster.complex;
 
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import net.glowstone.entity.GlowEntityTest;
+import org.bukkit.boss.BarColor;
+import org.bukkit.boss.BarFlag;
+import org.bukkit.boss.BarStyle;
+import org.junit.Before;
 
 public class GlowEnderDragonPartTest extends GlowEntityTest<GlowEnderDragonPart> {
     public GlowEnderDragonPartTest() {
         super(location -> new GlowEnderDragonPart(new GlowEnderDragon(location)));
+    }
+
+    @Override
+    public boolean createEntityInSuperSetUp() {
+        return false;
+    }
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        when(server.createBossBar(anyString(), any(BarColor.class), any(BarStyle.class),
+                any(BarFlag[].class))).thenCallRealMethod();
+        entity = entityCreator.apply(location);
     }
 
     @Override

--- a/src/test/java/net/glowstone/entity/monster/complex/GlowEnderDragonTest.java
+++ b/src/test/java/net/glowstone/entity/monster/complex/GlowEnderDragonTest.java
@@ -1,7 +1,5 @@
 package net.glowstone.entity.monster.complex;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import net.glowstone.entity.monster.GlowBossTest;
 
 public class GlowEnderDragonTest extends GlowBossTest<GlowEnderDragon> {

--- a/src/test/java/net/glowstone/entity/objects/GlowMinecartTest.java
+++ b/src/test/java/net/glowstone/entity/objects/GlowMinecartTest.java
@@ -1,10 +1,10 @@
 package net.glowstone.entity.objects;
 
+import com.binarytweed.test.DelegateRunningTo;
 import net.glowstone.entity.GlowEntityTest;
 import org.junit.runners.Parameterized;
-import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
-@PowerMockRunnerDelegate(Parameterized.class)
+@DelegateRunningTo(Parameterized.class)
 public class GlowMinecartTest extends GlowEntityTest<GlowMinecart> {
 
     @Parameterized.Parameters(name = "{0}")

--- a/src/test/java/net/glowstone/entity/objects/GlowMinecartTest.java
+++ b/src/test/java/net/glowstone/entity/objects/GlowMinecartTest.java
@@ -1,10 +1,11 @@
 package net.glowstone.entity.objects;
 
 import net.glowstone.entity.GlowEntityTest;
+import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
-@PowerMockRunnerDelegate(Parameterized.class)
+@RunWith(Parameterized.class)
 public class GlowMinecartTest extends GlowEntityTest<GlowMinecart> {
 
     @Parameterized.Parameters(name = "{0}")

--- a/src/test/java/net/glowstone/entity/objects/GlowMinecartTest.java
+++ b/src/test/java/net/glowstone/entity/objects/GlowMinecartTest.java
@@ -1,10 +1,10 @@
 package net.glowstone.entity.objects;
 
 import net.glowstone.entity.GlowEntityTest;
-import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
-@RunWith(Parameterized.class)
+@PowerMockRunnerDelegate(Parameterized.class)
 public class GlowMinecartTest extends GlowEntityTest<GlowMinecart> {
 
     @Parameterized.Parameters(name = "{0}")

--- a/src/test/java/net/glowstone/entity/objects/GlowMinecartTest.java
+++ b/src/test/java/net/glowstone/entity/objects/GlowMinecartTest.java
@@ -1,10 +1,10 @@
 package net.glowstone.entity.objects;
 
-import com.binarytweed.test.DelegateRunningTo;
 import net.glowstone.entity.GlowEntityTest;
 import org.junit.runners.Parameterized;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
-@DelegateRunningTo(Parameterized.class)
+@PowerMockRunnerDelegate(Parameterized.class)
 public class GlowMinecartTest extends GlowEntityTest<GlowMinecart> {
 
     @Parameterized.Parameters(name = "{0}")

--- a/src/test/java/net/glowstone/entity/objects/GlowMinecartTest.java
+++ b/src/test/java/net/glowstone/entity/objects/GlowMinecartTest.java
@@ -3,7 +3,6 @@ package net.glowstone.entity.objects;
 import net.glowstone.entity.GlowEntityTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
 @RunWith(Parameterized.class)
 public class GlowMinecartTest extends GlowEntityTest<GlowMinecart> {

--- a/src/test/java/net/glowstone/entity/objects/GlowPaintingTest.java
+++ b/src/test/java/net/glowstone/entity/objects/GlowPaintingTest.java
@@ -1,7 +1,6 @@
 package net.glowstone.entity.objects;
 
 import net.glowstone.entity.GlowHangingEntityTest;
-import org.bukkit.block.BlockFace;
 
 public class GlowPaintingTest extends GlowHangingEntityTest<GlowPainting> {
     public GlowPaintingTest() {

--- a/src/test/java/net/glowstone/entity/passive/GlowFishingHookTest.java
+++ b/src/test/java/net/glowstone/entity/passive/GlowFishingHookTest.java
@@ -2,7 +2,6 @@ package net.glowstone.entity.passive;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.argThat;
@@ -11,14 +10,9 @@ import static org.mockito.Matchers.intThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
-import java.io.IOException;
-import java.util.Collections;
-import net.glowstone.EventFactory;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.FishingRewardManager;
 import net.glowstone.entity.GlowEntityTest;
@@ -36,7 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.internal.matchers.GreaterThan;
-import org.powermock.api.mockito.PowerMockito;
 
 public class GlowFishingHookTest extends GlowEntityTest<GlowFishingHook> {
 

--- a/src/test/java/net/glowstone/entity/passive/GlowFishingHookTest.java
+++ b/src/test/java/net/glowstone/entity/passive/GlowFishingHookTest.java
@@ -65,13 +65,12 @@ public class GlowFishingHookTest extends GlowEntityTest<GlowFishingHook> {
         fishingRewardManager = new FishingRewardManager();
         when(server.getFishingRewardManager()).thenReturn(fishingRewardManager);
         when(player.getLocation()).thenReturn(location);
-        mockStatic(EventFactory.class);
-        when(EventFactory.callEvent(any(Event.class))).thenAnswer(invocation -> {
+        when(eventFactory.callEvent(any(Event.class))).thenAnswer(invocation -> {
             Event e = invocation.getArgument(0);
             eventsFired.put(e.getClass(), e);
             return e;
         });
-        when(EventFactory.onEntityDamage(any(EntityDamageEvent.class))).thenAnswer(
+        when(eventFactory.onEntityDamage(any(EntityDamageEvent.class))).thenAnswer(
                 RETURN_FIRST_ARG);
     }
 

--- a/src/test/java/net/glowstone/entity/projectile/GlowProjectileTest.java
+++ b/src/test/java/net/glowstone/entity/projectile/GlowProjectileTest.java
@@ -1,7 +1,5 @@
 package net.glowstone.entity.projectile;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.util.function.Function;
 import net.glowstone.entity.GlowEntityTest;
 import org.bukkit.Location;

--- a/src/test/java/net/glowstone/entity/projectile/GlowSnowballTest.java
+++ b/src/test/java/net/glowstone/entity/projectile/GlowSnowballTest.java
@@ -1,7 +1,5 @@
 package net.glowstone.entity.projectile;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 public class GlowSnowballTest extends GlowProjectileTest<GlowSnowball> {
     public GlowSnowballTest() {
         super(GlowSnowball::new);

--- a/src/test/java/net/glowstone/net/QueryTest.java
+++ b/src/test/java/net/glowstone/net/QueryTest.java
@@ -41,7 +41,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
  * Tests for the minecraft query server.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({GlowServer.class, GlowPlayer.class, QueryServer.class})
+@PrepareForTest({GlowPlayer.class, QueryServer.class})
 public class QueryTest {
 
     /**

--- a/src/test/java/net/glowstone/util/nbt/CompoundTagTest.java
+++ b/src/test/java/net/glowstone/util/nbt/CompoundTagTest.java
@@ -2,14 +2,8 @@ package net.glowstone.util.nbt;
 
 import static org.junit.Assert.assertTrue;
 
-import net.glowstone.GlowWorld;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({GlowWorld.class})
 public class CompoundTagTest {
 
     @Test


### PR DESCRIPTION
Fixes #875 

Makes GlowWorld, GlowServer and GlowScoreboardManager non-final. Makes EventFactory a non-final singleton, and changes its methods to instance methods. GlowEntityTest now uses PowerMock to mock `Bukkit.getServer()`, but not to alter any other class. Several non-entity tests also make less use of PowerMock, and two no longer use it at all.

Saves about 3 minutes on the full suite of tests. A follow-up PR will eliminate most static mocking of Bukkit and will bring the running time back into the 3-4 minute range.