### PR TITLE
Add support for PaperServerListPingEvent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <api.version>1.12.2-R2.1-SNAPSHOT</api.version>
+    <api.version>1.12.2-R3.0-SNAPSHOT</api.version>
     <minecraft.version>1.12.2</minecraft.version>
     <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -47,6 +47,7 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import net.glowstone.advancement.GlowAdvancement;
 import net.glowstone.advancement.GlowAdvancementDisplay;
@@ -1882,6 +1883,12 @@ public class GlowServer implements Server {
             }
         }
         return null;
+    }
+
+    @Nullable
+    @Override
+    public UUID getPlayerUniqueId(String playerName) {
+        throw new UnsupportedOperationException("Not implemented yet.");
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/GlowHumanEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowHumanEntity.java
@@ -32,6 +32,7 @@ import net.glowstone.util.nbt.CompoundTag;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Sign;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
@@ -587,5 +588,10 @@ public abstract class GlowHumanEntity extends GlowLivingEntity implements HumanE
 
     public void setRightShoulderTag(CompoundTag tag) {
         metadata.set(MetadataIndex.PLAYER_RIGHT_SHOULDER, tag == null ? new CompoundTag() : tag);
+    }
+
+    @Override
+    public void openSign(Sign sign) {
+        throw new UnsupportedOperationException("Not implemented yet.");
     }
 }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.destroystokyo.paper.Title;
+import com.destroystokyo.paper.profile.PlayerProfile;
 import com.flowpowered.network.Message;
 import com.flowpowered.network.util.ByteBufUtils;
 import com.google.common.base.Preconditions;
