### PR TITLE
/stop can now take a custom kick message

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -915,6 +915,15 @@ public class GlowServer implements Server {
      */
     @Override
     public void shutdown() {
+        shutdown(getShutdownMessage());
+    }
+
+    /**
+     * Stops this server, sending the specified message to all players on their kick screen.
+     *
+     * @param message Message to send to all players as they are kicked
+     */
+    public void shutdown(String message) {
         // Just in case this gets called twice
         if (isShuttingDown) {
             return;
@@ -927,7 +936,7 @@ public class GlowServer implements Server {
 
         // Kick all players (this saves their data too)
         for (GlowPlayer player : new ArrayList<>(getRawOnlinePlayers())) {
-            player.kickPlayer(getShutdownMessage(), false);
+            player.kickPlayer(message, false);
         }
 
         // Stop the network servers - starts the shutdown process

--- a/src/main/java/net/glowstone/command/minecraft/StopCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/StopCommand.java
@@ -1,14 +1,17 @@
 package net.glowstone.command.minecraft;
 
 import java.util.Collections;
+import net.glowstone.GlowServer;
+import net.glowstone.ServerProvider;
 import org.bukkit.Bukkit;
+import org.bukkit.Server;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.defaults.VanillaCommand;
 
 public class StopCommand extends VanillaCommand {
 
     public StopCommand() {
-        super("stop", "Gracefully stops the server.", "/stop", Collections.emptyList());
+        super("stop", "Gracefully stops the server.", "/stop [message]", Collections.emptyList());
         setPermission("minecraft.command.stop");
     }
 
@@ -17,7 +20,12 @@ public class StopCommand extends VanillaCommand {
         if (!testPermission(sender)) {
             return false;
         }
-        Bukkit.shutdown();
+        Server server = ServerProvider.getServer();
+        if (args.length > 0 && server instanceof GlowServer) {
+            ((GlowServer) server).shutdown(String.join(" ", args));
+        } else {
+            server.shutdown();
+        }
         return true;
     }
 }

--- a/src/main/java/net/glowstone/command/minecraft/StopCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/StopCommand.java
@@ -3,7 +3,6 @@ package net.glowstone.command.minecraft;
 import java.util.Collections;
 import net.glowstone.GlowServer;
 import net.glowstone.ServerProvider;
-import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.defaults.VanillaCommand;

--- a/src/test/java/net/glowstone/command/minecraft/StopCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/StopCommandTest.java
@@ -1,0 +1,54 @@
+package net.glowstone.command.minecraft;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import net.glowstone.GlowServer;
+import net.glowstone.ServerProvider;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class StopCommandTest {
+    private GlowServer server;
+
+    private CommandSender sender, opSender;
+
+    private Command command;
+
+    @BeforeEach
+    public void before() {
+        command = new StopCommand();
+        sender = Mockito.mock(CommandSender.class);
+        opSender = Mockito.mock(CommandSender.class);
+        server = Mockito.mock(GlowServer.class);
+        ServerProvider.setMockServer(server);
+        when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
+        when(opSender.getServer()).thenReturn(server);
+    }
+
+    @Test
+    public void testExecuteFailsWithoutPermission() {
+        assertThat(command.execute(sender, "label", new String[0]), is(false));
+        Mockito.verify(sender).sendMessage(eq(ChatColor.RED
+                + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error."));
+    }
+
+    @Test
+    public void testNoArgs() {
+        assertThat(command.execute(opSender, "label", new String[0]), is(true));
+        Mockito.verify(server).shutdown();
+    }
+
+    @Test
+    public void testWithArgs() {
+        assertThat(command.execute(opSender, "label",
+                new String[]{"This", "is", "a", "custom", "shutdown", "message"}), is(true));
+        Mockito.verify(server).shutdown("This is a custom shutdown message");
+    }
+}


### PR DESCRIPTION
The message consists of all arguments, if any are present; with no arguments, the default is still used.

Also adds StopCommandTest, and refactors StopCommand so that StopCommandTest doesn't need Powermock.