### PR TITLE
GlowPlayerProfile looks up UUID asynchronously

### DIFF
--- a/src/main/java/net/glowstone/GlowOfflinePlayer.java
+++ b/src/main/java/net/glowstone/GlowOfflinePlayer.java
@@ -120,7 +120,7 @@ public final class GlowOfflinePlayer implements OfflinePlayer {
 
     @Override
     public UUID getUniqueId() {
-        return profile.getUniqueId();
+        return profile.getId();
     }
 
     @Override

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -100,7 +100,6 @@ import net.glowstone.entity.EntityIdManager;
 import net.glowstone.entity.FishingRewardManager;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.meta.profile.GlowPlayerProfile;
-import net.glowstone.entity.meta.profile.ProfileCache;
 import net.glowstone.generator.GlowChunkData;
 import net.glowstone.generator.NetherGenerator;
 import net.glowstone.generator.OverworldGenerator;

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1689,11 +1689,7 @@ public final class GlowServer implements Server {
     @Override
     public GlowPlayerProfile createProfile(String name) {
         checkNotNull(name);
-        UUID id = ProfileCache.getUuid(name).join();
-        if (id == null) {
-            throw new IllegalArgumentException("Could not fetch UUID for username: " + name);
-        }
-        return createProfile(id, name);
+        return createProfile(null, name);
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/entity/state/GlowSkull.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowSkull.java
@@ -79,7 +79,7 @@ public class GlowSkull extends GlowBlockState implements Skull {
 
     @Override
     public OfflinePlayer getOwningPlayer() {
-        return Bukkit.getOfflinePlayer(owner.getUniqueId());
+        return Bukkit.getOfflinePlayer(owner.getId());
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/GlowHumanEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowHumanEntity.java
@@ -154,7 +154,7 @@ public abstract class GlowHumanEntity extends GlowLivingEntity implements HumanE
         double z = location.getZ();
         int yaw = Position.getIntYaw(location);
         int pitch = Position.getIntPitch(location);
-        result.add(new SpawnPlayerMessage(entityId, profile.getUniqueId(), x, y, z, yaw, pitch,
+        result.add(new SpawnPlayerMessage(entityId, profile.getId(), x, y, z, yaw, pitch,
                 metadata.getEntryList()));
 
         // head facing
@@ -222,15 +222,15 @@ public abstract class GlowHumanEntity extends GlowLivingEntity implements HumanE
 
     @Override
     public UUID getUniqueId() {
-        return profile.getUniqueId();
+        return profile.getId();
     }
 
     @Override
     public void setUniqueId(UUID uuid) {
         // silently allow setting the same UUID again
-        if (!profile.getUniqueId().equals(uuid)) {
+        if (!profile.getId().equals(uuid)) {
             throw new IllegalStateException(
-                    "UUID of " + this + " is already " + profile.getUniqueId());
+                    "UUID of " + this + " is already " + profile.getId());
         }
     }
 

--- a/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
@@ -198,6 +198,12 @@ public class GlowPlayerProfile implements PlayerProfile {
         return profileTag;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This method will block if the UUID is still being looked up. It will not block if {@link
+     * #isComplete()}.
+     */
     @Override
     public UUID getId() {
         return this.uniqueId.join();
@@ -251,6 +257,12 @@ public class GlowPlayerProfile implements PlayerProfile {
         this.properties.clear();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>A player profile that's currently incomplete may become complete later, because UUIDs are
+     * looked up asynchronously when needed.
+     */
     @Override
     public boolean isComplete() {
         return name != null && uniqueId.isDone()

--- a/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
@@ -253,6 +253,7 @@ public class GlowPlayerProfile implements PlayerProfile {
 
     @Override
     public boolean isComplete() {
-        return name != null && uniqueId != null && properties.containsKey("textures");
+        return name != null && uniqueId.isDone()
+                && uniqueId.join() != null && properties.containsKey("textures");
     }
 }

--- a/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
@@ -203,15 +203,6 @@ public class GlowPlayerProfile implements PlayerProfile {
         return this.uniqueId.join();
     }
 
-    /**
-     * Gets the UUID of this profile.
-     *
-     * @return the UUID of this profile.
-     */
-    public UUID getUniqueId() {
-        return getId();
-    }
-
     @Override
     public Set<ProfileProperty> getProperties() {
         return Sets.newHashSet(this.properties.values());

--- a/src/main/java/net/glowstone/net/GlowSession.java
+++ b/src/main/java/net/glowstone/net/GlowSession.java
@@ -244,7 +244,7 @@ public class GlowSession extends BasicSession {
         }
 
         // initialize the player
-        PlayerReader reader = server.getPlayerDataService().beginReadingData(profile.getUniqueId());
+        PlayerReader reader = server.getPlayerDataService().beginReadingData(profile.getId());
         player = new GlowPlayer(this, profile, reader);
         finalizeLogin(profile);
 
@@ -472,7 +472,7 @@ public class GlowSession extends BasicSession {
         }
 
         // send login response
-        send(new LoginSuccessMessage(profile.getUniqueId().toString(), profile.getName()));
+        send(new LoginSuccessMessage(profile.getId().toString(), profile.getName()));
         setProtocol(ProtocolType.PLAY);
     }
 

--- a/src/main/java/net/glowstone/net/handler/login/LoginStartHandler.java
+++ b/src/main/java/net/glowstone/net/handler/login/LoginStartHandler.java
@@ -49,7 +49,7 @@ public final class LoginStartHandler implements MessageHandler<GlowSession, Logi
             }
 
             AsyncPlayerPreLoginEvent event = EventFactory
-                .onPlayerPreLogin(profile.getName(), session.getAddress(), profile.getUniqueId());
+                .onPlayerPreLogin(profile.getName(), session.getAddress(), profile.getId());
             if (event.getLoginResult() != Result.ALLOWED) {
                 session.disconnect(event.getKickMessage(), true);
                 return;

--- a/src/main/java/net/glowstone/net/handler/play/player/SpectateHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/SpectateHandler.java
@@ -16,7 +16,7 @@ public final class SpectateHandler implements MessageHandler<GlowSession, Specta
 
         GlowPlayer player = session.getPlayer();
         if (player.getGameMode() == GameMode.SPECTATOR && !Objects
-            .equals(player.getProfile().getUniqueId(), message.getTarget())) {
+            .equals(player.getProfile().getId(), message.getTarget())) {
             Entity entity = Bukkit.getEntity(message.getTarget());
 
             if (entity != null) {

--- a/src/main/java/net/glowstone/net/message/play/game/UserListItemMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/game/UserListItemMessage.java
@@ -58,7 +58,7 @@ public final class UserListItemMessage implements Message {
     public static Entry add(GlowPlayerProfile profile, int gameMode, int ping,
                             TextMessage displayName) {
         // TODO: measure ping
-        return new Entry(profile.getUniqueId(), profile, gameMode, ping, displayName,
+        return new Entry(profile.getId(), profile, gameMode, ping, displayName,
                 Action.ADD_PLAYER);
     }
 

--- a/src/main/java/net/glowstone/util/bans/UuidListFile.java
+++ b/src/main/java/net/glowstone/util/bans/UuidListFile.java
@@ -68,7 +68,7 @@ public final class UuidListFile extends JsonListFile {
      * @return whether the player is on this list
      */
     public boolean containsProfile(GlowPlayerProfile profile) {
-        return containsUuid(profile.getUniqueId());
+        return containsUuid(profile.getId());
     }
 
     /**
@@ -93,7 +93,7 @@ public final class UuidListFile extends JsonListFile {
      * @param profile the player to remove
      */
     public void remove(GlowPlayerProfile profile) {
-        UUID playerUuid = profile.getUniqueId();
+        UUID playerUuid = profile.getId();
         entriesByUuid.remove(playerUuid);
         // FIXME: Unnecessary linear time
         Iterator<BaseEntry> iter = entries.iterator();


### PR DESCRIPTION
Fixes #881. `GlowServer.createProfile()` now returns immediately, but `GlowPlayerProfile.getId()` may block if the instance `!isComplete()` and didn't come from `GlowPlayerProfile.getProfile(String name)`. I've asked @Minecrell to test this change, to determine if the blocking `getId()` poses a problem in practice.