### PR TITLE
Separate message names from logging levels

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -639,7 +639,7 @@ public class GlowServer implements Server {
 
         if (getProxySupport()) {
             if (getOnlineMode()) {
-                logger.warning("console.proxy.online");
+                LocalizedStrings.Console.Info.Proxy.ONLINE.log();
             } else {
                 LocalizedStrings.Console.Info.PROXY.log();
             }

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -639,7 +639,7 @@ public class GlowServer implements Server {
 
         if (getProxySupport()) {
             if (getOnlineMode()) {
-                logger.warning("console.info.proxy.online");
+                logger.warning("console.proxy.online");
             } else {
                 LocalizedStrings.Console.Info.PROXY.log();
             }

--- a/src/main/java/net/glowstone/i18n/LocalizedStrings.java
+++ b/src/main/java/net/glowstone/i18n/LocalizedStrings.java
@@ -7,184 +7,184 @@ public interface LocalizedStrings {
         interface Error {
             interface Biome {
                 LoggableLocalizedString UNKNOWN = new LoggableLocalizedStringImpl(
-                    "console.error.biome.unknown", Level.SEVERE
+                        "console.biome.unknown", Level.SEVERE
                 );
             }
 
             LoggableLocalizedString CLASSPATH = new LoggableLocalizedStringImpl(
-                "console.error.classpath", Level.WARNING
+                    "console.classpath.error", Level.WARNING
             );
 
             interface Import {
                 LoggableLocalizedString NO_MESSAGE = new LoggableLocalizedStringImpl(
-                    "console.error.import.no-message", Level.WARNING
+                        "console.import.failed.no-message", Level.WARNING
                 );
 
                 LoggableLocalizedString WITH_MESSAGE = new LoggableLocalizedStringImpl(
-                    "console.error.import.with-message", Level.WARNING
+                        "console.import.failed.with-message", Level.WARNING
                 );
             }
 
             LoggableLocalizedString LOOTING_MANAGER = new LoggableLocalizedStringImpl(
-                "console.error.looting-manager", Level.SEVERE
+                    "console.looting-manager.load-failed", Level.SEVERE
             );
 
             interface Permission {
                 LoggableLocalizedString INVALID = new LoggableLocalizedStringImpl(
-                    "console.error.permission.invalid", Level.SEVERE
+                        "console.permission.invalid", Level.SEVERE
                 );
             }
 
             interface Plugin {
                 LoggableLocalizedString LOADING = new LoggableLocalizedStringImpl(
-                    "console.error.plugin.loading", Level.SEVERE
+                        "console.plugin.load-failed", Level.SEVERE
                 );
 
                 LoggableLocalizedString MKDIR = new LoggableLocalizedStringImpl(
-                    "console.error.plugin.mkdir", Level.SEVERE
+                        "console.plugin.mkdir-failed", Level.SEVERE
                 );
             }
 
             interface Profile {
                 LoggableLocalizedString INTERRUPTED = new LoggableLocalizedStringImpl(
-                    "console.error.profile.interrupted", Level.SEVERE
+                        "console.profile.interrupted", Level.SEVERE
                 );
             }
 
             interface Rcon {
                 LoggableLocalizedString BIND_INTERRUPTED = new LoggableLocalizedStringImpl(
-                    "console.error.rcon.bind-interrupted", Level.SEVERE
+                        "console.rcon.bind-interrupted", Level.SEVERE
                 );
             }
 
             LoggableLocalizedString RELOAD = new LoggableLocalizedStringImpl(
-                "console.error.reload", Level.SEVERE
+                    "console.reload-failed", Level.SEVERE
             );
 
             LoggableLocalizedString STARTUP = new LoggableLocalizedStringImpl(
-                "console.error.startup", Level.SEVERE
+                    "console.startup-failed", Level.SEVERE
             );
 
             interface Structure {
                 LoggableLocalizedString UNKNOWN_PIECE_TYPE = new LoggableLocalizedStringImpl(
-                    "console.error.structure.unknown-piece-type", Level.SEVERE
+                        "console.structure.unknown-piece-type", Level.SEVERE
                 );
             }
 
             interface Uuid {
                 LoggableLocalizedString INTERRUPTED = new LoggableLocalizedStringImpl(
-                    "console.error.uuid.interrupted", Level.SEVERE
+                        "console.uuid.interrupted", Level.SEVERE
                 );
             }
         }
 
         interface Info {
             LoggableLocalizedString CONFIG_ONLY_DONE = new LoggableLocalizedStringImpl(
-                "console.info.config-only-done", Level.INFO
+                    "console.config-only-done", Level.INFO
             );
 
             interface Icon {
                 LoggableLocalizedString IMPORT = new LoggableLocalizedStringImpl(
-                    "console.info.icon.import", Level.INFO
+                        "console.icon.import", Level.INFO
                 );
             }
 
             LoggableLocalizedString IMPORT = new LoggableLocalizedStringImpl(
-                "console.info.import", Level.INFO
+                    "console.import", Level.INFO
             );
 
             interface NativeTransport {
                 LoggableLocalizedString EPOLL = new LoggableLocalizedStringImpl(
-                    "console.info.native-transport.epoll", Level.INFO
+                        "console.native-transport.epoll", Level.INFO
                 );
 
                 LoggableLocalizedString KQUEUE = new LoggableLocalizedStringImpl(
-                    "console.info.native-transport.kqueue", Level.INFO
+                        "console.native-transport.kqueue", Level.INFO
                 );
             }
 
             interface Opencl {
                 LoggableLocalizedString BEST = new LoggableLocalizedStringImpl(
-                    "console.info.opencl.best", Level.INFO
+                        "console.opencl.best", Level.INFO
                 );
                 LoggableLocalizedString BEST_VERSION_TIEBREAKER = new LoggableLocalizedStringImpl(
-                    "console.info.opencl.best.version-tiebreaker", Level.INFO
+                        "console.opencl.best.version-tiebreaker", Level.INFO
                 );
 
                 LoggableLocalizedString CPU = new LoggableLocalizedStringImpl(
-                    "console.info.opencl.cpu", Level.INFO
+                        "console.opencl.cpu", Level.INFO
                 );
 
                 LoggableLocalizedString FOUND_DEVICE = new LoggableLocalizedStringImpl(
-                    "console.info.opencl.found-device", Level.INFO
+                        "console.opencl.found-device", Level.INFO
                 );
 
                 LoggableLocalizedString INTEL_GPU = new LoggableLocalizedStringImpl(
-                    "console.info.opencl.intel-gpu", Level.INFO
+                        "console.opencl.intel-gpu", Level.INFO
                 );
 
                 LoggableLocalizedString NO_DEVICE = new LoggableLocalizedStringImpl(
-                    "console.info.opencl.no-device", Level.INFO
+                        "console.opencl.no-device", Level.INFO
                 );
 
                 LoggableLocalizedString REQUIRED_EXTENSIONS = new LoggableLocalizedStringImpl(
-                    "console.info.opencl.required-extensions", Level.INFO
+                        "console.opencl.required-extensions", Level.INFO
                 );
 
                 LoggableLocalizedString REQUIRED_VERSION = new LoggableLocalizedStringImpl(
-                    "console.info.opencl.required-version", Level.INFO
+                        "console.opencl.required-version", Level.INFO
                 );
             }
 
             interface Option {
                 LoggableLocalizedString HELP = new LoggableLocalizedStringImpl(
-                    "console.info.option.help", Level.INFO
+                        "console.option.help", Level.INFO
                 );
             }
 
             interface Plugin {
                 LoggableLocalizedString COUNTS = new LoggableLocalizedStringImpl(
-                    "console.info.plugin.counts", Level.INFO
+                        "console.plugin.counts", Level.INFO
                 );
 
                 LoggableLocalizedString SCANNING = new LoggableLocalizedStringImpl(
-                    "console.info.plugin.scanning", Level.INFO
+                        "console.plugin.scanning", Level.INFO
                 );
             }
 
             LoggableLocalizedString PROXY = new LoggableLocalizedStringImpl(
-                "console.info.proxy", Level.INFO
+                    "console.proxy", Level.INFO
             );
 
             interface Proxy {
                 LoggableLocalizedString ONLINE = new LoggableLocalizedStringImpl(
-                    "console.info.proxy.online", Level.INFO
+                        "console.proxy.online", Level.INFO
                 );
             }
 
             LoggableLocalizedString READY = new LoggableLocalizedStringImpl(
-                "console.info.ready", Level.INFO
+                    "console.ready", Level.INFO
             );
 
             LoggableLocalizedString SAVE = new LoggableLocalizedStringImpl(
-                "console.info.save", Level.INFO
+                    "console.save", Level.INFO
             );
 
             LoggableLocalizedString SHUTDOWN = new LoggableLocalizedStringImpl(
-                "console.info.shutdown", Level.INFO
+                    "console.shutdown", Level.INFO
             );
 
             interface Version {
                 LoggableLocalizedString BUKKIT = new LoggableLocalizedStringImpl(
-                    "console.info.version.bukkit", Level.INFO
+                        "console.version.bukkit", Level.INFO
                 );
 
                 LoggableLocalizedString GLOWSTONE = new LoggableLocalizedStringImpl(
-                    "console.info.version.glowstone", Level.INFO
+                        "console.version.glowstone", Level.INFO
                 );
 
                 LoggableLocalizedString MINECRAFT_CLIENT = new LoggableLocalizedStringImpl(
-                    "console.info.version.minecraft-client", Level.INFO
+                        "console.version.minecraft-client", Level.INFO
                 );
             }
         }
@@ -192,105 +192,105 @@ public interface LocalizedStrings {
         interface Warn {
             interface Event {
                 LoggableLocalizedString INTERRUPTED = new LoggableLocalizedStringImpl(
-                        "console.warn.event.interrupted", Level.WARNING
+                        "console.event.interrupted", Level.WARNING
                 );
 
                 LoggableLocalizedString SHUTDOWN = new LoggableLocalizedStringImpl(
-                        "console.warn.event.shutdown", Level.WARNING
+                        "console.event.shutdown", Level.WARNING
                 );
             }
 
             interface Icon {
                 LoggableLocalizedString LOAD_FAILED_IMPORT = new LoggableLocalizedStringImpl(
-                    "console.warn.icon.load-failed.import", Level.WARNING
+                        "console.icon.load-failed.import", Level.WARNING
                 );
 
                 LoggableLocalizedString LOAD_FAILED = new LoggableLocalizedStringImpl(
-                    "console.warn.icon.load-failed", Level.WARNING
+                        "console.icon.load-failed", Level.WARNING
                 );
             }
 
             LoggableLocalizedString OFFLINE = new LoggableLocalizedStringImpl(
-                "console.warn.offline", Level.WARNING
+                    "console.offline", Level.WARNING
             );
 
             interface Option {
                 LoggableLocalizedString INVALID = new LoggableLocalizedStringImpl(
-                    "console.warn.option.invalid", Level.WARNING
+                        "console.option.invalid", Level.WARNING
                 );
 
                 LoggableLocalizedString NO_VALUE = new LoggableLocalizedStringImpl(
-                    "console.warn.option.no-value", Level.WARNING
+                        "console.option.no-value", Level.WARNING
                 );
             }
 
             interface Permission {
                 LoggableLocalizedString DUPLICATE = new LoggableLocalizedStringImpl(
-                    "console.warn.permission.duplicate", Level.WARNING
+                        "console.permission.duplicate", Level.WARNING
                 );
             }
 
             interface Plugin {
                 LoggableLocalizedString NO_SPONGE = new LoggableLocalizedStringImpl(
-                    "console.warn.plugin.no-sponge", Level.WARNING
+                        "console.plugin.no-sponge", Level.WARNING
                 );
 
                 LoggableLocalizedString UNRECOGNIZED = new LoggableLocalizedStringImpl(
-                    "console.warn.plugin.unrecognized", Level.WARNING
+                        "console.plugin.unrecognized", Level.WARNING
                 );
 
                 LoggableLocalizedString MALFORMED_URL = new LoggableLocalizedStringImpl(
-                        "console.warn.plugin.malformed-url", Level.WARNING
+                        "console.plugin.malformed-url", Level.WARNING
                 );
 
                 LoggableLocalizedString IO = new LoggableLocalizedStringImpl(
-                        "console.warn.plugin.io", Level.WARNING
+                        "console.plugin.ioexception", Level.WARNING
                 );
 
                 LoggableLocalizedString BUKKIT2SPONGE = new LoggableLocalizedStringImpl(
-                    "console.warn.plugin.no-sponge.bukkit2sponge", Level.WARNING
+                        "console.plugin.no-sponge.bukkit2sponge", Level.WARNING
                 );
 
                 LoggableLocalizedString PERMISSION_DUPLICATE = new LoggableLocalizedStringImpl(
-                    "console.warn.plugin.permission.duplicate", Level.WARNING
+                        "console.plugin.permission.duplicate", Level.WARNING
                 );
 
                 LoggableLocalizedString UNSUPPORTED = new LoggableLocalizedStringImpl(
-                    "console.warn.plugin.unsupported", Level.WARNING
+                        "console.plugin.unsupported", Level.WARNING
                 );
 
                 LoggableLocalizedString UNSUPPORTED_CANARY = new LoggableLocalizedStringImpl(
-                    "console.warn.plugin.unsupported.canary", Level.WARNING
+                        "console.plugin.unsupported.canary", Level.WARNING
                 );
 
                 LoggableLocalizedString UNSUPPORTED_FORGE = new LoggableLocalizedStringImpl(
-                    "console.warn.plugin.unsupported.forge", Level.WARNING
+                        "console.plugin.unsupported.forge", Level.WARNING
                 );
 
                 LoggableLocalizedString UNSUPPORTED_OTHER = new LoggableLocalizedStringImpl(
-                    "console.warn.plugin.unsupported.other", Level.WARNING
+                        "console.plugin.unsupported.other", Level.WARNING
                 );
 
                 LoggableLocalizedString UNSUPPORTED_SPONGE = new LoggableLocalizedStringImpl(
-                    "console.warn.plugin.unsupported.sponge", Level.WARNING
+                        "console.plugin.unsupported.sponge", Level.WARNING
                 );
             }
 
             interface Profile {
                 LoggableLocalizedString TIMEOUT = new LoggableLocalizedStringImpl(
-                    "console.warn.profile.timeout", Level.WARNING
+                        "console.profile.timeout", Level.WARNING
                 );
             }
 
             interface Uuid {
                 LoggableLocalizedString TIMEOUT = new LoggableLocalizedStringImpl(
-                    "console.warn.uuid.timeout", Level.WARNING
+                        "console.uuid.timeout", Level.WARNING
                 );
             }
 
             interface WorldGen {
                 LoggableLocalizedString DISABLED = new LoggableLocalizedStringImpl(
-                    "console.warn.worldgen.disabled", Level.WARNING
+                        "console.worldgen.disabled", Level.WARNING
                 );
             }
         }

--- a/src/main/java/net/glowstone/i18n/LocalizedStrings.java
+++ b/src/main/java/net/glowstone/i18n/LocalizedStrings.java
@@ -12,7 +12,7 @@ public interface LocalizedStrings {
             }
 
             LoggableLocalizedString CLASSPATH = new LoggableLocalizedStringImpl(
-                    "console.classpath.error", Level.WARNING
+                    "console.classpath.load-failed", Level.WARNING
             );
 
             interface Import {

--- a/src/main/resources/strings.properties
+++ b/src/main/resources/strings.properties
@@ -1,37 +1,32 @@
 # Notes on the naming convention:
-# Message names beginning with "console.error" are logged at the severe level or directly to System.err.
-# Message names beginning with "console.info" are logged at the info level or directly to System.out.
-# Message names beginning with "console.warn" are logged at the warning level.
+# Message names beginning with "console" are logged or sent to to System.err or System.out. Players other than the
+# server operator won't see them.
 # Message names beginning with "glowstone" are the only ones that can be sent to players; the second-level name of the
 # message is usually the relevant subpackage of net.glowstone.
-console.error.biome.unknown=Unknown biome id: {0}!
-console.error.classpath=Error loading classpath!
-console.error.import.no-message=Import of {0} failed
-console.error.import.with-message=Importing file {0} failed: {1}
-console.error.looting-manager=Failed to load looting manager:
-console.error.permission.invalid=Permission node ''%s'' in permissions config is invalid
-console.error.plugin.loading=Error loading {0}
-console.error.plugin.mkdir=Could not create plugins directory: {0}
-console.error.profile.interrupted=Profile lookup interrupted:
-console.error.rcon.bind-interrupted=Bind interrupted!
-console.error.reload=Uncaught error while reloading
-console.error.startup=Error during server startup.
-console.error.structure.unknown-piece-type=Unknown structure piece type to load: "{0}"
-console.error.uuid.interrupted=UUID lookup interrupted:
-console.info.config-only-done=Configuration files have been loaded, exiting...
-console.info.icon.import=Importing ''{0}'' from Vanilla.
-console.info.import=Importing {0} from {1}
-console.info.native-transport.epoll=Native epoll transport is enabled.
-console.info.native-transport.kqueue=Native kqueue transport is enabled.
-console.info.opencl.best=Device is best platform so far, on {0}
-console.info.opencl.best.version-tiebreaker=Device tied for flops, but had higher version on {0}
-console.info.opencl.cpu=No Intel graphics found, best platform is the best CPU platform we could find...
-console.info.opencl.found-device=Found {0} with {1} flops
-console.info.opencl.intel-gpu=No dGPU found, best platform is the best Intel graphics we could find...
-console.info.opencl.no-device=Your system does not meet the OpenCL requirements for Glowstone. See if driver updates are available.
-console.info.opencl.required-extensions=Required extensions: [ cl_khr_fp64 ]
-console.info.opencl.required-version=Required version: {0}.{1}
-console.info.option.help=Available command-line options:\n\
+console.biome.unknown=Unknown biome id: {0}!
+console.classpath.error=Error loading classpath!
+console.config-only-done=Configuration files have been loaded, exiting...
+console.event.interrupted=Interrupted while handling {0}
+console.event.shutdown=Not handling event {0} due to shutdown
+console.icon.import=Importing ''{0}'' from Vanilla.
+console.icon.load-failed=Failed to load ''{0}''
+console.icon.load-failed.import=Failed to import ''{0}'' from Vanilla
+console.import=Importing {0} from {1}
+console.import.failed.no-message=Import of {0} failed
+console.import.failed.with-message=Importing file {0} failed: {1}
+console.looting-manager.load-failed=Failed to load looting manager:
+console.native-transport.epoll=Native epoll transport is enabled.
+console.native-transport.kqueue=Native kqueue transport is enabled.
+console.offline=The server is running in offline mode! Only do this if you know what you''re doing.
+console.opencl.best=Device is best platform so far, on {0}
+console.opencl.best.version-tiebreaker=Device tied for flops, but had higher version on {0}
+console.opencl.cpu=No Intel graphics found, best platform is the best CPU platform we could find...
+console.opencl.found-device=Found {0} with {1} flops
+console.opencl.intel-gpu=No dGPU found, best platform is the best Intel graphics we could find...
+console.opencl.no-device=Your system does not meet the OpenCL requirements for Glowstone. See if driver updates are available.
+console.opencl.required-extensions=Required extensions: [ cl_khr_fp64 ]
+console.opencl.required-version=Required version: {0}.{1}
+console.option.help=Available command-line options:\n\
   --help, -h, -?                 Shows this help message and exits.\n\
   --version, -v                  Shows version information and exits.\n\
   --generate-config              Generates and loads configuration files, then exits.\n\
@@ -47,37 +42,41 @@ console.info.option.help=Available command-line options:\n\
   --max-players, -M <director>   Sets the maximum amount of players.\n\
   --world-name, -N <name>        Sets the main world name.\n\
   --log-pattern, -L <pattern>    Sets the log file pattern (%D for date).
-console.info.plugin.counts=PluginTypeDetector: found %d Bukkit, %d Sponge, %d Forge, %d Canary, %d unknown plugins (total %d)
-console.info.plugin.scanning=Scanning plugins...
-console.info.proxy=Proxy support is enabled.
-console.info.proxy.online=Proxy support is enabled, but online mode is enabled.
-console.info.ready=Ready for connections.
-console.info.save=Saving world: {0}
-console.info.shutdown=The server is shutting down...
-console.info.version.bukkit=Bukkit version:    {0}
-console.info.version.glowstone=Glowstone version: {0}
-console.info.version.minecraft-client=Minecraft version: {0} protocol {1}
-console.warn.event.interrupted=Interrupted while handling {0}
-console.warn.event.shutdown=Not handling event {0} due to shutdown
-console.warn.icon.load-failed=Failed to load ''{0}''
-console.warn.icon.load-failed.import=Failed to import ''{0}'' from Vanilla
-console.warn.offline=The server is running in offline mode! Only do this if you know what you''re doing.
-console.warn.option.invalid=Ignored invalid option: {0}
-console.warn.option.no-value=Ignored option specified without value: {0}
-console.warn.permission.duplicate=Permission config tried to register ''{0}'' but it''s already registered
-console.warn.plugin.io=PluginTypeDetector: Error reading {0}
-console.warn.plugin.malformed-url=PluginTypeDetector: Malformed URL: {0}
-console.warn.plugin.no-sponge=SpongeAPI plugins found, but no Sponge bridge present! They will be ignored.
-console.warn.plugin.no-sponge.bukkit2sponge=Suggestion: install https://github.com/GlowstoneMC/Bukkit2Sponge to load these plugins
-console.warn.plugin.permission.duplicate=Plugin {0} tried to register permission ''{1}'' but it''s already registered
-console.warn.plugin.unrecognized=Unrecognized plugin: {0}
-console.warn.plugin.unsupported=Unsupported plugin types found, will be ignored:
-console.warn.plugin.unsupported.canary=Canary plugin not supported: {0}
-console.warn.plugin.unsupported.forge=Forge plugin not supported: {0}
-console.warn.plugin.unsupported.other=Unrecognized plugin not supported: {0}
-console.warn.plugin.unsupported.sponge=Ignored SpongeAPI plugin: {0}
-console.warn.profile.timeout=Profile lookup timeout:
-console.warn.uuid.timeout=UUID lookup timeout:
-console.warn.worldgen.disabled=World generation is disabled! World ''{0}'' will be empty.
+console.option.invalid=Ignored invalid option: {0}
+console.option.no-value=Ignored option specified without value: {0}
+console.permission.duplicate=Permission config tried to register ''{0}'' but it''s already registered
+console.permission.invalid=Permission node ''%s'' in permissions config is invalid
+console.plugin.counts=PluginTypeDetector: found %d Bukkit, %d Sponge, %d Forge, %d Canary, %d unknown plugins (total %d)
+console.plugin.ioexception=PluginTypeDetector: Error reading {0}
+console.plugin.load-failed=Error loading {0}
+console.plugin.malformed-url=PluginTypeDetector: Malformed URL: {0}
+console.plugin.mkdir-failed=Could not create plugins directory: {0}
+console.plugin.no-sponge=SpongeAPI plugins found, but no Sponge bridge present! They will be ignored.
+console.plugin.no-sponge.bukkit2sponge=Suggestion: install https://github.com/GlowstoneMC/Bukkit2Sponge to load these plugins
+console.plugin.permission.duplicate=Plugin {0} tried to register permission ''{1}'' but it''s already registered
+console.plugin.scanning=Scanning plugins...
+console.plugin.unrecognized=Unrecognized plugin: {0}
+console.plugin.unsupported=Unsupported plugin types found, will be ignored:
+console.plugin.unsupported.canary=Canary plugin not supported: {0}
+console.plugin.unsupported.forge=Forge plugin not supported: {0}
+console.plugin.unsupported.other=Unrecognized plugin not supported: {0}
+console.plugin.unsupported.sponge=Ignored SpongeAPI plugin: {0}
+console.profile.interrupted=Profile lookup interrupted:
+console.profile.timeout=Profile lookup timeout:
+console.proxy=Proxy support is enabled.
+console.proxy.online=Proxy support is enabled, but online mode is enabled.
+console.rcon.bind-interrupted=Bind interrupted!
+console.ready=Ready for connections.
+console.reload-failed=Uncaught error while reloading
+console.save=Saving world: {0}
+console.shutdown=The server is shutting down...
+console.startup-failed=Error during server startup.
+console.structure.unknown-piece-type=Unknown structure piece type to load: "{0}"
+console.uuid.interrupted=UUID lookup interrupted:
+console.uuid.timeout=UUID lookup timeout:
+console.version.bukkit=Bukkit version:    {0}
+console.version.glowstone=Glowstone version: {0}
+console.version.minecraft-client=Minecraft version: {0} protocol {1}
+console.worldgen.disabled=World generation is disabled! World ''{0}'' will be empty.
 glowstone.advancement.title=Advancements in Glowstone
 glowstone.command.error.unknown-command={0}Unknown command "{1}", try "help"

--- a/src/main/resources/strings.properties
+++ b/src/main/resources/strings.properties
@@ -4,7 +4,7 @@
 # Message names beginning with "glowstone" are the only ones that can be sent to players; the second-level name of the
 # message is usually the relevant subpackage of net.glowstone.
 console.biome.unknown=Unknown biome id: {0}!
-console.classpath.error=Error loading classpath!
+console.classpath.load-failed=Error loading classpath!
 console.config-only-done=Configuration files have been loaded, exiting...
 console.event.interrupted=Interrupted while handling {0}
 console.event.shutdown=Not handling event {0} due to shutdown


### PR DESCRIPTION
This removes ".warn.", ".error." and ".info." from the names of logging messages in `strings.properties`, for several reasons:

1. Console messages about the same subject matter now appear together, even when they are split across multiple logging levels.
2. Calls to the LoggableLocalizedStringImpl constructor already specify the logging level, so embedding it in the name violates the Don't Repeat Yourself and Separation of Concerns principles.
3. If we ever need to change the logging level of a message once multiple locales exist, we then have to update it in *all* versions of the resource file, and we make translators more susceptible to merge conflicts.
4. We may eventually want to use the same message in multiple situations, at different logging levels.

This PR does *not* change the hierarchy inside LocalizedStrings, for two reasons:

1. The current scheme makes it clear what level we're logging at, without having to jump from the calling class to LocalizedStrings. Thus, while it still violates DRY and SoC, in that case it may be a price worth paying for the readability gain.
2. If we *do* start using the same message at multiple logging levels, then each level will need a different LoggableLocalizedString instance, and we'll need to disambiguate between them. The current scheme accomplishes that.