### PR TITLE
Add 'compatibility bundles' to allow runtime library upgrades.

### DIFF
--- a/src/main/java/net/glowstone/util/CompatibilityBundle.java
+++ b/src/main/java/net/glowstone/util/CompatibilityBundle.java
@@ -1,0 +1,58 @@
+package net.glowstone.util;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import net.glowstone.util.library.Library;
+import net.glowstone.util.library.LibraryKey;
+import net.glowstone.util.library.LibraryManager;
+
+/**
+ * Compatibility bundles are bundles of libraries that other servers include in their servers
+ * but Glowstone does not. We will download the libraries included in the bundle specified
+ * within the Glowstone config.
+ */
+public enum CompatibilityBundle {
+    CRAFTBUKKIT(
+        Stream.of(
+            new Library("org.xerial", "sqlite-jdbc", "3.21.0",
+                LibraryManager.HashAlgorithm.SHA1, "347e4d1d3e1dff66d389354af8f0021e62344584"),
+            new Library("mysql", "mysql-connector-java", "5.1.44",
+                LibraryManager.HashAlgorithm.SHA1, "61b6b998192c85bb581c6be90e03dcd4b9079db4"),
+            new Library("org.apache.logging.log4j", "log4j-api", "2.8.1",
+                LibraryManager.HashAlgorithm.SHA1, "e801d13612e22cad62a3f4f3fe7fdbe6334a8e72"),
+            new Library("org.apache.logging.log4j", "log4j-core", "2.8.1",
+                LibraryManager.HashAlgorithm.SHA1, "4ac28ff2f1ddf05dae3043a190451e8c46b73c31"),
+            new Library("org.apache.commons", "commons-lang3", "3.5",
+                LibraryManager.HashAlgorithm.SHA1, "6c6c702c89bfff3cd9e80b04d668c5e190d588c6")
+        )
+            .collect(ImmutableMap.toImmutableMap(Library::getLibraryKey, Function.identity()))
+    ),
+    NONE(ImmutableMap.of());
+
+    public final Map<LibraryKey, Library> libraries;
+
+    CompatibilityBundle(Map<LibraryKey, Library> libraries) {
+        this.libraries = libraries;
+    }
+
+    /**
+     * Converts the given config value into the appropriate bundle. If the given value is blank or
+     * null, the default value is returned. If the given value does not match any preprogrammmed
+     * bundles case insensitively, then null is returned.
+     *
+     * @param configValue The value from the config file.
+     */
+    public static CompatibilityBundle fromConfig(String configValue) {
+        if (configValue == null || CharMatcher.whitespace().matchesAllOf(configValue)) {
+            return CompatibilityBundle.CRAFTBUKKIT;
+        }
+        try {
+            return valueOf(configValue.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/net/glowstone/util/config/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/config/ServerConfig.java
@@ -3,7 +3,6 @@ package net.glowstone.util.config;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -12,6 +11,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,9 +20,8 @@ import java.util.function.Predicate;
 import java.util.logging.Level;
 import lombok.Getter;
 import net.glowstone.GlowServer;
+import net.glowstone.util.CompatibilityBundle;
 import net.glowstone.util.DynamicallyTypedMap;
-import net.glowstone.util.library.Library;
-import net.glowstone.util.library.LibraryManager.HashAlgorithm;
 import org.bukkit.Difficulty;
 import org.bukkit.GameMode;
 import org.bukkit.WorldType;
@@ -380,23 +379,6 @@ public final class ServerConfig implements DynamicallyTypedMap<ServerConfig.Key>
         return migrateStatus;
     }
 
-    private static final List<Map<?, ?>> DEFAULT_LIBRARIES_VALUE =
-            ImmutableList.<Map<?, ?>>builder()
-                    .add(new Library("org.xerial", "sqlite-jdbc", "3.21.0", HashAlgorithm.SHA1,
-                            "347e4d1d3e1dff66d389354af8f0021e62344584").toConfigMap())
-                    .add(new Library("mysql", "mysql-connector-java", "5.1.44", HashAlgorithm.SHA1,
-                            "61b6b998192c85bb581c6be90e03dcd4b9079db4").toConfigMap())
-                    .add(new Library("org.apache.logging.log4j", "log4j-api", "2.8.1",
-                            HashAlgorithm.SHA1, "e801d13612e22cad62a3f4f3fe7fdbe6334a8e72")
-                            .toConfigMap())
-                    .add(new Library("org.apache.logging.log4j", "log4j-core", "2.8.1",
-                            HashAlgorithm.SHA1, "4ac28ff2f1ddf05dae3043a190451e8c46b73c31")
-                            .toConfigMap())
-                    .add(new Library("org.apache.commons", "commons-lang3", "3.5",
-                            HashAlgorithm.SHA1, "6c6c702c89bfff3cd9e80b04d668c5e190d588c6")
-                            .toConfigMap())
-                    .build();
-
     /**
      * An enum containing configuration keys used by the server.
      */
@@ -584,8 +566,12 @@ public final class ServerConfig implements DynamicallyTypedMap<ServerConfig.Key>
         DB_ISOLATION("database.isolation", "SERIALIZABLE", Migrate.BUKKIT, "database.isolation",
                 String.class::isInstance),
 
+        // compatibility Bundles
+        COMPATIBILITY_BUNDLE("compatibility-bundle", CompatibilityBundle.CRAFTBUKKIT.name(),
+            (val) -> val instanceof String && CompatibilityBundle.valueOf((String) val) != null),
+
         // libraries
-        LIBRARIES("libraries", DEFAULT_LIBRARIES_VALUE);
+        LIBRARIES("libraries", Collections.emptyList());
 
         @Getter
         private final String path;

--- a/src/main/java/net/glowstone/util/library/Library.java
+++ b/src/main/java/net/glowstone/util/library/Library.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.Getter;
 import net.glowstone.util.library.LibraryManager.HashAlgorithm;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Represents a library that will be injected into the classpath at runtime.
@@ -49,13 +50,7 @@ public class Library {
      * by periods.
      */
     @Getter
-    private final String groupId;
-
-    /**
-     * The artifact ID of the library in a maven-style repo.
-     */
-    @Getter
-    private final String artifactId;
+    private final LibraryKey libraryKey;
 
     /**
      * The version number of the library in a maven-style repo.
@@ -134,10 +129,9 @@ public class Library {
      */
     public Library(String groupId, String artifactId, String version,
                    String repository, HashAlgorithm checksumType, String checksumValue) {
-        this.groupId = groupId;
-        this.artifactId = artifactId;
+        this.libraryKey = new LibraryKey(groupId, artifactId);
         this.version = version;
-        this.repository = repository;
+        this.repository = StringUtils.isBlank(repository) ? null : repository;
         this.checksumType = checksumType;
         this.checksumValue = checksumValue;
     }
@@ -151,8 +145,8 @@ public class Library {
     public Map<?, ?> toConfigMap() {
         // Using LinkedHashMap to keep the props in order when written into the config file.
         Map<String, Object> configMap = new LinkedHashMap<>();
-        configMap.put(GROUP_ID_KEY, groupId);
-        configMap.put(ARTIFACT_ID_KEY, artifactId);
+        configMap.put(GROUP_ID_KEY, libraryKey.getGroupId());
+        configMap.put(ARTIFACT_ID_KEY, libraryKey.getArtifactId());
         configMap.put(VERSION_KEY, version);
 
         if (repository != null) {
@@ -169,9 +163,26 @@ public class Library {
         return configMap;
     }
 
+    // The fields the following getters represent were moved from this class to the LibraryKey
+    // class. These methods are being preserved here for compatibiltiy with old code as well as
+    // ease of use.
+    /**
+     * Returns the group ID of this library.
+     */
+    public String getGroupId() {
+        return libraryKey.getGroupId();
+    }
+
+    /**
+     * Returns the artifact ID of this library.
+     */
+    public String getArtifactId() {
+        return libraryKey.getArtifactId();
+    }
+
     @Override
     public String toString() {
-        return groupId + ":" + artifactId + ":" + version;
+        return libraryKey.toString() + ":" + version;
     }
 
     @Override
@@ -183,13 +194,12 @@ public class Library {
             return false;
         }
         Library library = (Library) o;
-        return Objects.equals(groupId, library.groupId)
-                && Objects.equals(artifactId, library.artifactId)
+        return Objects.equals(libraryKey, library.libraryKey)
                 && Objects.equals(version, library.version);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(groupId, artifactId, version);
+        return Objects.hash(libraryKey, version);
     }
 }

--- a/src/main/java/net/glowstone/util/library/LibraryKey.java
+++ b/src/main/java/net/glowstone/util/library/LibraryKey.java
@@ -1,0 +1,43 @@
+package net.glowstone.util.library;
+
+import com.google.common.collect.ComparisonChain;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+/**
+ * Encapsulates the identifying pieces of a library in a Maven repository, its group ID and
+ * artifact ID. Can be safely used as a key in a map or within a set.
+ */
+@EqualsAndHashCode
+public class LibraryKey implements Comparable<LibraryKey> {
+    /**
+     * The group ID of the library in a maven-style repo. Parts of the group ID must be separated
+     * by periods.
+     */
+    @Getter
+    private final String groupId;
+
+    /**
+     * The artifact ID of the library in a maven-style repo.
+     */
+    @Getter
+    private final String artifactId;
+
+    public LibraryKey(String groupId, String artifactId) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+    }
+
+    @Override
+    public String toString() {
+        return groupId + ":" + artifactId;
+    }
+
+    @Override
+    public int compareTo(LibraryKey o) {
+        return ComparisonChain.start()
+                .compare(groupId, o.groupId)
+                .compare(artifactId, o.artifactId)
+                .result();
+    }
+}

--- a/src/test/java/net/glowstone/util/CompatibilityBundleTest.java
+++ b/src/test/java/net/glowstone/util/CompatibilityBundleTest.java
@@ -1,0 +1,31 @@
+package net.glowstone.util;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class CompatibilityBundleTest {
+    @Test
+    public void fromConfigTest() {
+        assertConfigValueMatchesBundle(null, CompatibilityBundle.CRAFTBUKKIT);
+        assertConfigValueMatchesBundle("", CompatibilityBundle.CRAFTBUKKIT);
+        assertConfigValueMatchesBundle("     ", CompatibilityBundle.CRAFTBUKKIT);
+
+        assertConfigValueMatchesBundle("CRAFTBUKKIT", CompatibilityBundle.CRAFTBUKKIT);
+        assertConfigValueMatchesBundle("craftbukkit", CompatibilityBundle.CRAFTBUKKIT);
+        assertConfigValueMatchesBundle("cRaFtBuKkIt", CompatibilityBundle.CRAFTBUKKIT);
+
+        assertConfigValueMatchesBundle("NONE", CompatibilityBundle.NONE);
+        assertConfigValueMatchesBundle("none", CompatibilityBundle.NONE);
+        assertConfigValueMatchesBundle("NoNe", CompatibilityBundle.NONE);
+
+        assertConfigValueMatchesBundle("unknown", null);
+        assertConfigValueMatchesBundle(" CRAFTBUKKIT ", null);
+        assertConfigValueMatchesBundle("NONE.", null);
+    }
+
+    private void assertConfigValueMatchesBundle(String configValue, CompatibilityBundle expected) {
+        CompatibilityBundle actual = CompatibilityBundle.fromConfig(configValue);
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
During the review of #865, it was found that we didn't have as much control over the libraries that CraftBukkit includes and plugins may depend on. After discussion, it was decided that Glowstone needs to have some control over updating these libraries. So, after much thought, I came up with the concept of the Compatibility Bundle.

These bundles are a collection of libraries that are statically compiled into our code. These libraries will be downloaded alongside any libraries specified in the config. In order to avoid conflicts, only one compatibility bundle will be allowed to be specified. In cases where there's a conflict between the user specified libraries and the compatibility bundle, the library from the bundle will be used and a warning will be issued to the console.

Other changes included:
- An error will be issued if a library is specified multiple times in the libraries section of the config.