### PR TITLE
Download runtime library dependencies, resolve conflicts.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,17 @@
       <artifactId>jocl-main</artifactId>
       <version>2.3.2</version>
     </dependency>
+    <!-- Maven stuff -->
+    <dependency>
+      <groupId>com.tobedevoured.naether</groupId>
+      <artifactId>core</artifactId>
+      <version>0.15.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>3.0.3</version>
+    </dependency>
     <!-- Tests -->
     <dependency>
       <groupId>org.junit.vintage</groupId>

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1085,7 +1085,7 @@ public class GlowServer implements Server {
                 Library library = entry.getValue().get(0);
                 if (serverContainsLibrary(library)) {
                     conflicts.add(entry.getKey().toString());
-                } else {
+                } else if (!library.isExcludeDependencies()) {
                     Naether naether = clients.computeIfAbsent(
                         library.getRepository(),
                         k -> createNaetherWithRepository(k, libraryFolder)

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -3,18 +3,25 @@ package net.glowstone;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.flowpowered.network.Message;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Multimaps;
+import com.google.common.collect.Sets;
 import com.jogamp.opencl.CLDevice;
 import com.jogamp.opencl.CLPlatform;
+import com.tobedevoured.naether.NaetherException;
+import com.tobedevoured.naether.api.Naether;
+import com.tobedevoured.naether.impl.NaetherImpl;
+import com.tobedevoured.naether.util.RepoBuilder;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.kqueue.KQueue;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Files;
@@ -31,6 +38,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
@@ -43,6 +51,7 @@ import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import net.glowstone.advancement.GlowAdvancement;
@@ -421,6 +430,13 @@ public class GlowServer implements Server {
      * Whether the macOS/BSD kqueue native transport is available for Netty.
      */
     public static final boolean KQUEUE = KQueue.isAvailable();
+    /**
+     * Libraries that are known to cause problems when loaded up via the server config or plugin
+     * dependencies.
+     */
+    private static final Set<LibraryKey> blacklistedRuntimeLibs = ImmutableSet.of(
+            new LibraryKey("it.unimi.dsi", "fastutil")
+    );
 
     /**
      * Creates a new server.
@@ -747,9 +763,10 @@ public class GlowServer implements Server {
         }
 
         // Start loading plugins
-        Set<Library> libraries = aggregateLibraries();
-        new LibraryManager(config.getString(Key.LIBRARY_REPOSITORY_URL),
-                config.getString(Key.LIBRARIES_FOLDER),
+        String repository = config.getString(Key.LIBRARY_REPOSITORY_URL);
+        String libraryFolder = config.getString(Key.LIBRARIES_FOLDER);
+        Set<Library> libraries = aggregateLibraries(repository, libraryFolder);
+        new LibraryManager(repository, libraryFolder,
                 config.getBoolean(Key.LIBRARY_CHECKSUM_VALIDATION),
                 config.getInt(Key.LIBRARY_DOWNLOAD_ATTEMPTS), libraries).run();
         loadPlugins();
@@ -999,10 +1016,35 @@ public class GlowServer implements Server {
         }
     }
 
-    /**
-     * Aggregates libraries from all relevant sources together.
-     */
-    private Set<Library> aggregateLibraries() {
+    private boolean serverContainsLibrary(Library library) {
+        return this.getClass().getResource(
+                String.format(
+                        "/META-INF/maven/%s/%s/pom.xml",
+                        library.getGroupId(),
+                        library.getArtifactId()
+                )
+        ) != null;
+    }
+
+    private Naether createNaetherWithRepository(String repository, String libraryFolder) {
+        Naether naether = new NaetherImpl();
+        naether.setLocalRepoPath(new File(libraryFolder).getAbsolutePath());
+
+        try {
+            // Must overwrite the collection here in order to remove Maven Central from it.
+            naether.setRemoteRepositories(Sets.newHashSet(
+                    RepoBuilder.remoteRepositoryFromUrl(repository)
+            ));
+        } catch (MalformedURLException e) {
+            logger.log(Level.WARNING, "Unable to resolve library dependencies. Falling back to "
+                    + "explicitly defined dependencies only.", e);
+            return null;
+        }
+
+        return naether;
+    }
+
+    private Set<Library> aggregateLibraries(String repository, String libraryFolder) {
         String bundleString = config.getString(Key.COMPATIBILITY_BUNDLE);
         CompatibilityBundle bundle = CompatibilityBundle.fromConfig(bundleString);
         if (bundle == null) {
@@ -1013,33 +1055,113 @@ public class GlowServer implements Server {
         Map<LibraryKey, Library> bundleLibs = bundle.libraries;
 
         ListMultimap<LibraryKey, Library> configLibs = config.getMapList(Key.LIBRARIES_LIST)
-                .stream()
-                .map(Library::fromConfigMap)
-                .collect(Multimaps.toMultimap(Library::getLibraryKey, Function.identity(),
-                        MultimapBuilder.hashKeys().arrayListValues()::build));
+            .stream()
+            .map(Library::fromConfigMap)
+            .filter(library -> {
+                if (bundleLibs.containsKey(library.getLibraryKey())) {
+                    logger.log(Level.WARNING, String.format(
+                        "Library '%s' is already defined as part of bundle '%s'. This entry within"
+                            + " the 'libraries' config section will be ignored.",
+                        library.getLibraryKey().toString(),
+                        bundleString
+                    ));
+                    return false;
+                }
+                return true;
+            })
+            .collect(Multimaps.toMultimap(Library::getLibraryKey, Function.identity(),
+                MultimapBuilder.hashKeys().arrayListValues()::build));
 
-        Set<Library> libs = new HashSet<>(bundleLibs.values());
+        Set<String> conflicts = new HashSet<>();
+        Set<String> duplicateLibs = new HashSet<>();
+
+        Map<String, Naether> clients = new HashMap<>();
+        clients.put(null, createNaetherWithRepository(repository, libraryFolder));
 
         for (Map.Entry<LibraryKey, List<Library>> entry : Multimaps.asMap(configLibs).entrySet()) {
             if (entry.getValue().size() > 1) {
-                logger.log(Level.SEVERE, String.format(
-                    "Library '%s' is defined multiple times in the 'libraries' config section.",
-                    entry.getKey().toString()
-                ));
-                System.exit(1);
-            } else if (bundleLibs.containsKey(entry.getKey())) {
-                logger.log(Level.WARNING, String.format(
-                    "Library '%s' is already defined as part of bundle '%s'. This entry within "
-                        + "the 'libraries' config section will be ignored.",
-                    entry.getKey().toString(),
-                    bundleString
-                ));
+                duplicateLibs.add(entry.getKey().toString());
             } else {
-                libs.add(entry.getValue().get(0));
+                Library library = entry.getValue().get(0);
+                if (serverContainsLibrary(library)) {
+                    conflicts.add(entry.getKey().toString());
+                } else {
+                    Naether naether = clients.computeIfAbsent(
+                        library.getRepository(),
+                        k -> createNaetherWithRepository(k, libraryFolder)
+                    );
+                    if (naether != null) {
+                        naether.addDependency(
+                            String.format(
+                                "%s:%s:jar:%s",
+                                library.getGroupId(),
+                                library.getArtifactId(),
+                                library.getVersion()
+                            )
+                        );
+                    }
+                }
             }
         }
 
-        return libs;
+        if (!conflicts.isEmpty() || !duplicateLibs.isEmpty()) {
+            if (!conflicts.isEmpty()) {
+                String joinedConflicts = conflicts.stream()
+                    .collect(Collectors.joining("', '", "['", "']"));
+                logger.log(Level.SEVERE, String.format(
+                    "Libraries %s conflict with libraries built into this JAR file. Please fix"
+                        + " this issue and restart the server.",
+                    joinedConflicts
+                ));
+            }
+            if (!duplicateLibs.isEmpty()) {
+                String joinedDuplicates = duplicateLibs.stream()
+                    .collect(Collectors.joining("', '", "['", "']"));
+                logger.log(Level.SEVERE, String.format(
+                    "Libraries %s are defined multiple times in the 'libraries' config section.",
+                    joinedDuplicates
+                ));
+            }
+            System.exit(1);
+        }
+
+        Map<LibraryKey, Library> dependencyLibs = clients.entrySet().stream()
+                .filter(Objects::nonNull)
+                .flatMap(entry -> {
+                    try {
+                        entry.getValue().resolveDependencies(false);
+                        return entry.getValue().getDependenciesNotation().stream()
+                            .map(dependency -> {
+                                // same format as above, {groupId}:{artifactId}:jar:{version}
+                                String[] expanded = dependency.split(":");
+                                // TODO: populate the checksum fields if possible
+                                return new Library(expanded[0], expanded[1], expanded[3],
+                                    entry.getKey());
+                            });
+                    } catch (NaetherException e) {
+                        logger.log(Level.WARNING, "Unable to resolve library dependencies. Falling"
+                                + " back to explicitly defined dependencies only.", e);
+                        return Stream.empty();
+                    }
+                })
+                .filter(library -> !configLibs.containsKey(library.getLibraryKey())
+                        && !serverContainsLibrary(library)
+                        && !blacklistedRuntimeLibs.contains(library.getLibraryKey()))
+                .collect(Collectors.toMap(
+                    Library::getLibraryKey,
+                    Function.identity(),
+                    (library1, library2) -> library1.compareTo(library2) > 0
+                        ? library1 : library2
+                ));
+
+        Set<Library> libraries = new HashSet<>(
+            bundleLibs.size() + configLibs.size() + dependencyLibs.size()
+        );
+        libraries.addAll(bundleLibs.values());
+        libraries.addAll(configLibs.values());
+        libraries.addAll(dependencyLibs.values());
+
+        return libraries;
     }
 
     /**

--- a/src/main/java/net/glowstone/util/RectangularRegion.java
+++ b/src/main/java/net/glowstone/util/RectangularRegion.java
@@ -3,9 +3,9 @@ package net.glowstone.util;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.AbstractIterator;
 import java.util.Iterator;
+import javax.annotation.Nonnull;
 import lombok.Getter;
 import org.bukkit.Location;
-import org.jetbrains.annotations.NotNull;
 
 @Getter
 public class RectangularRegion {
@@ -88,7 +88,7 @@ public class RectangularRegion {
             this.iterableZ = iterableZ;
         }
 
-        @NotNull
+        @Nonnull
         @Override
         public Iterator<Location> iterator() {
             return new LocationIterator(lowCorner, iterableX, iterableY, iterableZ);
@@ -172,7 +172,7 @@ public class RectangularRegion {
             this.max = max;
         }
 
-        @NotNull
+        @Nonnull
         @Override
         public Iterator<Integer> iterator() {
             return new ForwardsAxisIterator(max);
@@ -208,7 +208,7 @@ public class RectangularRegion {
             this.max = max;
         }
 
-        @NotNull
+        @Nonnull
         @Override
         public Iterator<Integer> iterator() {
             return new BackwardsAxisIterator(max);

--- a/src/main/java/net/glowstone/util/library/Library.java
+++ b/src/main/java/net/glowstone/util/library/Library.java
@@ -1,16 +1,18 @@
 package net.glowstone.util.library;
 
+import com.google.common.collect.ComparisonChain;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import lombok.Getter;
 import net.glowstone.util.library.LibraryManager.HashAlgorithm;
 import org.apache.commons.lang.StringUtils;
+import org.apache.maven.artifact.versioning.ComparableVersion;
 
 /**
  * Represents a library that will be injected into the classpath at runtime.
  */
-public class Library {
+public class Library implements Comparable<Library> {
     private static final String ARTIFACT_ID_KEY = "artifact-id";
     private static final String CHECKSUM_KEY = "checksum";
     private static final String CHECKSUM_TYPE_KEY = "type";
@@ -201,5 +203,13 @@ public class Library {
     @Override
     public int hashCode() {
         return Objects.hash(libraryKey, version);
+    }
+
+    @Override
+    public int compareTo(Library o) {
+        return ComparisonChain.start()
+                .compare(libraryKey, o.libraryKey)
+                .compare(new ComparableVersion(version), new ComparableVersion(o.version))
+                .result();
     }
 }

--- a/src/main/java/net/glowstone/util/library/Library.java
+++ b/src/main/java/net/glowstone/util/library/Library.java
@@ -17,6 +17,7 @@ public class Library implements Comparable<Library> {
     private static final String CHECKSUM_KEY = "checksum";
     private static final String CHECKSUM_TYPE_KEY = "type";
     private static final String CHECKSUM_VALUE_KEY = "value";
+    private static final String EXCLUDE_DEPENDENCIES_KEY = "exclude-dependencies";
     private static final String GROUP_ID_KEY = "group-id";
     private static final String REPOSITORY_KEY = "repository";
     private static final String VERSION_KEY = "version";
@@ -43,8 +44,13 @@ public class Library implements Comparable<Library> {
             checksumValue = (String) checksum.get(CHECKSUM_VALUE_KEY);
         }
 
+        Boolean excludeDependencies = (Boolean) configMap.get(EXCLUDE_DEPENDENCIES_KEY);
+        if (excludeDependencies == null) {
+            excludeDependencies = Boolean.FALSE;
+        }
+
         return new Library(group, artifact, version, repository, checksumType,
-                checksumValue);
+                checksumValue, excludeDependencies);
     }
 
     /**
@@ -80,6 +86,13 @@ public class Library implements Comparable<Library> {
     private final String checksumValue;
 
     /**
+     * Excludes the dependency from any dependency checks. Use this if the library is locally
+     * hosted.
+     */
+    @Getter
+    private final boolean excludeDependencies;
+
+    /**
      * Creates a {@link Library} instance with the specified group ID, artifact ID, and version.
      *
      * @param groupId The group ID of the library, separated by periods.
@@ -87,7 +100,7 @@ public class Library implements Comparable<Library> {
      * @param version The version of the library.
      */
     public Library(String groupId, String artifactId, String version) {
-        this(groupId, artifactId, version, null, null, null);
+        this(groupId, artifactId, version, null, null, null, false);
     }
 
     /**
@@ -100,7 +113,7 @@ public class Library implements Comparable<Library> {
      * @param repository The URL of the library's repository.
      */
     public Library(String groupId, String artifactId, String version, String repository) {
-        this(groupId, artifactId, version, repository, null, null);
+        this(groupId, artifactId, version, repository, null, null, false);
     }
 
     /**
@@ -115,27 +128,29 @@ public class Library implements Comparable<Library> {
      */
     public Library(String groupId, String artifactId, String version, HashAlgorithm checksumType,
                    String checksumValue) {
-        this(groupId, artifactId, version, null, checksumType, checksumValue);
+        this(groupId, artifactId, version, null, checksumType, checksumValue, false);
     }
 
     /**
      * Creates a {@link Library} instance with the specified group ID, artifact ID, version,
      * repository, and checksum.
-     *
-     * @param groupId The group ID of the library, separated by periods.
+     *  @param groupId The group ID of the library, separated by periods.
      * @param artifactId The artifact ID of the library.
      * @param version The version of the library.
      * @param repository The URL of the library's repository.
      * @param checksumType The type of hash the checksum is using.
      * @param checksumValue The checksum to validate the downloaded library against.
+     * @param excludeDependencies Specifies that dependencies may be excluded.
      */
     public Library(String groupId, String artifactId, String version,
-                   String repository, HashAlgorithm checksumType, String checksumValue) {
+                   String repository, HashAlgorithm checksumType, String checksumValue,
+                   boolean excludeDependencies) {
         this.libraryKey = new LibraryKey(groupId, artifactId);
         this.version = version;
         this.repository = StringUtils.isBlank(repository) ? null : repository;
         this.checksumType = checksumType;
         this.checksumValue = checksumValue;
+        this.excludeDependencies = excludeDependencies;
     }
 
     /**
@@ -160,6 +175,10 @@ public class Library implements Comparable<Library> {
             checksumMap.put(CHECKSUM_TYPE_KEY, checksumType.getName());
             checksumMap.put(CHECKSUM_VALUE_KEY, checksumValue);
             configMap.put(CHECKSUM_KEY, checksumMap);
+        }
+
+        if (excludeDependencies) {
+            configMap.put(EXCLUDE_DEPENDENCIES_KEY, excludeDependencies);
         }
 
         return configMap;


### PR DESCRIPTION
Adapting the changes of #865 after #879 was merged in.

This PR adds the ability for Glowstone to download dependencies for libraries specified in the glowstone.yml. It does so using an abstraction on top of Maven's Aether API, Naether, that makes dependency resolution fairly easy. I check the tree that is built up by this plugin against the libraries builtin to the server by searching the classpath for the dependency's POM, which maven-shade-plugin embeds into the JAR. I tried various methods (hence why this change took so long), and this seems to be the most stable way of attempting to do this.

Now, there's a few downsides to how I implemented this:
* The way I am checking for what dependencies Glowstone includes relies on an implementation detail from maven-shade-plugin. While not a large piece of code, it will have to be rewritten if we ever decide to move away from this plugin or from Maven in general. I tried exploring other possibilities, such as serializing the depndency tree at build time, but it proved to be a lot more work for not much more benefit.
* This requires embedding portions of Maven itself into Glowstone in order to perform the dependency resolution. While this doesn't tie us to Maven for builds like the dependency checking does, it still ties us to resolving dependencies in a certain way. If we decide to move build systems, it could be awkward to have two different ways of resolving dependencies depending on if they are runtime vs builtin. Currently, we're using Maven, so I think it's fine to use it for our library downloads as well.
* Naether provides the ability to download the dependencies itself, but I am explicitly disabling that since we have our own download manager. We may choose to use this at some point in the future, but I felt it was better to let this functionality bake before trying this out.
* Checksums are required for publishing on Maven Central, so we could take advantage of those in many cases, but I decided to put that as a possible future task rather than making this change even bigger.

*Do note that due to concerns in the previous commit, I reverted my Kotlin changes. Kotlin will still be included with the Glowstone JAR file.*

As before, let me know what you think of this change! I think the benefits of this outweigh the downsides listed above, but certainly there's room for improvement here.