### PR TITLE
Digging fixes

### DIFF
--- a/src/main/java/net/glowstone/block/BuiltinMaterialValueManager.java
+++ b/src/main/java/net/glowstone/block/BuiltinMaterialValueManager.java
@@ -62,7 +62,7 @@ public class BuiltinMaterialValueManager implements MaterialValueManager {
 
         private Object get(String name) {
             Object got = section.get(name);
-            if (got == null) {
+            if (got == null && this != defaultValue) {
                 return defaultValue.get(name);
             }
             return got;
@@ -76,7 +76,8 @@ public class BuiltinMaterialValueManager implements MaterialValueManager {
 
         @Override
         public ToolType getTool() {
-            return ToolType.valueOf((String) get("tool"));
+            String toolName = (String) get("tool");
+            return toolName == null ? null : ToolType.valueOf(toolName);
         }
 
         @Override

--- a/src/main/java/net/glowstone/block/BuiltinMaterialValueManager.java
+++ b/src/main/java/net/glowstone/block/BuiltinMaterialValueManager.java
@@ -1,5 +1,6 @@
 package net.glowstone.block;
 
+import net.glowstone.inventory.ToolType;
 import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -61,6 +62,11 @@ public class BuiltinMaterialValueManager implements MaterialValueManager {
         public float getHardness() {
             float hardness = ((Number) get("hardness")).floatValue();
             return hardness == -1 ? Float.MAX_VALUE : hardness;
+        }
+
+        @Override
+        public ToolType getTool() {
+            return ToolType.valueOf((String) get("tool"));
         }
 
         @Override

--- a/src/main/java/net/glowstone/block/MaterialValueManager.java
+++ b/src/main/java/net/glowstone/block/MaterialValueManager.java
@@ -1,6 +1,6 @@
 package net.glowstone.block;
 
-import net.glowstone.inventory.MaterialMatcher;
+import net.glowstone.inventory.ToolType;
 import org.bukkit.Material;
 
 /**
@@ -32,7 +32,7 @@ public interface MaterialValueManager {
          *
          * @return the tool (or null for none)
          */
-        MaterialMatcher getTool();
+        ToolType getTool();
 
         /**
          * Returns the blast resistance-component of this value.

--- a/src/main/java/net/glowstone/block/MaterialValueManager.java
+++ b/src/main/java/net/glowstone/block/MaterialValueManager.java
@@ -1,5 +1,6 @@
 package net.glowstone.block;
 
+import net.glowstone.inventory.ToolType;
 import org.bukkit.Material;
 
 /**
@@ -22,6 +23,13 @@ public interface MaterialValueManager {
          * @return the hardness (or Float.MAX_VALUE for infinity hardness)
          */
         float getHardness();
+
+        /**
+         * Returns the minimum effective tool type of this value.
+         *
+         * @return the tool (or null for none)
+         */
+        ToolType getTool();
 
         /**
          * Returns the blast resistance-component of this value.

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3422,84 +3422,82 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         // multiplier, etc.). For now, assuming hands are used and the block is not dropped.
         hardness *= 5;
 
-        double completion = (double) diggingTicks / hardness;
-        if (diggingTicks >= completion) {
-            ItemStack tool = getItemInHand();
-            digging.breakNaturally(tool);
-            short durability = tool.getDurability();
-            short maxDurability = tool.getType().getMaxDurability();
-            if (!InventoryUtil.isEmpty(tool) && maxDurability != 0 && durability != maxDurability) {
-                switch (digging.getType()) {
-                    case GRASS:
-                    case DIRT:
-                    case SAND:
-                    case GRAVEL:
-                    case MYCEL:
-                    case SOUL_SAND:
-                        switch (tool.getType()) {
-                            case WOOD_SPADE:
-                            case STONE_SPADE:
-                            case IRON_SPADE:
-                            case GOLD_SPADE:
-                            case DIAMOND_SPADE:
-                                tool.setDurability((short) (durability + 1));
-                                break;
-                            default:
-                                tool.setDurability((short) (durability + 2));
-                                break;
-                        }
-                        break;
-                    case LOG:
-                    case LOG_2:
-                    case WOOD:
-                    case CHEST:
-                        switch (tool.getType()) {
-                            case WOOD_AXE:
-                            case STONE_AXE:
-                            case IRON_AXE:
-                            case GOLD_AXE:
-                            case DIAMOND_AXE:
-                                tool.setDurability((short) (durability + 1));
-                                break;
-                            default:
-                                tool.setDurability((short) (durability + 2));
-                                break;
-                        }
-                        break;
-                    case STONE:
-                    case COBBLESTONE:
-                        switch (tool.getType()) {
-                            case WOOD_PICKAXE:
-                            case STONE_PICKAXE:
-                            case IRON_PICKAXE:
-                            case GOLD_PICKAXE:
-                            case DIAMOND_PICKAXE:
-                                tool.setDurability((short) (durability + 1));
-                                break;
-                            default:
-                                tool.setDurability((short) (durability + 2));
-                                break;
-                        }
-                        break;
-                    default:
-                        tool.setDurability((short) (durability + 2));
-                        break;
-                }
-                if (durability >= maxDurability) {
-                    tool.setType(Material.AIR);
-                }
-                // Force-update item
-                setItemInHand(tool);
+        if (diggingTicks < hardness) {
+            int stage = (int) (10 * (double) diggingTicks / hardness);
+            if (stage > 9) {
+                stage = 9;
             }
-            setDigging(null);
+            broadcastBlockBreakAnimation(digging, stage);
             return;
         }
-        int stage = (int) (completion * 10);
-        if (stage > 9) {
-            stage = 9;
+        ItemStack tool = getItemInHand();
+        digging.breakNaturally(tool);
+        setDigging(null);
+        short durability = tool.getDurability();
+        short maxDurability = tool.getType().getMaxDurability();
+        if (!InventoryUtil.isEmpty(tool) && maxDurability != 0 && durability != maxDurability) {
+            switch (digging.getType()) {
+                case GRASS:
+                case DIRT:
+                case SAND:
+                case GRAVEL:
+                case MYCEL:
+                case SOUL_SAND:
+                    switch (tool.getType()) {
+                        case WOOD_SPADE:
+                        case STONE_SPADE:
+                        case IRON_SPADE:
+                        case GOLD_SPADE:
+                        case DIAMOND_SPADE:
+                            tool.setDurability((short) (durability + 1));
+                            break;
+                        default:
+                            tool.setDurability((short) (durability + 2));
+                            break;
+                    }
+                    break;
+                case LOG:
+                case LOG_2:
+                case WOOD:
+                case CHEST:
+                    switch (tool.getType()) {
+                        case WOOD_AXE:
+                        case STONE_AXE:
+                        case IRON_AXE:
+                        case GOLD_AXE:
+                        case DIAMOND_AXE:
+                            tool.setDurability((short) (durability + 1));
+                            break;
+                        default:
+                            tool.setDurability((short) (durability + 2));
+                            break;
+                    }
+                    break;
+                case STONE:
+                case COBBLESTONE:
+                    switch (tool.getType()) {
+                        case WOOD_PICKAXE:
+                        case STONE_PICKAXE:
+                        case IRON_PICKAXE:
+                        case GOLD_PICKAXE:
+                        case DIAMOND_PICKAXE:
+                            tool.setDurability((short) (durability + 1));
+                            break;
+                        default:
+                            tool.setDurability((short) (durability + 2));
+                            break;
+                    }
+                    break;
+                default:
+                    tool.setDurability((short) (durability + 2));
+                    break;
+            }
+            if (durability >= maxDurability) {
+                tool.setType(Material.AIR);
+            }
+            // Force-update item
+            setItemInHand(tool);
         }
-
-        broadcastBlockBreakAnimation(digging, stage);
     }
 
     /**

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3442,7 +3442,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         logger.info(String.format("Hardness of %s is %d; been digging for %d ticks",
                 digging, totalDiggingTicks, diggingTicks));
         if (diggingTicks < totalDiggingTicks) {
-            int stage = (int) (10 * (double) diggingTicks / hardness);
+            int stage = (int) (10 * (double) diggingTicks / totalDiggingTicks);
             broadcastBlockBreakAnimation(digging, stage);
             return;
         }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3429,8 +3429,6 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             return;
         }
         ItemStack tool = getItemInHand();
-        digging.breakNaturally(tool);
-        setDigging(null);
         short durability = tool.getDurability();
         short maxDurability = tool.getType().getMaxDurability();
         if (!InventoryUtil.isEmpty(tool) && maxDurability != 0 && durability != maxDurability) {
@@ -3495,6 +3493,9 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             }
             // Force-update item
             setItemInHand(tool);
+            // Finally, break the block
+            digging.breakNaturally(tool);
+            setDigging(null);
         }
     }
 

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3404,9 +3404,9 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             if (tool != null) {
                 ToolType effectiveTool = block.getMaterialValues().getTool();
                 Material toolType = tool.getType();
-                if (digging.getType() == Material.WEB && ToolType.SWORD.matches(toolType)) {
+                if (block.getType() == Material.WEB && ToolType.SWORD.matches(toolType)) {
                     breakingTimeMultiplier = 0.1;
-                } else if (digging.getType() == Material.WOOL && toolType == Material.SHEARS) {
+                } else if (block.getType() == Material.WOOL && toolType == Material.SHEARS) {
                     breakingTimeMultiplier = 0.3;
                 } else if (effectiveTool.matches(toolType)) {
                     breakingTimeMultiplier = 1.5 / effectiveTool.getMiningMultiplier();

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3396,10 +3396,8 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         }
         if (block == null) {
             totalDiggingTicks = Long.MAX_VALUE;
-            if (digging != null) {
-                // remove the animation
-                broadcastBlockBreakAnimation(digging, 10);
-            }
+            // remove the animation
+            broadcastBlockBreakAnimation(digging, 10);
         } else {
             double hardness = block.getMaterialValues().getHardness() * 20; // seconds to ticks
             double breakingTimeMultiplier = 5; // default of 5 when using bare hands

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -2,6 +2,7 @@ package net.glowstone.entity;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static net.glowstone.GlowServer.logger;
 
 import com.destroystokyo.paper.Title;
 import com.destroystokyo.paper.profile.PlayerProfile;
@@ -2468,7 +2469,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             session.sendAndRelease(new PluginMessage("MC|StopSound", buffer.array()),
                 buffer);
         } catch (IOException e) {
-            GlowServer.logger.info("Failed to send stop-sound event.");
+            logger.info("Failed to send stop-sound event.");
             e.printStackTrace();
         }
     }
@@ -3421,12 +3422,9 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         // TODO: take into account the tool used to mine (ineffective=5x, effective=1.5x, material
         // multiplier, etc.). For now, assuming hands are used and the block is not dropped.
         hardness *= 5;
-
+        logger.info(String.format("Hardness of %s is %d; been digging for %d ticks", digging, hardness, diggingTicks));
         if (diggingTicks < hardness) {
             int stage = (int) (10 * (double) diggingTicks / hardness);
-            if (stage > 9) {
-                stage = 9;
-            }
             broadcastBlockBreakAnimation(digging, stage);
             return;
         }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3402,7 +3402,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             double breakingTimeMultiplier = 5; // default of 5 when using bare hands
             ItemStack tool = getItemInHand();
             if (tool != null) {
-                ToolType effectiveTool = digging.getMaterialValues().getTool();
+                ToolType effectiveTool = block.getMaterialValues().getTool();
                 Material toolType = tool.getType();
                 if (digging.getType() == Material.WEB && ToolType.SWORD.matches(toolType)) {
                     breakingTimeMultiplier = 0.1;

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3391,6 +3391,9 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
      * @param block the block to start breaking
      */
     public void setDigging(GlowBlock block) {
+        if (block == digging) {
+            return;
+        }
         if (block == null) {
             totalDiggingTicks = Long.MAX_VALUE;
             if (digging != null) {

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -66,12 +66,9 @@ import net.glowstone.entity.passive.GlowFishingHook;
 import net.glowstone.inventory.GlowInventory;
 import net.glowstone.inventory.GlowInventoryView;
 import net.glowstone.inventory.InventoryMonitor;
-<<<<<<< HEAD
 import net.glowstone.inventory.MaterialMatcher;
-import net.glowstone.inventory.crafting.PlayerRecipeMonitor;
-=======
 import net.glowstone.inventory.ToolType;
->>>>>>> satoshinm/hardness2
+import net.glowstone.inventory.crafting.PlayerRecipeMonitor;
 import net.glowstone.io.PlayerDataService.PlayerReader;
 import net.glowstone.map.GlowMapCanvas;
 import net.glowstone.net.GlowSession;
@@ -3401,14 +3398,18 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                 broadcastBlockBreakAnimation(digging, 10);
             }
         } else {
-            float hardness = block.getMaterialValues().getHardness() * 20; // seconds to ticks
-            float breakingTimeMultiplier = 5; // default of 5 when using bare hands
+            double hardness = block.getMaterialValues().getHardness() * 20; // seconds to ticks
+            double breakingTimeMultiplier = 5; // default of 5 when using bare hands
             ItemStack tool = getItemInHand();
             if (tool != null) {
-                MaterialMatcher effectiveTool = digging.getMaterialValues().getTool();
-
-                if (effectiveTool.matches(tool.getType())) {
-                    breakingTimeMultiplier = 1.5f / effectiveTool.getMiningMultiplier();
+                ToolType effectiveTool = digging.getMaterialValues().getTool();
+                Material toolType = tool.getType();
+                if (digging.getType() == Material.WEB && ToolType.SWORD.matches(toolType)) {
+                    breakingTimeMultiplier = 0.1;
+                } else if (digging.getType() == Material.WOOL && toolType == Material.SHEARS) {
+                    breakingTimeMultiplier = 0.3;
+                } else if (effectiveTool.matches(toolType)) {
+                    breakingTimeMultiplier = 1.5 / effectiveTool.getMiningMultiplier();
                 }
             }
             totalDiggingTicks = (long)(breakingTimeMultiplier * hardness);

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -39,7 +39,6 @@ import lombok.Getter;
 import lombok.Setter;
 import net.glowstone.EventFactory;
 import net.glowstone.GlowOfflinePlayer;
-import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
 import net.glowstone.GlowWorldBorder;
 import net.glowstone.block.GlowBlock;
@@ -3422,7 +3421,8 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         // TODO: take into account the tool used to mine (ineffective=5x, effective=1.5x, material
         // multiplier, etc.). For now, assuming hands are used and the block is not dropped.
         hardness *= 5;
-        logger.info(String.format("Hardness of %s is %f; been digging for %d ticks", digging, hardness, diggingTicks));
+        logger.info(String.format("Hardness of %s is %f; been digging for %d ticks",
+                digging, hardness, diggingTicks));
         if (diggingTicks < hardness) {
             int stage = (int) (10 * (double) diggingTicks / hardness);
             broadcastBlockBreakAnimation(digging, stage);

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3492,7 +3492,6 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                 setItemInHand(tool);
             }
             setDigging(null);
-            diggingTicks = 0;
             return;
         }
         int stage = (int) (completion * 10);

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -66,7 +66,6 @@ import net.glowstone.entity.passive.GlowFishingHook;
 import net.glowstone.inventory.GlowInventory;
 import net.glowstone.inventory.GlowInventoryView;
 import net.glowstone.inventory.InventoryMonitor;
-import net.glowstone.inventory.MaterialMatcher;
 import net.glowstone.inventory.ToolType;
 import net.glowstone.inventory.crafting.PlayerRecipeMonitor;
 import net.glowstone.io.PlayerDataService.PlayerReader;

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3422,7 +3422,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         // TODO: take into account the tool used to mine (ineffective=5x, effective=1.5x, material
         // multiplier, etc.). For now, assuming hands are used and the block is not dropped.
         hardness *= 5;
-        logger.info(String.format("Hardness of %s is %d; been digging for %d ticks", digging, hardness, diggingTicks));
+        logger.info(String.format("Hardness of %s is %f; been digging for %d ticks", digging, hardness, diggingTicks));
         if (diggingTicks < hardness) {
             int stage = (int) (10 * (double) diggingTicks / hardness);
             broadcastBlockBreakAnimation(digging, stage);

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -114,6 +114,7 @@ import net.glowstone.net.message.play.player.UseBedMessage;
 import net.glowstone.scoreboard.GlowScoreboard;
 import net.glowstone.scoreboard.GlowTeam;
 import net.glowstone.util.Convert;
+import net.glowstone.util.InventoryUtil;
 import net.glowstone.util.Position;
 import net.glowstone.util.StatisticMap;
 import net.glowstone.util.TextMessage;
@@ -3422,6 +3423,78 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         hardness *= 5;
 
         double completion = (double) diggingTicks / hardness;
+        if (diggingTicks >= completion) {
+            ItemStack tool = getItemInHand();
+            digging.breakNaturally(tool);
+            short durability = tool.getDurability();
+            short maxDurability = tool.getType().getMaxDurability();
+            if (!InventoryUtil.isEmpty(tool) && maxDurability != 0 && durability != maxDurability) {
+                switch (digging.getType()) {
+                    case GRASS:
+                    case DIRT:
+                    case SAND:
+                    case GRAVEL:
+                    case MYCEL:
+                    case SOUL_SAND:
+                        switch (tool.getType()) {
+                            case WOOD_SPADE:
+                            case STONE_SPADE:
+                            case IRON_SPADE:
+                            case GOLD_SPADE:
+                            case DIAMOND_SPADE:
+                                tool.setDurability((short) (durability + 1));
+                                break;
+                            default:
+                                tool.setDurability((short) (durability + 2));
+                                break;
+                        }
+                        break;
+                    case LOG:
+                    case LOG_2:
+                    case WOOD:
+                    case CHEST:
+                        switch (tool.getType()) {
+                            case WOOD_AXE:
+                            case STONE_AXE:
+                            case IRON_AXE:
+                            case GOLD_AXE:
+                            case DIAMOND_AXE:
+                                tool.setDurability((short) (durability + 1));
+                                break;
+                            default:
+                                tool.setDurability((short) (durability + 2));
+                                break;
+                        }
+                        break;
+                    case STONE:
+                    case COBBLESTONE:
+                        switch (tool.getType()) {
+                            case WOOD_PICKAXE:
+                            case STONE_PICKAXE:
+                            case IRON_PICKAXE:
+                            case GOLD_PICKAXE:
+                            case DIAMOND_PICKAXE:
+                                tool.setDurability((short) (durability + 1));
+                                break;
+                            default:
+                                tool.setDurability((short) (durability + 2));
+                                break;
+                        }
+                        break;
+                    default:
+                        tool.setDurability((short) (durability + 2));
+                        break;
+                }
+                if (durability >= maxDurability) {
+                    tool.setType(Material.AIR);
+                }
+                // Force-update item
+                setItemInHand(tool);
+            }
+            setDigging(null);
+            diggingTicks = 0;
+            return;
+        }
         int stage = (int) (completion * 10);
         if (stage > 9) {
             stage = 9;

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -31,6 +31,7 @@ import net.glowstone.entity.meta.profile.PlayerProfile;
 import net.glowstone.entity.objects.GlowItem;
 import net.glowstone.inventory.GlowInventory;
 import net.glowstone.inventory.InventoryMonitor;
+import net.glowstone.inventory.ToolType;
 import net.glowstone.io.PlayerDataService.PlayerReader;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.entity.*;
@@ -2862,9 +2863,23 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
         float hardness = digging.getMaterialValues().getHardness() * 20; // seconds to ticks
 
-        // TODO: take into account the tool used to mine (ineffective=5x, effective=1.5x, material multiplier, etc.)
-        // for now, assuming hands are used and the block is not dropped
-        hardness *= 5;
+        boolean holdingEffectiveTool = false;
+        ItemStack tool = getItemInHand(); // TODO: replace with getItemInMainHand
+        if (tool != null) {
+            ToolType effectiveTool = digging.getMaterialValues().getTool();
+
+            if (effectiveTool.matches(tool.getType())) {
+                holdingEffectiveTool = true;
+            }
+        }
+
+        if (holdingEffectiveTool) {
+            hardness *= 1.5;
+        } else {
+            hardness *= 5;
+        }
+        // TODO: multiply by tool class (1x=nothing, 2x=wood, 4x=stone, 6x=iron, 8x=diamond, 12x=gold)
+
 
         double completion = (double) diggingTicks / hardness;
         int stage = (int) (completion * 10);

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -2863,23 +2863,19 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
         float hardness = digging.getMaterialValues().getHardness() * 20; // seconds to ticks
 
-        boolean holdingEffectiveTool = false;
         ItemStack tool = getItemInHand(); // TODO: replace with getItemInMainHand
         if (tool != null) {
             ToolType effectiveTool = digging.getMaterialValues().getTool();
 
             if (effectiveTool.matches(tool.getType())) {
-                holdingEffectiveTool = true;
+                hardness *= 1.5;
+                hardness *= effectiveTool.getMiningMultiplier();
+            } else {
+                hardness *= 5;
             }
-        }
-
-        if (holdingEffectiveTool) {
-            hardness *= 1.5;
         } else {
             hardness *= 5;
         }
-        // TODO: multiply by tool class (1x=nothing, 2x=wood, 4x=stone, 6x=iron, 8x=diamond, 12x=gold)
-
 
         double completion = (double) diggingTicks / hardness;
         int stage = (int) (completion * 10);

--- a/src/main/java/net/glowstone/inventory/ToolType.java
+++ b/src/main/java/net/glowstone/inventory/ToolType.java
@@ -7,39 +7,49 @@ import org.bukkit.Material;
  */
 public enum ToolType implements MaterialMatcher {
     // Pickaxes
-    DIAMOND_PICKAXE(Material.DIAMOND_PICKAXE, null),
-    IRON_PICKAXE(Material.IRON_PICKAXE, DIAMOND_PICKAXE),
-    STONE_PICKAXE(Material.STONE_PICKAXE, IRON_PICKAXE),
-    GOLD_PICKAXE(Material.GOLD_PICKAXE, STONE_PICKAXE),
-    PICKAXE(Material.WOOD_PICKAXE, GOLD_PICKAXE),
+    DIAMOND_PICKAXE(Material.DIAMOND_PICKAXE, null, ToolMaterial.DIAMOND),
+    IRON_PICKAXE(Material.IRON_PICKAXE, DIAMOND_PICKAXE, ToolMaterial.IRON),
+    STONE_PICKAXE(Material.STONE_PICKAXE, IRON_PICKAXE, ToolMaterial.STONE),
+    GOLD_PICKAXE(Material.GOLD_PICKAXE, STONE_PICKAXE, ToolMaterial.GOLD),
+    PICKAXE(Material.WOOD_PICKAXE, GOLD_PICKAXE, ToolMaterial.WOOD),
 
     //Axes
-    DIAMOND_AXE(Material.DIAMOND_AXE, null),
-    IRON_AXE(Material.IRON_AXE, DIAMOND_AXE),
-    STONE_AXE(Material.STONE_AXE, IRON_AXE),
-    GOLD_AXE(Material.GOLD_AXE, STONE_AXE),
-    AXE(Material.WOOD_AXE, GOLD_AXE),
+    DIAMOND_AXE(Material.DIAMOND_AXE, null, ToolMaterial.DIAMOND),
+    IRON_AXE(Material.IRON_AXE, DIAMOND_AXE, ToolMaterial.IRON),
+    STONE_AXE(Material.STONE_AXE, IRON_AXE, ToolMaterial.STONE),
+    GOLD_AXE(Material.GOLD_AXE, STONE_AXE, ToolMaterial.GOLD),
+    AXE(Material.WOOD_AXE, GOLD_AXE, ToolMaterial.WOOD),
 
     // Spades
-    DIAMOND_SPADE(Material.DIAMOND_SPADE, null),
-    IRON_SPADE(Material.IRON_SPADE, DIAMOND_SPADE),
-    STONE_SPADE(Material.STONE_SPADE, IRON_SPADE),
-    GOLD_SPADE(Material.GOLD_SPADE, STONE_SPADE),
-    SPADE(Material.WOOD_SPADE, GOLD_SPADE),
+    DIAMOND_SPADE(Material.DIAMOND_SPADE, null, ToolMaterial.DIAMOND),
+    IRON_SPADE(Material.IRON_SPADE, DIAMOND_SPADE, ToolMaterial.IRON),
+    STONE_SPADE(Material.STONE_SPADE, IRON_SPADE, ToolMaterial.STONE),
+    GOLD_SPADE(Material.GOLD_SPADE, STONE_SPADE, ToolMaterial.GOLD),
+    SPADE(Material.WOOD_SPADE, GOLD_SPADE, ToolMaterial.WOOD),
 
     // Swords
-    DIAMOND_SWORD(Material.DIAMOND_SWORD, null),
-    IRON_SWORD(Material.IRON_SWORD, DIAMOND_SWORD),
-    STONE_SWORD(Material.STONE_SWORD, IRON_SWORD),
-    GOLD_SWORD(Material.GOLD_SWORD, STONE_SWORD),
-    SWORD(Material.WOOD_SWORD, GOLD_SWORD);
+    DIAMOND_SWORD(Material.DIAMOND_SWORD, null, ToolMaterial.DIAMOND),
+    IRON_SWORD(Material.IRON_SWORD, DIAMOND_SWORD, ToolMaterial.IRON),
+    STONE_SWORD(Material.STONE_SWORD, IRON_SWORD, ToolMaterial.STONE),
+    GOLD_SWORD(Material.GOLD_SWORD, STONE_SWORD, ToolMaterial.GOLD),
+    SWORD(Material.WOOD_SWORD, GOLD_SWORD, ToolMaterial.WOOD),
+
+    // Shears
+    SHEARS(Material.SHEARS, null, ToolMaterial.IRON) {
+        @Override
+        public double getMiningMultiplier() {
+            return 1.5;
+        }
+    };
 
     private final Material bukkitMaterial;
     private final ToolType better;
+    private final ToolMaterial toolMaterial;
 
-    ToolType(Material bukkitMaterial, ToolType better) {
+    ToolType(Material bukkitMaterial, ToolType better, ToolMaterial toolMaterial) {
         this.bukkitMaterial = bukkitMaterial;
         this.better = better;
+        this.toolMaterial = toolMaterial;
     }
 
     /**
@@ -51,5 +61,32 @@ public enum ToolType implements MaterialMatcher {
     @Override
     public boolean matches(Material material) {
         return bukkitMaterial == material || better != null && better.matches(material);
+    }
+
+    /**
+     * Get the factor to multiply mining speed with if this tool is used to mine.
+     *
+     * @return the multiplier
+     */
+    public double getMiningMultiplier() {
+        return this.toolMaterial.getMultiplier();
+    }
+
+    private enum ToolMaterial {
+        WOOD(2),
+        STONE(4),
+        IRON(6),
+        DIAMOND(8),
+        GOLD(12);
+
+        private final int multiplier;
+
+        ToolMaterial(int multiplier) {
+            this.multiplier = multiplier;
+        }
+
+        public int getMultiplier() {
+            return this.multiplier;
+        }
     }
 }

--- a/src/main/java/net/glowstone/inventory/ToolType.java
+++ b/src/main/java/net/glowstone/inventory/ToolType.java
@@ -1,5 +1,7 @@
 package net.glowstone.inventory;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.bukkit.Material;
 
 /**
@@ -35,12 +37,7 @@ public enum ToolType implements MaterialMatcher {
     SWORD(Material.WOOD_SWORD, GOLD_SWORD, ToolMaterial.WOOD),
 
     // Shears
-    SHEARS(Material.SHEARS, null, ToolMaterial.IRON) {
-        @Override
-        public double getMiningMultiplier() {
-            return 1.5;
-        }
-    };
+    SHEARS(Material.SHEARS, null, ToolMaterial.SHEARS);
 
     private final Material bukkitMaterial;
     private final ToolType better;
@@ -72,21 +69,16 @@ public enum ToolType implements MaterialMatcher {
         return this.toolMaterial.getMultiplier();
     }
 
+    @RequiredArgsConstructor
     private enum ToolMaterial {
         WOOD(2),
         STONE(4),
         IRON(6),
         DIAMOND(8),
-        GOLD(12);
+        GOLD(12),
+        SHEARS(1.5);
 
-        private final int multiplier;
-
-        ToolMaterial(int multiplier) {
-            this.multiplier = multiplier;
-        }
-
-        public int getMultiplier() {
-            return this.multiplier;
-        }
+        @Getter
+        private final double multiplier;
     }
 }

--- a/src/main/java/net/glowstone/inventory/ToolType.java
+++ b/src/main/java/net/glowstone/inventory/ToolType.java
@@ -7,39 +7,41 @@ import org.bukkit.Material;
  */
 public enum ToolType implements MaterialMatcher {
     // Pickaxes
-    DIAMOND_PICKAXE(Material.DIAMOND_PICKAXE, null),
-    IRON_PICKAXE(Material.IRON_PICKAXE, DIAMOND_PICKAXE),
-    STONE_PICKAXE(Material.STONE_PICKAXE, IRON_PICKAXE),
-    GOLD_PICKAXE(Material.GOLD_PICKAXE, STONE_PICKAXE),
-    PICKAXE(Material.WOOD_PICKAXE, GOLD_PICKAXE),
+    DIAMOND_PICKAXE(Material.DIAMOND_PICKAXE, null, ToolMaterial.DIAMOND),
+    IRON_PICKAXE(Material.IRON_PICKAXE, DIAMOND_PICKAXE, ToolMaterial.IRON),
+    STONE_PICKAXE(Material.STONE_PICKAXE, IRON_PICKAXE, ToolMaterial.STONE),
+    GOLD_PICKAXE(Material.GOLD_PICKAXE, STONE_PICKAXE, ToolMaterial.GOLD),
+    PICKAXE(Material.WOOD_PICKAXE, GOLD_PICKAXE, ToolMaterial.WOOD),
 
     //Axes
-    DIAMOND_AXE(Material.DIAMOND_AXE, null),
-    IRON_AXE(Material.IRON_AXE, DIAMOND_AXE),
-    STONE_AXE(Material.STONE_AXE, IRON_AXE),
-    GOLD_AXE(Material.GOLD_AXE, STONE_AXE),
-    AXE(Material.WOOD_AXE, GOLD_AXE),
+    DIAMOND_AXE(Material.DIAMOND_AXE, null, ToolMaterial.DIAMOND),
+    IRON_AXE(Material.IRON_AXE, DIAMOND_AXE, ToolMaterial.IRON),
+    STONE_AXE(Material.STONE_AXE, IRON_AXE, ToolMaterial.STONE),
+    GOLD_AXE(Material.GOLD_AXE, STONE_AXE, ToolMaterial.GOLD),
+    AXE(Material.WOOD_AXE, GOLD_AXE, ToolMaterial.WOOD),
 
     // Spades
-    DIAMOND_SPADE(Material.DIAMOND_SPADE, null),
-    IRON_SPADE(Material.IRON_SPADE, DIAMOND_SPADE),
-    STONE_SPADE(Material.STONE_SPADE, IRON_SPADE),
-    GOLD_SPADE(Material.GOLD_SPADE, STONE_SPADE),
-    SPADE(Material.WOOD_SPADE, GOLD_SPADE),
+    DIAMOND_SPADE(Material.DIAMOND_SPADE, null, ToolMaterial.DIAMOND),
+    IRON_SPADE(Material.IRON_SPADE, DIAMOND_SPADE, ToolMaterial.IRON),
+    STONE_SPADE(Material.STONE_SPADE, IRON_SPADE, ToolMaterial.STONE),
+    GOLD_SPADE(Material.GOLD_SPADE, STONE_SPADE, ToolMaterial.GOLD),
+    SPADE(Material.WOOD_SPADE, GOLD_SPADE, ToolMaterial.WOOD),
 
     // Swords
-    DIAMOND_SWORD(Material.DIAMOND_SWORD, null),
-    IRON_SWORD(Material.IRON_SWORD, DIAMOND_SWORD),
-    STONE_SWORD(Material.STONE_SWORD, IRON_SWORD),
-    GOLD_SWORD(Material.GOLD_SWORD, STONE_SWORD),
-    SWORD(Material.WOOD_SWORD, GOLD_SWORD);
+    DIAMOND_SWORD(Material.DIAMOND_SWORD, null, ToolMaterial.DIAMOND),
+    IRON_SWORD(Material.IRON_SWORD, DIAMOND_SWORD, ToolMaterial.IRON),
+    STONE_SWORD(Material.STONE_SWORD, IRON_SWORD, ToolMaterial.STONE),
+    GOLD_SWORD(Material.GOLD_SWORD, STONE_SWORD, ToolMaterial.GOLD),
+    SWORD(Material.WOOD_SWORD, GOLD_SWORD, ToolMaterial.WOOD);
 
     private final Material bukkitMaterial;
     private final ToolType better;
+    private final ToolMaterial toolMaterial;
 
-    ToolType(Material bukkitMaterial, ToolType better) {
+    ToolType(Material bukkitMaterial, ToolType better, ToolMaterial toolMaterial) {
         this.bukkitMaterial = bukkitMaterial;
         this.better = better;
+        this.toolMaterial = toolMaterial;
     }
 
     /**
@@ -51,5 +53,32 @@ public enum ToolType implements MaterialMatcher {
     @Override
     public boolean matches(Material material) {
         return bukkitMaterial == material || better != null && better.matches(material);
+    }
+
+    /**
+     * Get the factor to multiply mining speed with if this tool is used to mine.
+     *
+     * @return the multiplier
+     */
+    public int getMiningMultiplier() {
+        return this.toolMaterial.getMultiplier();
+    }
+
+    private enum ToolMaterial {
+        WOOD(2),
+        STONE(4),
+        IRON(6),
+        DIAMOND(8),
+        GOLD(12);
+
+        private final int multiplier;
+
+        ToolMaterial(int multiplier) {
+            this.multiplier = multiplier;
+        }
+
+        public int getMultiplier() {
+            return this.multiplier;
+        }
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -51,6 +51,9 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
         boolean blockBroken = false;
         boolean revert = false;
         if (message.getState() == DiggingMessage.START_DIGGING) {
+            if (block.equals(player.getDigging())) {
+                return;
+            }
             // call interact event
             Action action = Action.LEFT_CLICK_BLOCK;
             Block eventBlock = block;

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -51,7 +51,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
         boolean blockBroken = false;
         boolean revert = false;
         if (message.getState() == DiggingMessage.START_DIGGING) {
-            if (block.equals(player.getDigging())) {
+            if (block.equals(player.getDigging()) || block.isLiquid()) {
                 return;
             }
             // call interact event

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -96,78 +96,12 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
         } else if (message.getState() == DiggingMessage.CANCEL_DIGGING) {
             player.setDigging(null);
         } else if (message.getState() == DiggingMessage.FINISH_DIGGING) {
-            // shouldn't happen in creative mode
-
-            // todo: verification against malicious clients
-            blockBroken = block.equals(player.getDigging());
-
-            if (blockBroken && holding.getType().getMaxDurability() != 0
-                && holding.getType() != Material.AIR && holding.getDurability() != holding.getType()
-                .getMaxDurability()) {
-                switch (block.getType()) {
-                    case GRASS:
-                    case DIRT:
-                    case SAND:
-                    case GRAVEL:
-                    case MYCEL:
-                    case SOUL_SAND:
-                        switch (holding.getType()) {
-                            case WOOD_SPADE:
-                            case STONE_SPADE:
-                            case IRON_SPADE:
-                            case GOLD_SPADE:
-                            case DIAMOND_SPADE:
-                                holding.setDurability((short) (holding.getDurability() + 1));
-                                break;
-                            default:
-                                holding.setDurability((short) (holding.getDurability() + 2));
-                                break;
-                        }
-                        break;
-                    case LOG:
-                    case LOG_2:
-                    case WOOD:
-                    case CHEST:
-                        switch (holding.getType()) {
-                            case WOOD_AXE:
-                            case STONE_AXE:
-                            case IRON_AXE:
-                            case GOLD_AXE:
-                            case DIAMOND_AXE:
-                                holding.setDurability((short) (holding.getDurability() + 1));
-                                break;
-                            default:
-                                holding.setDurability((short) (holding.getDurability() + 2));
-                                break;
-                        }
-                        break;
-                    case STONE:
-                    case COBBLESTONE:
-                        switch (holding.getType()) {
-                            case WOOD_PICKAXE:
-                            case STONE_PICKAXE:
-                            case IRON_PICKAXE:
-                            case GOLD_PICKAXE:
-                            case DIAMOND_PICKAXE:
-                                holding.setDurability((short) (holding.getDurability() + 1));
-                                break;
-                            default:
-                                holding.setDurability((short) (holding.getDurability() + 2));
-                                break;
-                        }
-                        break;
-                    default:
-                        holding.setDurability((short) (holding.getDurability() + 2));
-                        break;
-                }
-                if (holding.getType().getMaxDurability() != 0 && holding.getDurability() >= holding
-                    .getType().getMaxDurability()) {
-                    holding.setType(Material.AIR);
-                }
-                // Force-update item
-                player.setItemInHand(holding);
+            // Update client with block if digging isn't actually finished
+            // (FINISH_DIGGING is client's guess based on wall-clock time, not ticks, and is
+            // untrusted)
+            if (!block.isEmpty()) {
+                player.sendBlockChange(block.getLocation(), block.getType(), block.getData());
             }
-            player.setDigging(null);
         } else if (message.getState() == DiggingMessage.STATE_DROP_ITEM) {
             player.dropItemInHand(false);
             return;

--- a/src/main/resources/builtin/materialValues.yml
+++ b/src/main/resources/builtin/materialValues.yml
@@ -84,6 +84,7 @@ values:
     hardness: 2
     blastResistance: 10
   LEAVES:
+    tool: SHEARS
     lightOpacity: 1
     flameResistance: 30
     fireResistance: 60
@@ -132,6 +133,7 @@ values:
     hardness: 0.5
     blastResistance: 2.5
   WEB:
+    tool: SHEARS
     lightOpacity: 1
     hardness: 4
     blastResistance: 20
@@ -154,6 +156,7 @@ values:
     hardness: 0.5
     blastResistance: 2.5
   WOOL:
+    tool: SHEARS
     flameResistance: 30
     fireResistance: 60
     hardness: 0.8

--- a/src/main/resources/builtin/materialValues.yml
+++ b/src/main/resources/builtin/materialValues.yml
@@ -22,6 +22,7 @@ values:
     hardness: 0.6
     baseMapColor: 4
   DIRT:
+    tool: SPADE
     blastResistance: 2.5
     hardness: 0.5
     baseMapColor: 40

--- a/src/main/resources/builtin/materialValues.yml
+++ b/src/main/resources/builtin/materialValues.yml
@@ -8,18 +8,22 @@ values:
   AIR:
     lightOpacity: 0
   STONE:
+    tool: PICKAXE
     blastResistance: 30
     hardness: 1.5
   GRASS:
+    tool: SPADE
     blastResistance: 3
     hardness: 0.6
   DIRT:
     blastResistance: 2.5
     hardness: 0.5
   COBBLESTONE:
+    tool: PICKAXE
     blastResistance: 30
     hardness: 2
   WOOD:
+    tool: AXE
     flameResistance: 5
     fireResistance: 20
     hardness: 2
@@ -42,16 +46,21 @@ values:
     lightOpacity: 0
     hardness: 100
   SAND:
+    tool: SPADE
     hardness: 0.5
   GRAVEL:
+    tool: SPADE
     hardness: 0.6
   GOLD_ORE:
     hardness: 3
   IRON_ORE:
+    tool: PICKAXE
     hardness: 3
   COAL_ORE:
+    tool: PICKAXE
     hardness: 3
   LOG:
+    tool: AXE
     flameResistance: 5
     fireResistance: 5
     hardness: 2
@@ -66,14 +75,19 @@ values:
     lightOpacity: 0
     hardness: 0.3
   LAPIS_ORE:
+    tool: STONE_PICKAXE
     hardness: 3
   LAPIS_BLOCK:
+    tool: STONE_PICKAXE
     hardness: 3
   DISPENSER:
+    tool: PICKAXE
     hardness: 3.5
   SANDSTONE:
+    tool: PICKAXE
     hardness: 0.8
   NOTE_BLOCK:
+    tool: AXE
     hardness: 0.8
   BED_BLOCK:
     lightOpacity: 0
@@ -130,27 +144,35 @@ values:
     hardness: 0
     lightOpacity: 0
   GOLD_BLOCK:
+    tool: IRON_PICKAXE
     hardness: 3
   IRON_BLOCK:
+    tool: STONE_PICKAXE
     hardness: 5
   DOUBLE_STEP:
+    tool: AXE
     hardness: 2
   STEP:
+    tool: PICKAXE
     lightOpacity: 0
     hardness: 2
   BRICK:
+    tool: PICKAXE
     hardness: 2
   TNT:
     hardness: 0
     flameResistance: 15
     fireResistance: 100
   BOOKSHELF:
+    tool: AXE
     flameResistance: 30
     fireResistance: 20
     hardness: 1.5
   MOSSY_COBBLESTONE:
+    tool: PICKAXE
     hardness: 2
   OBSIDIAN:
+    tool: DIAMOND_PICKAXE
     hardness: 50
     blastResistance: 6000
   TORCH:
@@ -160,66 +182,84 @@ values:
     lightOpacity: 0
     hardness: 0
   MOB_SPAWNER:
+    tool: PICKAXE
     lightOpacity: 0
     hardness: 5
   WOOD_STAIRS:
+    tool: AXE
     lightOpacity: 0
     flameResistance: 5
     fireResistance: 20
     hardness: 2
   CHEST:
+    tool: AXE
     lightOpacity: 0
     hardness: 2.5
   REDSTONE_WIRE:
     hardness: 0
     lightOpacity: 0
   DIAMOND_ORE:
+    tool: IRON_PICKAXE
     hardness: 3
   DIAMOND_BLOCK:
+    tool: IRON_PICKAXE
     hardness: 5
   WORKBENCH:
+    tool: AXE
     hardness: 2.5
   CROPS:
     hardness: 0
     lightOpacity: 0
   SOIL:
+    tool: SPADE
     lightOpacity: 0
     hardness: 0.6
   FURNACE:
+    tool: PICKAXE
     hardness: 3.5
   BURNING_FURNACE:
     hardness: 3.5
   SIGN_POST:
+    tool: AXE
     lightOpacity: 0
     hardness: 1
   WOODEN_DOOR:
+    tool: AXE
     lightOpacity: 0
     hardness: 3
   LADDER:
+    tool: AXE
     lightOpacity: 0
     hardness: 0.4
   RAILS:
+    tool: PICKAXE
     lightOpacity: 0
     hardness: 0.7
   COBBLESTONE_STAIRS:
+    tool: PICKAXE
     hardness: 2
     lightOpacity: 0
   WALL_SIGN:
+    tool: AXE
     hardness: 1
     lightOpacity: 0
   LEVER:
     hardness: 0.5
     lightOpacity: 0
   STONE_PLATE:
+    tool: PICKAXE
     hardness: 0.5
     lightOpacity: 0
   IRON_DOOR_BLOCK:
+    tool: PICKAXE
     hardness: 5
     lightOpacity: 0
   WOOD_PLATE:
+    tool: AXE
     hardness: 2
     lightOpacity: 0
   REDSTONE_ORE:
+    tool: IRON_PICKAXE
     hardness: 3
   GLOWING_REDSTONE_ORE:
     hardness: 3
@@ -233,9 +273,11 @@ values:
     hardness: 0.5
     lightOpacity: 0
   SNOW:
+    tool: SPADE
     hardness: 0.1
     lightOpacity: 0
   ICE:
+    tool: PICKAXE
     hardness: 0.5
     lightOpacity: 3
   SNOW_BLOCK:
@@ -244,20 +286,26 @@ values:
     hardness: 0.4
     lightOpacity: 0
   CLAY:
+    tool: SPADE
     hardness: 0.6
   SUGAR_CANE_BLOCK:
     hardness: 0
     lightOpacity: 0
   JUKEBOX:
+    tool: AXE
     hardness: 2
   FENCE:
+    tool: AXE
     hardness: 2
     lightOpacity: 0
   PUMPKIN:
+    tool: AXE
     hardness: 1
   NETHERRACK:
+    tool: PICKAXE
     hardness: 0.4
   SOUL_SAND:
+    tool: SPADE
     hardness: 0.5
   GLOWSTONE:
     hardness: 0.3
@@ -265,6 +313,7 @@ values:
     lightOpacity: 0
     hardness: -1
   JACK_O_LANTERN:
+    tool: AXE
     hardness: 1
   CAKE_BLOCK:
     hardness: 0.5
@@ -279,23 +328,29 @@ values:
     hardness: 0.3
     lightOpacity: 0
   TRAP_DOOR:
+    tool: AXE
     hardness: 3
     lightOpacity: 0
   MONSTER_EGGS:
     hardness: 0.75
   SMOOTH_BRICK:
+    tool: PICKAXE
     hardness: 1.5
   HUGE_MUSHROOM_1:
+    tool: AXE
     hardness: 0.2
   HUGE_MUSHROOM_2:
+    tool: AXE
     hardness: 0.2
   IRON_FENCE:
+    tool: PICKAXE
     hardness: 5
     lightOpacity: 0
   THIN_GLASS:
     hardness: 0.3
     lightOpacity: 0
   MELON_BLOCK:
+    tool: AXE
     hardness: 1
   PUMPKIN_STEM:
     hardness: 0
@@ -304,41 +359,52 @@ values:
     hardness: 0
     lightOpacity: 0
   VINE:
+    tool: AXE
     hardness: 0.2
     lightOpacity: 0
     flameResistance: 15
     fireResistance: 100
   FENCE_GATE:
+    tool: AXE
     hardness: 2
     lightOpacity: 0
   BRICK_STAIRS:
+    tool: PICKAXE
     hardness: 2
     lightOpacity: 0
   SMOOTH_STAIRS:
+    tool: PICKAXE
     hardness: 1.5
     lightOpacity: 0
   MYCEL:
+    tool: SPADE
     hardness: 0.6
   WATER_LILY:
     lightOpacity: 0
   NETHER_BRICK:
+    tool: PICKAXE
     hardness: 2
   NETHER_FENCE:
+    tool: PICKAXE
     hardness: 2
     lightOpacity: 0
   NETHER_BRICK_STAIRS:
+    tool: PICKAXE
     hardness: 2
     lightOpacity: 0
   NETHER_WARTS:
     hardness: 0
     lightOpacity: 0
   ENCHANTMENT_TABLE:
+    tool: PICKAXE
     hardness: 5
     lightOpacity: 0
   BREWING_STAND:
+    tool: PICKAXE
     hardness: 0.5
     lightOpacity: 0
   CAULDRON:
+    tool: PICKAXE
     hardness: 2
     lightOpacity: 0
   ENDER_PORTAL:
@@ -348,6 +414,7 @@ values:
     hardness: -1
     lightOpacity: 0
   ENDER_STONE:
+    tool: PICKAXE
     hardness: 3
   DRAGON_EGG:
     hardness: 3
@@ -366,14 +433,18 @@ values:
     flameResistance: 5
     fireResistance: 20
   COCOA:
+    tool: AXE
     hardness: 0.2
     lightOpacity: 0
   SANDSTONE_STAIRS:
+    tool: PICKAXE
     hardness: 0.8
     lightOpacity: 0
   EMERALD_ORE:
+    tool: IRON_PICKAXE
     hardness: 3
   ENDER_CHEST:
+    tool: PICKAXE
     hardness: 22.5
     lightOpacity: 0
   TRIPWIRE_HOOK:
@@ -383,6 +454,7 @@ values:
     hardness: 0
     lightOpacity: 0
   EMERALD_BLOCK:
+    tool: IRON_PICKAXE
     hardness: 5
   SPRUCE_WOOD_STAIRS:
     hardness: 2
@@ -405,6 +477,7 @@ values:
     hardness: 3
     lightOpacity: 0
   COBBLE_WALL:
+    tool: PICKAXE
     hardness: 2
     lightOpacity: 0
   FLOWER_POT:
@@ -423,15 +496,19 @@ values:
     hardness: 1
     lightOpacity: 0
   ANVIL:
+    tool: PICKAXE
     hardness: 5
     lightOpacity: 0
   TRAPPED_CHEST:
+    tool: AXE
     hardness: 2.5
     lightOpacity: 0
   GOLD_PLATE:
+    tool: PICKAXE
     hardness: 0.5
     lightOpacity: 0
   IRON_PLATE:
+    tool: PICKAXE
     hardness: 0.5
     lightOpacity: 0
   REDSTONE_COMPARATOR_OFF:
@@ -441,24 +518,31 @@ values:
     hardness: 0
     lightOpacity: 0
   DAYLIGHT_DETECTOR:
+    tool: AXE
     hardness: 0.2
     lightOpacity: 0
   REDSTONE_BLOCK:
+    tool: PICKAXE
     hardness: 5
   QUARTZ_ORE:
+    tool: PICKAXE
     hardness: 3
   HOPPER:
+    tool: PICKAXE
     hardness: 3
     lightOpacity: 0
   QUARTZ_BLOCK:
+    tool: PICKAXE
     hardness: 0.8
   QUARTZ_STAIRS:
+    tool: PICKAXE
     hardness: 0.8
     lightOpacity: 0
   ACTIVATOR_RAIL:
     hardness: 0.7
     lightOpacity: 0
   DROPPER:
+    tool: PICKAXE
     hardness: 3.5
   STAINED_CLAY:
     hardness: 1.4
@@ -489,9 +573,11 @@ values:
   BARRIER:
     hardness: -1
   IRON_TRAPDOOR:
+    tool: PICKAXE
     hardness: 5
     lightOpacity: 0
   PRISMARINE:
+    tool: PICKAXE
     hardness: 1.5
   SEA_LANTERN:
     hardness: 0.3
@@ -507,10 +593,12 @@ values:
   HARD_CLAY:
     hardness: 1.25
   COAL_BLOCK:
+    tool: PICKAXE
     hardness: 5
     flameResistance: 5
     fireResistance: 5
   PACKED_ICE:
+    tool: PICKAXE
     hardness: 0.5
   DOUBLE_PLANT:
     lightOpacity: 0
@@ -518,15 +606,19 @@ values:
     fireResistance: 100
     hardness: 0
   STANDING_BANNER:
+    tool: AXE
     hardness: 1
   WALL_BANNER:
+    tool: AXE
     hardness: 1
   DAYLIGHT_DETECTOR_INVERTED:
     hardness: 0.2
     lightOpacity: 0
   RED_SANDSTONE:
+    tool: PICKAXE
     hardness: 0.8
   RED_SANDSTONE_STAIRS:
+    tool: PICKAXE
     hardness: 0.8
     lightOpacity: 0
   SPRUCE_FENCE_GATE:
@@ -580,17 +672,22 @@ values:
     flameResistance: 5
     fireResistance: 20
   SPRUCE_DOOR:
+    tool: AXE
     hardness: 3
     lightOpacity: 0
   BIRCH_DOOR:
+    tool: AXE
     hardness: 3
     lightOpacity: 0
   JUNGLE_DOOR:
+    tool: AXE
     hardness: 3
     lightOpacity: 0
   ACACIA_DOOR:
+    tool: AXE
     hardness: 3
     lightOpacity: 0
   DARK_OAK_DOOR:
+    tool: AXE
     hardness: 3
     lightOpacity: 0


### PR DESCRIPTION
Fixes #852, fixes #506

Block breaking now finishes when the correct number of ticks have elapsed, not when we receive a FINISH_DIGGING message. The response to a premature FINISH_DIGGING is now to re-send the affected block. We also now ignore START_DIGGING on the block we're already digging (which can happen if the client thinks digging is finished when it isn't and the player is still holding left-click).