### PR TITLE
Mules and undead horses cannot breed

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowAgeable.java
+++ b/src/main/java/net/glowstone/entity/GlowAgeable.java
@@ -102,7 +102,7 @@ public class GlowAgeable extends GlowCreature implements Ageable {
     }
 
     @Override
-    public final boolean canBreed() {
+    public boolean canBreed() {
         return age == AGE_ADULT;
     }
 

--- a/src/main/java/net/glowstone/entity/passive/GlowMule.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowMule.java
@@ -13,6 +13,11 @@ public class GlowMule extends GlowChestedHorse<GlowHorseInventory> implements Mu
     }
 
     @Override
+    public boolean canBreed() {
+        return false;
+    }
+
+    @Override
     protected Sound getDeathSound() {
         return Sound.ENTITY_MULE_DEATH;
     }

--- a/src/main/java/net/glowstone/entity/passive/GlowUndeadHorse.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowUndeadHorse.java
@@ -12,6 +12,11 @@ public class GlowUndeadHorse extends GlowAbstractHorse implements AbstractHorse 
     }
 
     @Override
+    public boolean canBreed() {
+        return false;
+    }
+
+    @Override
     public GlowHorseInventory getInventory() {
         return null;
     }

--- a/src/test/java/net/glowstone/entity/GlowAgeableTest.java
+++ b/src/test/java/net/glowstone/entity/GlowAgeableTest.java
@@ -53,7 +53,7 @@ public abstract class GlowAgeableTest<T extends GlowAgeable> extends GlowLivingE
     }
 
     @Test
-    public void testSetAgeAdultCanBreed() {
+    public void testSetAgeAdult() {
         entity.setAge(0);
         assertEquals(0, entity.getAge());
         assertAdult(entity);
@@ -68,7 +68,7 @@ public abstract class GlowAgeableTest<T extends GlowAgeable> extends GlowLivingE
         assertFalse(entity.canBreed());
     }
 
-    private void assertAdult(T ageable) {
+    protected void assertAdult(T ageable) {
         assertTrue(ageable.isAdult());
         // Check that scale is at least 1
         assertTrue(ageable.getWidth() >= ageable.width);

--- a/src/test/java/net/glowstone/entity/passive/GlowMuleTest.java
+++ b/src/test/java/net/glowstone/entity/passive/GlowMuleTest.java
@@ -1,7 +1,41 @@
 package net.glowstone.entity.passive;
 
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 public class GlowMuleTest extends GlowChestedHorseTest<GlowMule> {
     public GlowMuleTest() {
         super(GlowMule::new);
     }
+
+    @Test
+    @Override
+    public void testSetAgeAdult() {
+        entity.setAge(0);
+        assertEquals(0, entity.getAge());
+        assertAdult(entity);
+        assertFalse(entity.canBreed());
+    }
+
+    @Test
+    @Override
+    public void testSetBreedTrueBaby() {
+        entity.setBaby();
+        entity.setBreed(true);
+        assertAdult(entity);
+        assertFalse(entity.canBreed());
+    }
+
+    @Test
+    @Override
+    public void testSetBreedTrueAdult() {
+        entity.setAge(1);
+        assertFalse(entity.canBreed());
+        entity.setBreed(true);
+        assertAdult(entity);
+        assertFalse(entity.canBreed());
+    }
+
 }

--- a/src/test/java/net/glowstone/entity/passive/GlowUndeadHorseTest.java
+++ b/src/test/java/net/glowstone/entity/passive/GlowUndeadHorseTest.java
@@ -2,10 +2,42 @@ package net.glowstone.entity.passive;
 
 import java.util.function.Function;
 import org.bukkit.Location;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public abstract class GlowUndeadHorseTest<T extends GlowUndeadHorse> extends GlowAbstractHorseTest<T> {
     protected GlowUndeadHorseTest(
             Function<Location, ? extends T> entityCreator) {
         super(entityCreator);
+    }
+
+    @Test
+    @Override
+    public void testSetAgeAdult() {
+        entity.setAge(0);
+        assertEquals(0, entity.getAge());
+        assertAdult(entity);
+        assertFalse(entity.canBreed());
+    }
+
+    @Test
+    @Override
+    public void testSetBreedTrueBaby() {
+        entity.setBaby();
+        entity.setBreed(true);
+        assertAdult(entity);
+        assertFalse(entity.canBreed());
+    }
+
+    @Test
+    @Override
+    public void testSetBreedTrueAdult() {
+        entity.setAge(1);
+        assertFalse(entity.canBreed());
+        entity.setBreed(true);
+        assertAdult(entity);
+        assertFalse(entity.canBreed());
     }
 }


### PR DESCRIPTION
Currently, the canBreed method in ageableEntity is returning true if the age is set to AGE_ADULT (basically 0). However, some animals can not breed at all, like mules and skeleton/undead horses.

This PR modifies this in order to always return false for those particular cases.