### PR TITLE
GlowServer.getProfile without async lookup

### DIFF
--- a/src/main/java/net/glowstone/GlowOfflinePlayer.java
+++ b/src/main/java/net/glowstone/GlowOfflinePlayer.java
@@ -89,6 +89,7 @@ public final class GlowOfflinePlayer implements OfflinePlayer {
     // Core properties
 
     private void loadData() {
+        profile.completeCached();
         try (PlayerReader reader = server.getPlayerDataService().beginReadingData(getUniqueId())) {
             hasPlayed = reader.hasPlayedBefore();
             if (hasPlayed) {

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -1744,7 +1744,19 @@ public class GlowServer implements Server {
 
     @Override
     public GlowPlayerProfile createProfile(UUID id, String name) {
-        return new GlowPlayerProfile(name, id);
+        return createProfile(id, name, false);
+    }
+
+    /**
+     * Creates a player profile.
+     *
+     * @param name The player's name.
+     * @param uuid The player's UUID; may be null.
+     * @param asyncLookup If true and {@code uuid} is null, the UUID is looked up asynchronously.
+     * @return The player's profile.
+     */
+    public GlowPlayerProfile createProfile(UUID uuid, String name, boolean asyncLookup) {
+        return new GlowPlayerProfile(name, uuid, asyncLookup);
     }
 
     @Override
@@ -1965,7 +1977,7 @@ public class GlowServer implements Server {
             GlowServer.logger.log(Level.WARNING,
                     strings.getString("console.warn.profile.timeout"), ex);
         }
-        return new GlowOfflinePlayer(this, new GlowPlayerProfile(null, uuid));
+        return new GlowOfflinePlayer(this, new GlowPlayerProfile(null, uuid, false));
     }
 
     /**
@@ -2007,7 +2019,7 @@ public class GlowServer implements Server {
 
     private OfflinePlayer getOfflinePlayerFallback(String name) {
         return getOfflinePlayer(new GlowPlayerProfile(name, UUID
-                .nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes())));
+                .nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes()), false));
     }
 
 

--- a/src/main/java/net/glowstone/block/entity/state/GlowSkull.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowSkull.java
@@ -84,7 +84,8 @@ public class GlowSkull extends GlowBlockState implements Skull {
 
     @Override
     public void setOwningPlayer(OfflinePlayer offlinePlayer) {
-        this.owner = new GlowPlayerProfile(offlinePlayer.getName(), offlinePlayer.getUniqueId());
+        this.owner = new GlowPlayerProfile(offlinePlayer.getName(), offlinePlayer.getUniqueId(),
+                true);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -1392,7 +1392,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
     @Override
     public boolean isWhitelisted() {
         return server.getWhitelist().containsProfile(
-                new GlowPlayerProfile(getName(), getUniqueId()));
+                new GlowPlayerProfile(getName(), getUniqueId(), true));
     }
 
     @Override
@@ -1400,7 +1400,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         if (value) {
             server.getWhitelist().add(this);
         } else {
-            server.getWhitelist().remove(new GlowPlayerProfile(getName(), getUniqueId()));
+            server.getWhitelist().remove(new GlowPlayerProfile(getName(), getUniqueId(), true));
         }
     }
 
@@ -1427,7 +1427,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         if (value) {
             getServer().getOpsList().add(this);
         } else {
-            getServer().getOpsList().remove(new GlowPlayerProfile(getName(), getUniqueId()));
+            getServer().getOpsList().remove(new GlowPlayerProfile(getName(), getUniqueId(), true));
         }
         permissions.recalculatePermissions();
     }

--- a/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
@@ -90,7 +90,6 @@ public class GlowPlayerProfile implements PlayerProfile {
     private GlowPlayerProfile(String name, CompletableFuture<UUID> uuid,
             Collection<ProfileProperty> properties) {
         checkNotNull(properties, "properties must not be null");
-        checkNotNull(uuid, "uuid must not be null");
         this.name = name;
         this.uniqueId = uuid;
         this.properties = Maps.newHashMap();

--- a/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
@@ -1,6 +1,7 @@
 package net.glowstone.entity.meta.profile;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 
 import com.destroystokyo.paper.profile.PlayerProfile;
 import com.destroystokyo.paper.profile.ProfileProperty;
@@ -30,12 +31,20 @@ public class GlowPlayerProfile implements PlayerProfile {
     public static final int MAX_USERNAME_LENGTH = 16;
     @Getter
     private final String name;
-    private final CompletableFuture<UUID> uniqueId;
+    private volatile CompletableFuture<UUID> uniqueId;
     private final Map<String, ProfileProperty> properties;
 
-    private static CompletableFuture<UUID> lookUpIfNull(String name, UUID maybeUuid) {
-        return maybeUuid == null ? ProfileCache.getUuid(name) : CompletableFuture.completedFuture(
-                maybeUuid);
+    private static CompletableFuture<UUID> maybeLookUpNull(String name, UUID maybeUuid,
+            boolean asyncLookup) {
+        if (maybeUuid == null) {
+            if (asyncLookup) {
+                return ProfileCache.getUuid(name);
+            }
+            UUID maybeCachedUuid = ProfileCache.getUuidCached(name);
+            return maybeCachedUuid == null ? null : completedFuture(maybeCachedUuid);
+        } else {
+            return completedFuture(maybeUuid);
+        }
     }
 
     /**
@@ -45,9 +54,10 @@ public class GlowPlayerProfile implements PlayerProfile {
      *
      * @param name The player's name.
      * @param uuid The player's UUID; may be null.
+     * @param asyncLookup If true and {@code uuid} is null, the UUID is looked up asynchronously.
      */
-    public GlowPlayerProfile(String name, UUID uuid) {
-        this(name, lookUpIfNull(name, uuid), Collections.emptySet());
+    public GlowPlayerProfile(String name, UUID uuid, boolean asyncLookup) {
+        this(name, maybeLookUpNull(name, uuid, asyncLookup), Collections.emptySet());
     }
 
     /**
@@ -58,10 +68,13 @@ public class GlowPlayerProfile implements PlayerProfile {
      * @param name The player's name.
      * @param uuid The player's UUID; may be null.
      * @param properties A list of extra properties.
+     * @param asyncLookup If true and {@code uuid} is null, the UUID is looked up asynchronously
+     *     even if it's not in cache.
      * @throws IllegalArgumentException if properties are null.
      */
-    public GlowPlayerProfile(String name, UUID uuid, Collection<ProfileProperty> properties) {
-        this(name, lookUpIfNull(name, uuid), properties);
+    public GlowPlayerProfile(String name, UUID uuid, Collection<ProfileProperty> properties,
+            boolean asyncLookup) {
+        this(name, maybeLookUpNull(name, uuid, asyncLookup), properties);
     }
 
     /**
@@ -92,20 +105,20 @@ public class GlowPlayerProfile implements PlayerProfile {
      */
     public static CompletableFuture<GlowPlayerProfile> getProfile(String name) {
         if (name == null || name.length() > MAX_USERNAME_LENGTH || name.isEmpty()) {
-            return CompletableFuture.completedFuture(null);
+            return completedFuture(null);
         }
 
         GlowServer server = (GlowServer) ServerProvider.getServer();
         if (server.getOnlineMode() || server.getProxySupport()) {
             return ProfileCache.getUuid(name).thenComposeAsync((uuid) -> {
                 if (uuid == null) {
-                    return CompletableFuture.completedFuture(null);
+                    return completedFuture(null);
                 } else {
                     return ProfileCache.getProfile(uuid);
                 }
             });
         }
-        return CompletableFuture.completedFuture(null);
+        return completedFuture(null);
     }
 
     /**
@@ -130,11 +143,11 @@ public class GlowPlayerProfile implements PlayerProfile {
         }
 
         if (tag.containsKey("Name")) {
-            return CompletableFuture.completedFuture(
-                    new GlowPlayerProfile(tag.getString("Name"), uuid, properties));
+            return completedFuture(
+                    new GlowPlayerProfile(tag.getString("Name"), uuid, properties, true));
         } else {
             return ProfileCache.getProfile(uuid).thenApplyAsync(
-                (profile) -> new GlowPlayerProfile(profile.getName(), uuid, properties));
+                (profile) -> new GlowPlayerProfile(profile.getName(), uuid, properties, true));
         }
     }
 
@@ -168,7 +181,7 @@ public class GlowPlayerProfile implements PlayerProfile {
             properties.add(new ProfileProperty(propName, value, signature));
         }
 
-        return new GlowPlayerProfile(name, uuid, properties);
+        return new GlowPlayerProfile(name, uuid, properties, true);
     }
 
     /**
@@ -206,7 +219,7 @@ public class GlowPlayerProfile implements PlayerProfile {
      */
     @Override
     public UUID getId() {
-        return this.uniqueId.join();
+        return uniqueId == null ? null : uniqueId.join();
     }
 
     @Override
@@ -265,7 +278,52 @@ public class GlowPlayerProfile implements PlayerProfile {
      */
     @Override
     public boolean isComplete() {
-        return name != null && uniqueId.isDone()
-                && uniqueId.join() != null && properties.containsKey("textures");
+        return name != null && getId() != null && properties.containsKey("textures");
+    }
+
+    /**
+     * Looks up the UUID if it's missing and hasn't already been attempted, and waits for it.
+     *
+     * @return true if the profile {@link #isComplete()} when done; false otherwise
+     */
+    public boolean complete() {
+        completeAsync();
+        uniqueId.join();
+        return isComplete();
+    }
+
+    /**
+     * Looks up the UUID asynchronously if it's missing and hasn't already been attempted. Returns
+     * immediately.
+     */
+    public void completeAsync() {
+        if (uniqueId == null) {
+            synchronized (this) {
+                if (uniqueId == null) {
+                    uniqueId = ProfileCache.getUuid(name);
+                }
+            }
+        }
+    }
+
+    /**
+     * Looks up the UUID in cache, if it's missing and hasn't already been attempted.
+     *
+     * @return true if the profile {@link #isComplete()} when done; false otherwise
+     */
+    public boolean completeCached() {
+        if (uniqueId == null) {
+            synchronized (this) {
+                if (uniqueId == null) {
+                    UUID maybeCachedUuid = ProfileCache.getUuidCached(name);
+                    if (maybeCachedUuid != null) {
+                        uniqueId = completedFuture(maybeCachedUuid);
+                    } else {
+                        return false;
+                    }
+                }
+            }
+        }
+        return isComplete();
     }
 }

--- a/src/main/java/net/glowstone/entity/meta/profile/PlayerDataFetcher.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/PlayerDataFetcher.java
@@ -45,7 +45,7 @@ class PlayerDataFetcher {
             is = conn.getInputStream();
         } catch (IOException e) {
             GlowServer.logger.log(Level.WARNING, "Failed to look up profile");
-            return new GlowPlayerProfile(null, uuid);
+            return new GlowPlayerProfile(null, uuid, true);
         }
 
         JSONObject json;
@@ -53,14 +53,14 @@ class PlayerDataFetcher {
             if (br.ready()) {
                 json = (JSONObject) new JSONParser().parse(br);
             } else {
-                return new GlowPlayerProfile(null, uuid);
+                return new GlowPlayerProfile(null, uuid, true);
             }
         } catch (ParseException e) {
             GlowServer.logger.log(Level.WARNING, "Failed to parse profile response", e);
-            return new GlowPlayerProfile(null, uuid);
+            return new GlowPlayerProfile(null, uuid, true);
         } catch (IOException e) {
             GlowServer.logger.log(Level.WARNING, "Failed to look up profile", e);
-            return new GlowPlayerProfile(null, uuid);
+            return new GlowPlayerProfile(null, uuid, true);
         }
         return GlowPlayerProfile.fromJson(json);
     }

--- a/src/main/java/net/glowstone/entity/meta/profile/ProfileCache.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/ProfileCache.java
@@ -44,4 +44,14 @@ public class ProfileCache {
         uuidFuture.thenAccept(uid -> uuidCache.put(playerName, uid));
         return uuidFuture;
     }
+
+    /**
+     * Look up the UUID for a given username, but only in the cache and not on the Mojang server.
+     *
+     * @param playerName The name to look up.
+     * @return A UUID, or null if it's not found in the cache.
+     */
+    public static UUID getUuidCached(String playerName) {
+        return uuidCache.get(playerName);
+    }
 }

--- a/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
+++ b/src/main/java/net/glowstone/inventory/GlowMetaSkull.java
@@ -21,7 +21,7 @@ import org.bukkit.inventory.meta.SkullMeta;
 public class GlowMetaSkull extends GlowMetaItem implements SkullMeta {
 
     private static final GlowPlayerProfile UNKNOWN_PLAYER = new GlowPlayerProfile("MHF_Steve",
-            new UUID(0xc06f89064c8a4911L, 0x9c29ea1dbd1aab82L));
+            new UUID(0xc06f89064c8a4911L, 0x9c29ea1dbd1aab82L), true);
 
     final AtomicReference<GlowPlayerProfile> owner = new AtomicReference<>();
 

--- a/src/main/java/net/glowstone/net/ProxyData.java
+++ b/src/main/java/net/glowstone/net/ProxyData.java
@@ -133,7 +133,7 @@ public final class ProxyData {
      * @return The spoofed profile.
      */
     public GlowPlayerProfile getProfile(String name) {
-        return new GlowPlayerProfile(name, uuid, properties);
+        return new GlowPlayerProfile(name, uuid, properties, true);
     }
 
     /**
@@ -146,6 +146,6 @@ public final class ProxyData {
         if (name == null) {
             return null;
         }
-        return new GlowPlayerProfile(name, uuid, properties);
+        return new GlowPlayerProfile(name, uuid, properties, true);
     }
 }

--- a/src/main/java/net/glowstone/net/handler/login/EncryptionKeyResponseHandler.java
+++ b/src/main/java/net/glowstone/net/handler/login/EncryptionKeyResponseHandler.java
@@ -172,7 +172,7 @@ public final class EncryptionKeyResponseHandler implements
 
             // spawn player
             session.getServer().getScheduler().runTask(null, () -> session.setPlayer(
-                    new GlowPlayerProfile(name, uuid, properties)));
+                    new GlowPlayerProfile(name, uuid, properties, true)));
         }
 
         @Override

--- a/src/main/java/net/glowstone/net/handler/login/LoginStartHandler.java
+++ b/src/main/java/net/glowstone/net/handler/login/LoginStartHandler.java
@@ -42,7 +42,7 @@ public final class LoginStartHandler implements MessageHandler<GlowSession, Logi
             if (proxy == null) {
                 UUID uuid = UUID
                     .nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(StandardCharsets.UTF_8));
-                profile = new GlowPlayerProfile(name, uuid);
+                profile = new GlowPlayerProfile(name, uuid, true);
             } else {
                 profile = proxy.getProfile();
                 if (profile == null) {

--- a/src/test/java/net/glowstone/entity/GlowPlayerTest.java
+++ b/src/test/java/net/glowstone/entity/GlowPlayerTest.java
@@ -64,7 +64,7 @@ public class GlowPlayerTest extends GlowHumanEntityTest<GlowPlayer> {
     // Real objects
 
     private static final GlowPlayerProfile profile
-            = new GlowPlayerProfile("TestPlayer", UUID.randomUUID());
+            = new GlowPlayerProfile("TestPlayer", UUID.randomUUID(), true);
     private GlowScheduler scheduler;
     private final SessionRegistry sessionRegistry = new SessionRegistry();
     private File opsListFile;


### PR DESCRIPTION
Fixes #881. Only the new overload that takes a boolean parameter will trigger a UUID lookup from the Mojang server; to maintain compatibility with existing behavior, the existing code now uses that overload and sets the parameter to true.