### PR TITLE
Enhance Entity Physics Calculation

### DIFF
--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -1481,6 +1481,12 @@ public class GlowWorld implements World {
         return (T) spawn(location, descriptor.getEntityClass(), reason);
     }
 
+    /**
+     * Spawn an item at the given {@link Location} without shooting effect.
+     *
+     * @param location  the {@link Location} to spawn the item at
+     * @param item      the {@ItemStack} the item should have
+     */
     @Override
     public GlowItem dropItem(Location location, ItemStack item) {
         GlowItem entity = new GlowItem(location, item);
@@ -1491,14 +1497,33 @@ public class GlowWorld implements World {
         return entity;
     }
 
+    /**
+     * Spawn an item at the given {@link Location} with shooting effect.
+     *
+     * @param location  the {@link Location} to spawn the item at
+     * @param item      the {@ItemStack} the item should have
+     */
     @Override
     public GlowItem dropItemNaturally(Location location, ItemStack item) {
-        double xs = ThreadLocalRandom.current().nextFloat() * 0.7F + (1.0F - 0.7F) * 0.5D;
-        double ys = ThreadLocalRandom.current().nextFloat() * 0.7F + (1.0F - 0.7F) * 0.5D;
-        double zs = ThreadLocalRandom.current().nextFloat() * 0.7F + (1.0F - 0.7F) * 0.5D;
-        location = location.clone().add(xs, ys, zs);
+        ThreadLocalRandom tlr = ThreadLocalRandom.current();
+
+        // Calculate initial velocity using radius and offsetY as constant
+        // offsetX and offsetZ are calculated using random and Pythagorean theorem
+        double radius = 0.1;
+        double offsetX = tlr.nextDouble(radius * 2) - radius;
+        double offsetY = 0.15;
+        double offsetZ = Math.sqrt(Math.pow(radius, 2) - Math.pow(offsetX, 2));
+
+        // The previous calculation always gives a non-negative zOffset
+        // This adds a 50% chance of offsetZ being negative
+        if (tlr.nextInt(2) == 0) {
+            offsetZ *= -1;
+        }
+
+        // Move starting point to the center of the block
+        location.add(0.5, 0.5, 0.5);
         GlowItem dropItem = dropItem(location, item);
-        dropItem.setVelocity(new Vector(0, 0.01F, 0));
+        dropItem.setVelocity(new Vector(offsetX, offsetY, offsetZ));
         return dropItem;
     }
 

--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -1516,7 +1516,7 @@ public class GlowWorld implements World {
 
         // The previous calculation always gives a non-negative zOffset
         // This adds a 50% chance of offsetZ being negative
-        if (tlr.nextInt(2) == 0) {
+        if (tlr.nextBoolean()) {
             offsetZ *= -1;
         }
 

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -180,29 +180,43 @@ public abstract class GlowEntity implements Entity {
      */
     @Getter
     protected boolean removed;
+
     /**
-     * Velocity reduction applied each tick in air, y component.
+     * Velocity reduction applied each tick in air.
+     * For example, if the multiplier is 0.98,
+     * the entity will lose 2% of its velocity each physics tick.
+     * The default value 1 indicates no air drag.
      */
-    protected double airDrag = 0.98;
-    /**
-     * Velocity reduction applied each tick in air, x and z components.
-     */
-    @Getter
     @Setter
-    private double horizontalAirDrag = 0.91;
+    protected double airDrag = 1;
+
     /**
-     * Velocity reduction applied each tick in liquids.
+     * Velocity reduction applied each tick in water.
+     * For example, if the multiplier is 0.98,
+     * the entity will lose 2% of its velocity each physics tick.
+     * The default value 0.8 indicates 20% water drag.
      */
+    @Setter
     protected double liquidDrag = 0.8;
+
     /**
      * Gravity acceleration applied each tick.
+     * The default value (0,0,0) indicates no gravity acceleration.
      */
     @Setter
-    protected Vector gravityAccel = new Vector(0, -0.04, 0);
+    protected Vector gravityAccel = new Vector(0, 0, 0);
+
     /**
      * The slipperiness multiplier applied according to the block this entity was on.
      */
     protected double slipMultiplier = 0.6;
+
+    /**
+     * If drag is applied before appling acceleration while calculating physics.
+     */
+    @Setter
+    protected boolean applyDragBeforeAccel = false;
+
     /**
      * This entity's unique id.
      */
@@ -217,7 +231,7 @@ public abstract class GlowEntity implements Entity {
      * A flag indicting if the entity is on the ground.
      */
     @Getter
-    private boolean onGround = true;
+    private boolean onGround = false;
     /**
      * The distance the entity is currently falling without touching the ground.
      */
@@ -286,7 +300,9 @@ public abstract class GlowEntity implements Entity {
      */
     public GlowEntity(Location location) {
         this.origin = location.clone();
+        this.previousLocation = location.clone();
         this.location = location.clone();
+
         world = (GlowWorld) location.getWorld();
         server = world.getServer();
         // this is so dirty I washed my hands after writing it.
@@ -298,7 +314,6 @@ public abstract class GlowEntity implements Entity {
         }
         server.getEntityIdManager().allocate(this);
         world.getEntityManager().register(this);
-        previousLocation = location.clone();
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -434,22 +449,6 @@ public abstract class GlowEntity implements Entity {
 
     ////////////////////////////////////////////////////////////////////////////
     // Internals
-
-    /**
-     * Sets the velocity multiplier due to drag. For example, if the multiplier is 0.98, the entity
-     * will lose 2% of its velocity each physics tick. Set to 1.0 to disable drag.
-     *
-     * @param drag the new drag rate
-     * @param liquid true to set liquid drag; false to set air drag
-     */
-    public void setDrag(double drag, boolean liquid) {
-        if (liquid) {
-            liquidDrag = drag;
-        } else {
-            airDrag = drag;
-        }
-    }
-
     @Override
     public boolean teleport(Location location) {
         checkNotNull(location, "location cannot be null");
@@ -670,6 +669,7 @@ public abstract class GlowEntity implements Entity {
         }
 
         world.getEntityManager().move(this, location);
+        Position.copyLocation(this.location, this.previousLocation);
         Position.copyLocation(location, this.location);
 
         updateBoundingBox();
@@ -688,8 +688,11 @@ public abstract class GlowEntity implements Entity {
             }
         }
 
+        // set entity to be on ground if its bounding box intercepts a solid block in -Y direction
         if (fall && hasDefaultLandingBehavior()) {
-            setOnGround(location.clone().add(new Vector(0, -1, 0)).getBlock().getType().isSolid());
+            Vector detectOffset = boundingBox.getSize();
+            Location detectLocation = location.clone().add(0, -detectOffset.getY(), 0);
+            setOnGround(detectLocation.getBlock().getType().isSolid());
         }
     }
 
@@ -978,52 +981,63 @@ public abstract class GlowEntity implements Entity {
     }
 
     protected void pulsePhysics() {
-        Location velLoc = location.clone().add(velocity);
-        final Block block = velLoc.getBlock();
-        if (block.getType().isSolid()) {
-            Location velLocY = location.clone().add(0, velocity.getY(), 0);
-            if (velLocY.getBlock().getType().isSolid()) {
-                velocity.setY(0);
-            }
-            Location velLocX = location.clone().add(velocity.getX(), 0, 0);
-            if (velLocX.getBlock().getType().isSolid()) {
+        // The pending locaiton and the block at that location
+        Location pendingLocation = location.clone().add(velocity);
+        Block pendingBlock = pendingLocation.getBlock();
+
+        if (pendingBlock.getType().isSolid()) {
+            Location pendingLocationX = location.clone().add(velocity.getX(), 0, 0);
+            if (pendingLocationX.getBlock().getType().isSolid()) {
                 velocity.setX(0);
             }
-            Location velLocZ = location.clone().add(0, 0, velocity.getZ());
-            if (velLocZ.getBlock().getType().isSolid()) {
+
+            Location pendingLocationY = location.clone().add(0, velocity.getY(), 0);
+            if (pendingLocationY.getBlock().getType().isSolid()) {
+                velocity.setY(0);
+            }
+
+            Location pendingLocationZ = location.clone().add(0, 0, velocity.getZ());
+            if (pendingLocationZ.getBlock().getType().isSolid()) {
                 velocity.setZ(0);
             }
-            collide(block);
+
+            collide(pendingBlock);
         } else {
             if (hasFriction()) {
                 // apply friction and gravity
                 if (location.getBlock().getType() == Material.WATER) {
                     velocity.multiply(liquidDrag);
-                    velocity.setY(velocity.getY() + getGravityAccel().getY() / 4d);
+                    velocity.setY(velocity.getY() + getGravityAccel().getY() / 4);
                 } else if (location.getBlock().getType() == Material.LAVA) {
                     velocity.multiply(liquidDrag - 0.3);
-                    velocity.setY(velocity.getY() + getGravityAccel().getY() / 4d);
+                    velocity.setY(velocity.getY() + getGravityAccel().getY() / 4);
                 } else {
-                    velocity.setY(airDrag * (velocity.getY() + getGravityAccel().getY()));
+                    if (applyDragBeforeAccel) {
+                        velocity.setY(airDrag * velocity.getY() + getGravityAccel().getY());
+                    } else {
+                        velocity.setY(airDrag * (velocity.getY() + getGravityAccel().getY()));
+                    }
+
                     if (isOnGround()) {
                         velocity.setX(velocity.getX() * slipMultiplier);
+                        velocity.setY(0);
                         velocity.setZ(velocity.getZ() * slipMultiplier);
                     } else {
-                        velocity.setX(velocity.getX() * horizontalAirDrag);
-                        velocity.setZ(velocity.getZ() * horizontalAirDrag);
+                        velocity.setX(velocity.getX() * airDrag);
+                        velocity.setZ(velocity.getZ() * airDrag);
                     }
                 }
             } else if (hasGravity() && !isOnGround()) {
                 switch (location.getBlock().getType()) {
                     case WATER:
                     case LAVA:
-                        velocity.setY(velocity.getY() + getGravityAccel().getY() / 4d);
+                        velocity.setY(velocity.getY() + getGravityAccel().getY() / 4);
                         break;
                     default:
-                        velocity.setY(velocity.getY() + getGravityAccel().getY() / 4d);
+                        velocity.setY(velocity.getY() + getGravityAccel().getY() / 4);
                 }
             }
-            setRawLocation(velLoc);
+            setRawLocation(pendingLocation);
         }
     }
 

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -690,8 +690,12 @@ public abstract class GlowEntity implements Entity {
 
         // set entity to be on ground if its bounding box intercepts a solid block in -Y direction
         if (fall && hasDefaultLandingBehavior()) {
-            Vector detectOffset = boundingBox.getSize();
-            Location detectLocation = location.clone().add(0, -detectOffset.getY(), 0);
+            double detectOffsetY = 0;
+            if(boundingBox != null){
+                detectOffsetY = boundingBox.getSize().getY();
+            }
+
+            Location detectLocation = location.clone().add(0, -detectOffsetY, 0);
             setOnGround(detectLocation.getBlock().getType().isSolid());
         }
     }

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -691,7 +691,7 @@ public abstract class GlowEntity implements Entity {
         // set entity to be on ground if its bounding box intercepts a solid block in -Y direction
         if (fall && hasDefaultLandingBehavior()) {
             double detectOffsetY = 0;
-            if(boundingBox != null){
+            if (boundingBox != null) {
                 detectOffsetY = boundingBox.getSize().getY();
             }
 

--- a/src/main/java/net/glowstone/entity/objects/GlowBoat.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowBoat.java
@@ -23,8 +23,10 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.event.vehicle.VehicleDamageEvent;
 import org.bukkit.event.vehicle.VehicleDestroyEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
 
 public class GlowBoat extends GlowEntity implements Boat {
+    private static final double VERTICAL_GRAVITY_ACCEL = -0.04;
 
     @Getter
     private TreeSpecies woodType;
@@ -38,6 +40,8 @@ public class GlowBoat extends GlowEntity implements Boat {
     public GlowBoat(Location location) {
         super(location);
         setSize(1.375f, 0.5625f);
+        setAirDrag(0.95);
+        setGravityAccel(new Vector(0, VERTICAL_GRAVITY_ACCEL, 0));
         setWoodType(TreeSpecies.GENERIC);
     }
 

--- a/src/main/java/net/glowstone/entity/objects/GlowFallingBlock.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowFallingBlock.java
@@ -20,6 +20,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
 public class GlowFallingBlock extends GlowEntity implements FallingBlock {
+    private static final double VERTICAL_GRAVITY_ACCEL = -0.04;
 
     @Getter
     @Setter
@@ -66,8 +67,8 @@ public class GlowFallingBlock extends GlowEntity implements FallingBlock {
         }
         this.sourceLocation = location.clone();
         setBoundingBox(0.98, 0.98);
-        setDrag(0.98, false);
-        setGravityAccel(new Vector(0, -0.02, 0));
+        setAirDrag(0.98);
+        setGravityAccel(new Vector(0, VERTICAL_GRAVITY_ACCEL, 0));
 
         setMaterial(material);
         setDropItem(true);

--- a/src/main/java/net/glowstone/entity/objects/GlowItem.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowItem.java
@@ -29,6 +29,7 @@ import org.bukkit.util.Vector;
  * @author Graham Edgecombe
  */
 public class GlowItem extends GlowEntity implements Item {
+    private static final double VERTICAL_GRAVITY_ACCEL = -0.04;
 
     /**
      * The number of ticks (equal to 5 minutes) that item entities should live for.
@@ -55,9 +56,9 @@ public class GlowItem extends GlowEntity implements Item {
         super(location);
         setItemStack(item);
         setBoundingBox(0.25, 0.25);
-        setDrag(0.98, false);
-        setDrag(0.98, true);
-        setGravityAccel(new Vector(0, -0.02, 0));
+        setAirDrag(0.98);
+        setGravityAccel(new Vector(0, VERTICAL_GRAVITY_ACCEL, 0));
+        setApplyDragBeforeAccel(true);
         pickupDelay = 20;
     }
 

--- a/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
+++ b/src/main/java/net/glowstone/entity/objects/GlowMinecart.java
@@ -32,6 +32,7 @@ import org.bukkit.util.Vector;
 
 // TODO: Implement movement and collision detection.
 public abstract class GlowMinecart extends GlowEntity implements Minecart {
+    private static final double VERTICAL_GRAVITY_ACCEL = -0.04;
 
     @Getter
     @Setter
@@ -66,6 +67,8 @@ public abstract class GlowMinecart extends GlowEntity implements Minecart {
     public GlowMinecart(Location location, MinecartType minecartType) {
         super(location);
         setSize(0.98f, 0.7f);
+        setAirDrag(0.95);
+        setGravityAccel(new Vector(0, VERTICAL_GRAVITY_ACCEL, 0));
         this.minecartType = minecartType;
     }
 

--- a/src/main/java/net/glowstone/entity/passive/GlowChicken.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowChicken.java
@@ -40,7 +40,7 @@ public class GlowChicken extends GlowAnimal implements Chicken {
         super.pulse();
         eggLayTime--;
         if (eggLayTime <= 0) {
-            getWorld().dropItemNaturally(getLocation(), new ItemStack(Material.EGG, 1));
+            getWorld().dropItem(getLocation(), new ItemStack(Material.EGG, 1));
             getWorld().playSound(getLocation(), Sound.ENTITY_CHICKEN_EGG, 1, 1);
             generateEggLayDelay();
         }

--- a/src/main/java/net/glowstone/entity/projectile/GlowArrow.java
+++ b/src/main/java/net/glowstone/entity/projectile/GlowArrow.java
@@ -42,6 +42,8 @@ public class GlowArrow extends GlowProjectile implements Arrow {
     public GlowArrow(Location location) {
         super(location);
         setGravityAccel(new Vector(0, -0.05, 0));
+        setAirDrag(0.99);
+        setApplyDragBeforeAccel(true);
         setBoundingBox(0.5, 0.5);
     }
 

--- a/src/main/java/net/glowstone/entity/projectile/GlowEgg.java
+++ b/src/main/java/net/glowstone/entity/projectile/GlowEgg.java
@@ -26,10 +26,9 @@ public class GlowEgg extends GlowProjectile implements Egg {
      */
     public GlowEgg(Location location) {
         super(location);
-        setDrag(0.99, false);
-        setDrag(0.99, true);
-        setHorizontalAirDrag(1);
+        setAirDrag(0.99);
         setGravityAccel(new Vector(0, VERTICAL_GRAVITY_ACCEL, 0));
+        setApplyDragBeforeAccel(true);
         setVelocity(location.getDirection().multiply(3));
         setBoundingBox(0.25, 0.25);
     }

--- a/src/main/java/net/glowstone/entity/projectile/GlowEnderPearl.java
+++ b/src/main/java/net/glowstone/entity/projectile/GlowEnderPearl.java
@@ -4,6 +4,7 @@ import com.flowpowered.network.Message;
 import io.netty.util.internal.ThreadLocalRandom;
 import java.util.Arrays;
 import java.util.List;
+
 import net.glowstone.entity.monster.GlowEndermite;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
 import net.glowstone.net.message.play.entity.EntityTeleportMessage;
@@ -41,10 +42,9 @@ public class GlowEnderPearl extends GlowProjectile implements EnderPearl {
      */
     public GlowEnderPearl(Location location, float speed) {
         super(location);
-        setDrag(0.99, false);
-        setDrag(0.99, true);
-        setHorizontalAirDrag(1);
+        setAirDrag(0.99);
         setGravityAccel(new Vector(0, VERTICAL_GRAVITY_ACCEL, 0));
+        setApplyDragBeforeAccel(true);
         setVelocity(location.getDirection().multiply(speed));
         setBoundingBox(0.25, 0.25);
     }

--- a/src/main/java/net/glowstone/entity/projectile/GlowSnowball.java
+++ b/src/main/java/net/glowstone/entity/projectile/GlowSnowball.java
@@ -22,10 +22,9 @@ public class GlowSnowball extends GlowProjectile implements Snowball {
      */
     public GlowSnowball(Location location) {
         super(location);
-        setDrag(0.99, false);
-        setDrag(0.99, true);
-        setHorizontalAirDrag(1);
+        setAirDrag(0.99);
         setGravityAccel(new Vector(0, VERTICAL_GRAVITY_ACCEL, 0));
+        setApplyDragBeforeAccel(true);
         setVelocity(location.getDirection().multiply(3));
         setBoundingBox(0.25, 0.25);
     }


### PR DESCRIPTION
This pull request tries to solve the problem that entity trajectory is glitchy, especially when the player breaks a block and the item drops.

The major problem is, in GlowEntity.pulsePhysics(), only one case of the formula is used. According to Wiki, there are actually two cases used on different entities.

> Note that when thrown objects and arrows are simulated, the drag is applied before the acceleration, rather than after; this is why their terminal velocities are whole numbers while the others aren't.
[Entity](https://minecraft.gamepedia.com/Entity#cite_note-thrown-1)

This issue caused the server-side trajectory of many entities differ from the client-side trajectory. The glitchy happens when after the client animated the anticipated trajectory of the second tick, the server sends a different location of the second tick. The difference is significant enough that the client has to "glitch" the entity to the location the server sent. Because for each tick, the anticipated location and the server-calculated location is different, the client has to "glitch" every tick.

Works done:
1. Rewrite GlowEntity.pulsePhysics() to include the missing formula and enhance readability
2. Correct entity physics parameter according to Wiki
3. Small fixes

Known issues:
1. Entity still "vibrates" on the floor

To-do:
1. ~~Implement terminal velocity for entities.~~
2. Use bounding box interception to calculate the exact location where the entity touches the floor. This should solve the "vibration" problem.
3. Fix anything broken caused by 2?