@@ -2341,6 +2342,16 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
     @Override
     public boolean hasResourcePack() {
         return resourcePackStatus == PlayerResourcePackStatusEvent.Status.SUCCESSFULLY_LOADED;
+    }
+
+    @Override
+    public PlayerProfile getPlayerProfile() {
+        return getProfile();
+    }
+
+    @Override
+    public void setPlayerProfile(PlayerProfile playerProfile) {
+        throw new UnsupportedOperationException("Not implemented yet.");
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import net.glowstone.GlowServer;
 import net.glowstone.ServerProvider;
@@ -211,8 +212,18 @@ public class GlowPlayerProfile implements PlayerProfile {
     }
 
     @Override
+    public String setName(@Nullable String name) {
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+    @Override
     public UUID getId() {
         return uniqueId == null ? null : uniqueId.getNow(null);
+    }
+
+    @Override
+    public UUID setId(@Nullable UUID uuid) {
+        throw new UnsupportedOperationException("Not implemented yet.");
     }
 
     /**
@@ -228,6 +239,11 @@ public class GlowPlayerProfile implements PlayerProfile {
     @Override
     public Set<ProfileProperty> getProperties() {
         return Sets.newHashSet(this.properties.values());
+    }
+
+    @Override
+    public boolean hasProperty(String property) {
+        throw new UnsupportedOperationException("Not implemented yet.");
     }
 
     @Override
@@ -284,6 +300,11 @@ public class GlowPlayerProfile implements PlayerProfile {
         return name != null && getId() != null && properties.containsKey("textures");
     }
 
+    @Override
+    public boolean completeFromCache() {
+        return completeCached();
+    }
+
     /**
      * Looks up the UUID if it's missing and hasn't already been attempted, and waits for it.
      *
@@ -293,6 +314,11 @@ public class GlowPlayerProfile implements PlayerProfile {
         completeAsync();
         uniqueId.join();
         return isComplete();
+    }
+
+    @Override
+    public boolean complete(boolean textures) {
+        throw new UnsupportedOperationException("Not implemented yet.");
     }
 
     /**

--- a/src/main/java/net/glowstone/net/GlowStatusClient.java
+++ b/src/main/java/net/glowstone/net/GlowStatusClient.java
@@ -1,0 +1,28 @@
+package net.glowstone.net;
+
+import com.destroystokyo.paper.network.StatusClient;
+import java.net.InetSocketAddress;
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class GlowStatusClient implements StatusClient {
+
+    private final GlowSession session;
+
+    @Override
+    public InetSocketAddress getAddress() {
+        return session.getAddress();
+    }
+
+    @Override
+    public int getProtocolVersion() {
+        return session.getVersion();
+    }
+
+    @Nullable
+    @Override
+    public InetSocketAddress getVirtualHost() {
+        return session.getVirtualHost();
+    }
+}

--- a/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
+++ b/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
@@ -37,7 +37,6 @@ public final class StatusRequestHandler implements
         int sampleCount = server.getPlayerSampleCount();
         if (players.size() <= sampleCount) {
             sampleCount = players.size();
-            Collections.shuffle(players, random);
         } else {
             // Avoid shuffling the entire list if we only need a few players
             for (int i = 0; i < sampleCount; i++) {

--- a/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
+++ b/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
@@ -6,7 +6,7 @@ import com.destroystokyo.paper.profile.PlayerProfile;
 import com.flowpowered.network.MessageHandler;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -33,7 +33,7 @@ public final class StatusRequestHandler implements
     private static void choosePlayerSample(GlowServer server, PaperServerListPingEvent event) {
         ThreadLocalRandom random = ThreadLocalRandom.current();
 
-        List<Player> players = new ArrayList<>(server.getOnlinePlayers());
+        List<Player> players = Arrays.asList(server.getOnlinePlayers());
         int sampleCount = server.getPlayerSampleCount();
         if (players.size() <= sampleCount) {
             sampleCount = players.size();

--- a/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
+++ b/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
@@ -1,19 +1,25 @@
 package net.glowstone.net.handler.status;
 
+import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
+import com.destroystokyo.paper.network.StatusClient;
+import com.destroystokyo.paper.profile.PlayerProfile;
 import com.flowpowered.network.MessageHandler;
-import java.net.InetAddress;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import net.glowstone.EventFactory;
 import net.glowstone.GlowServer;
+import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
+import net.glowstone.net.GlowStatusClient;
 import net.glowstone.net.message.status.StatusRequestMessage;
 import net.glowstone.net.message.status.StatusResponseMessage;
-import net.glowstone.util.GlowServerIcon;
 import org.bukkit.entity.Player;
-import org.bukkit.event.server.ServerListPingEvent;
 import org.bukkit.util.CachedServerIcon;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -21,59 +27,69 @@ import org.json.simple.JSONObject;
 public final class StatusRequestHandler implements
     MessageHandler<GlowSession, StatusRequestMessage> {
 
+    private static final UUID BLANK_UUID = new UUID(0, 0);
+
     @Override
     @SuppressWarnings("unchecked")
     public void handle(GlowSession session, StatusRequestMessage message) {
         // create and call the event
         GlowServer server = session.getServer();
-        int online = server.getOnlinePlayers().size();
-        InetAddress address = session.getAddress().getAddress();
+        StatusEvent event = new StatusEvent(
+                new GlowStatusClient(session), server.getMotd(),
+                server.getOnlinePlayers().size(), server.getMaxPlayers(),
+                GlowServer.GAME_VERSION, GlowServer.PROTOCOL_VERSION,
+                server.getServerIcon());
 
-        StatusEvent event = new StatusEvent(address, server.getMotd(), online,
-            server.getMaxPlayers());
-        event.players = new ArrayList<>(server.getOnlinePlayers());
-        event.icon = server.getServerIcon();
         event.serverType = server.getServerType();
         event.clientModsAllowed = server.getAllowClientMods();
+
+        // Add player sample list
+        List<Player> playerList = new ArrayList<>(server.getOnlinePlayers());
+        int count = Math.min(playerList.size(), server.getPlayerSampleCount());
+        Collections.shuffle(playerList);
+        for (int i = 0; i < count; i++) {
+            event.getPlayerSample().add(((GlowPlayer) playerList.get(i)).getProfile());
+        }
+
         EventFactory.getInstance().callEvent(event);
+
+        // Disconnect immediately if event is cancelled
+        if (event.isCancelled()) {
+            session.getChannel().close();
+            return;
+        }
 
         // build the json
         JSONObject json = new JSONObject();
 
         JSONObject version = new JSONObject();
-        String gameVersion = GlowServer.GAME_VERSION;
-        int protocolVersion = GlowServer.PROTOCOL_VERSION;
-        version.put("name", gameVersion);
-        version.put("protocol", protocolVersion);
+        version.put("name", event.getVersion());
+        version.put("protocol", event.getProtocolVersion());
         json.put("version", version);
 
-        JSONObject players = new JSONObject();
-        players.put("max", event.getMaxPlayers());
-        players.put("online", online);
+        if (!event.shouldHidePlayers()) {
+            JSONObject players = new JSONObject();
+            players.put("max", event.getMaxPlayers());
+            players.put("online", event.getNumPlayers());
 
-        if (!event.players.isEmpty()) {
-            event.players = event.players
-                .subList(0, Math.min(event.players.size(), server.getPlayerSampleCount()));
-            Collections.shuffle(event.players);
             JSONArray playersSample = new JSONArray();
-
-            for (Player player : event.players) {
+            for (PlayerProfile profile : event.getPlayerSample()) {
                 JSONObject p = new JSONObject();
-                p.put("name", player.getName());
-                p.put("id", player.getUniqueId().toString());
+                p.put("name", Strings.nullToEmpty(profile.getName()));
+                p.put("id", MoreObjects.firstNonNull(profile.getId(), BLANK_UUID).toString());
                 playersSample.add(p);
             }
             players.put("sample", playersSample);
-        }
 
-        json.put("players", players);
+            json.put("players", players);
+        }
 
         JSONObject description = new JSONObject();
         description.put("text", event.getMotd());
         json.put("description", description);
 
-        if (event.icon.getData() != null) {
-            json.put("favicon", event.icon.getData());
+        if (event.getServerIcon() != null) {
+            json.put("favicon", event.getServerIcon().getData());
         }
 
         // Mod list must be included but can be empty
@@ -92,29 +108,16 @@ public final class StatusRequestHandler implements
         session.send(new StatusResponseMessage(json));
     }
 
-    private static class StatusEvent extends ServerListPingEvent {
+    private static class StatusEvent extends PaperServerListPingEvent {
 
-        private GlowServerIcon icon;
-        private List<Player> players;
         private String serverType; // VANILLA, BUKKIT, or FML
         private boolean clientModsAllowed;
 
-        private StatusEvent(InetAddress address, String motd, int numPlayers, int maxPlayers) {
-            super(address, motd, numPlayers, maxPlayers);
+        private StatusEvent(@Nonnull StatusClient client, String motd, int numPlayers,
+                int maxPlayers, @Nonnull String version, int protocolVersion,
+                @Nullable CachedServerIcon favicon) {
+            super(client, motd, numPlayers, maxPlayers, version, protocolVersion, favicon);
         }
 
-        @Override
-        public void setServerIcon(CachedServerIcon icon)
-            throws IllegalArgumentException, UnsupportedOperationException {
-            if (!(icon instanceof GlowServerIcon)) {
-                throw new IllegalArgumentException("Icon not provided by this implementation");
-            }
-            this.icon = (GlowServerIcon) icon;
-        }
-
-        @Override
-        public Iterator<Player> iterator() {
-            return players.iterator();
-        }
     }
 }

--- a/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
+++ b/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
@@ -6,7 +6,7 @@ import com.destroystokyo.paper.profile.PlayerProfile;
 import com.flowpowered.network.MessageHandler;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -33,7 +33,7 @@ public final class StatusRequestHandler implements
     private static void choosePlayerSample(GlowServer server, PaperServerListPingEvent event) {
         ThreadLocalRandom random = ThreadLocalRandom.current();
 
-        List<Player> players = Arrays.asList(server.getOnlinePlayers());
+        List<Player> players = new ArrayList<>(server.getOnlinePlayers());
         int sampleCount = server.getPlayerSampleCount();
         if (players.size() <= sampleCount) {
             sampleCount = players.size();

--- a/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
+++ b/src/main/java/net/glowstone/net/handler/status/StatusRequestHandler.java
@@ -38,7 +38,7 @@ public final class StatusRequestHandler implements
         if (players.size() <= sampleCount) {
             sampleCount = players.size();
         } else {
-            // Avoid shuffling the entire list if we only need a few players
+            // Send a random subset of players (modified Fisher-Yates shuffle)
             for (int i = 0; i < sampleCount; i++) {
                 Collections.swap(players, i, random.nextInt(i, players.size()));
             }

--- a/src/test/java/net/glowstone/testutils/ServerShim.java
+++ b/src/test/java/net/glowstone/testutils/ServerShim.java
@@ -58,6 +58,8 @@ import org.bukkit.scoreboard.ScoreboardManager;
 import org.bukkit.util.CachedServerIcon;
 import org.mockito.Mockito;
 
+import javax.annotation.Nullable;
+
 /**
  * Simple mocked Server implementation.
  */
@@ -241,6 +243,12 @@ public class ServerShim implements Server {
 
     @Override
     public Player getPlayer(UUID id) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public UUID getPlayerUniqueId(String playerName) {
         return null;
     }
 


### PR DESCRIPTION
PaperServerListPingEvent is an extended version of Bukkit's standard ServerListPingEvent, but allows full control over the status response. This makes it possible to change the player sample, modify the server version and many other things.

Until now, this was only possible by using ProtocolLib to modify the packets directly. With this event, it can be also done on Glowstone where ProtocolLib isn't working (yet).

### TODO before merging
Right now, the PR doesn't compile anymore as-is. The remaining changes (unrelated to the new event) need to be made by someone more familiar with the Glowstone implementation:

- [x] Needs an upstream merge in [Glowkit](https://github.com/GlowstoneMC/Glowkit), depends on https://github.com/GlowstoneMC/Glowkit/pull/18
- [x] Glowstone needs to be updated for new methods added in Bukkit/Spigot/Paper. There seem to be several new methods in the Paper API that need to be implemented.
- [x] Depends on https://github.com/GlowstoneMC/Glowstone/issues/881

### Test plugin
The new event is supported in the development builds of [ServerListPlus](https://www.spigotmc.org/resources/serverlistplus.241/).
Download `ServerListPlus-3.4.9-SNAPSHOT-Universal.jar` from [Jenkins](https://ci.minecrell.net/job/ServerListPlus/), all features should be working.
