### PR TITLE
Living entities now take fire damage

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -244,6 +244,10 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
      * If this entity has stood in fire (for fire application).
      */
     private boolean stoodInFire;
+    /**
+     * The ticks an entity stands adjacent to fire and lava.
+     */
+    private int adjacentBurnTicks;
 
     /**
      * Creates a mob within the specified world.
@@ -313,19 +317,12 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             damage(1, DamageCause.SUFFOCATION);
         }
 
-        // fire damage
+        // fire and lava damage
         if (getLocation().getBlock().getType() == Material.FIRE) {
             damage(1, DamageCause.FIRE);
             // not applying additional fire ticks after dying in fire
             stoodInFire = !isDead();
-        } else {
-            if (stoodInFire) {
-                setFireTicks(getFireTicks() + 180);
-                stoodInFire = false;
-            }
-        }
-
-        if (getLocation().getBlock().getType() == Material.LAVA
+        } else if (getLocation().getBlock().getType() == Material.LAVA 
                 || getLocation().getBlock().getType() == Material.STATIONARY_LAVA) {
             damage(4, DamageCause.LAVA);
             if (swamInLava) {
@@ -334,6 +331,19 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                 setFireTicks(getFireTicks() + 300);
                 swamInLava = true;
             }
+        } else if (isTouchingMaterial(Material.FIRE)
+                || isTouchingMaterial(Material.LAVA) 
+                || isTouchingMaterial(Material.STATIONARY_LAVA)) {
+            damage(1, DamageCause.FIRE);
+            // increment the ticks stood adjacent to fire or lava
+            adjacentBurnTicks++;
+            if (adjacentBurnTicks > 40) {
+                stoodInFire = !isDead();
+            }
+        } else if (stoodInFire) {
+            setFireTicks(getFireTicks() + 160);
+            stoodInFire = false;
+            adjacentBurnTicks = 0;
         } else {
             swamInLava = false;
             if (getLocation().getBlock().getType() == Material.WATER

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -240,6 +240,10 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
      * If this entity has swam in lava (for fire application).
      */
     private boolean swamInLava;
+    /**
+     * If this entity has stood in fire (for fire application).
+     */
+    private boolean stoodInFire;
 
     /**
      * Creates a mob within the specified world.
@@ -307,6 +311,18 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
         if (isWithinSolidBlock()) {
             damage(1, DamageCause.SUFFOCATION);
+        }
+
+        // fire damage
+        if (getLocation().getBlock().getType() == Material.FIRE) {
+            damage(1, DamageCause.FIRE);
+            // not applying additional fire ticks after dying in fire
+            stoodInFire = !isDead();
+        } else {
+            if (stoodInFire) {
+                setFireTicks(getFireTicks() + 180);
+                stoodInFire = false;
+            }
         }
 
         if (getLocation().getBlock().getType() == Material.LAVA


### PR DESCRIPTION
This pull request aims to implement fire damage for living entities:

**Observed Behavior:**  Entities would not catch fire when standing in a fire block.  Since entities were not being detected in the fire block, fire ticks were not updated and the entity takes zero damage.

**Expected Behavior:**  Entities will catch fire when standing in fire.  While standing in fire, the entity will take 1 tick of damage, equivalence of half a heart in-game.  Once the entity is no longer standing in fire, they will receive 8 ticks of damage, equivalence of four hearts in-game.  If the entity were to enter the fire again, they will continue to take damage and add an additional 8 ticks of fire damage once they exit.

This was implemented in a similar manner as lava damage, checking if the entity is standing in fire and dealing damage to the entity.  We must check if the entity is dead or not, that way if they were to die in the fire they do not receive the fire ticks after death.  Once exiting the fire if they were previously standing in fire, then their fire ticks will increment by 180.