### PR TITLE
Make GlowPlayerProfile.getId() non-blocking

### DIFF
--- a/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
@@ -198,15 +198,9 @@ public class GlowPlayerProfile implements PlayerProfile {
         return profileTag;
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * <p>This method will block if the UUID is still being looked up. It will not block if {@link
-     * #isComplete()}.
-     */
     @Override
     public UUID getId() {
-        return this.uniqueId.join();
+        return this.uniqueId.getNow(null);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
@@ -200,7 +200,16 @@ public class GlowPlayerProfile implements PlayerProfile {
 
     @Override
     public UUID getId() {
-        return this.uniqueId.getNow(null);
+        return uniqueId.getNow(null);
+    }
+
+    /**
+     * Waits for the lookup of, then returns, the player's UUID.
+     *
+     * @return the player UUID, or null if it's unknown and couldn't be looked up
+     */
+    public UUID getIdBlocking() {
+        return uniqueId.join();
     }
 
     @Override


### PR DESCRIPTION
Related to #881. Now returns null when the UUID is still being looked up. Also added `getIdBlocking()` just in case.