### PR TITLE
Refactors to reduce nesting depth

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockLeaves.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLeaves.java
@@ -85,70 +85,73 @@ public class BlockLeaves extends BlockType {
     @Override
     public void updateBlock(GlowBlock block) {
         GlowBlockState state = block.getState();
-        if ((state.getRawData() & 0x08) != 0
-            && (state.getRawData() & 0x04) == 0) { // check decay is on and decay is on
-            GlowWorld world = block.getWorld();
+        if ((state.getRawData() & 0x08) == 0
+                || (state.getRawData() & 0x04) != 0) {
+            // check decay is off or decay is off
+            return;
+        }
+        GlowWorld world = block.getWorld();
 
-            // build a 9x9x9 box to map neighboring blocks
+        // build a 9x9x9 box to map neighboring blocks
+        for (int x = 0; x < 9; x++) {
+            for (int z = 0; z < 9; z++) {
+                for (int y = 0; y < 9; y++) {
+                    GlowBlock b = world
+                        .getBlockAt(block.getLocation().add(x - 4, y - 4, z - 4));
+                    byte val = 127;
+                    if (b.getType() == Material.LOG || b.getType() == Material.LOG_2) {
+                        val = 0;
+                    } else if (b.getType() == Material.LEAVES
+                        || b.getType() == Material.LEAVES_2) {
+                        val = -1;
+                    }
+                    setBlockInMap(val, x, y, z);
+                }
+            }
+        }
+
+        // browse the map in several pass to detect connected leaves:
+        // leaf block that is 5 blocks away from log or without connection
+        // to another connected leaves block will decay
+        for (int i = 0; i < 4; i++) {
             for (int x = 0; x < 9; x++) {
                 for (int z = 0; z < 9; z++) {
                     for (int y = 0; y < 9; y++) {
-                        GlowBlock b = world
-                            .getBlockAt(block.getLocation().add(x - 4, y - 4, z - 4));
-                        byte val = 127;
-                        if (b.getType() == Material.LOG || b.getType() == Material.LOG_2) {
-                            val = 0;
-                        } else if (b.getType() == Material.LEAVES
-                            || b.getType() == Material.LEAVES_2) {
-                            val = -1;
+                        if (getBlockInMap(x, y, z) != i) {
+                            continue;
                         }
-                        setBlockInMap(val, x, y, z);
-                    }
-                }
-            }
-
-            // browse the map in several pass to detect connected leaves:
-            // leaf block that is 5 blocks away from log or without connection
-            // to another connected leaves block will decay
-            for (int i = 0; i < 4; i++) {
-                for (int x = 0; x < 9; x++) {
-                    for (int z = 0; z < 9; z++) {
-                        for (int y = 0; y < 9; y++) {
-                            if (getBlockInMap(x, y, z) == i) {
-                                if (getBlockInMap(x - 1, y, z) == -1) {
-                                    setBlockInMap((byte) (i + 1), x - 1, y, z);
-                                }
-                                if (getBlockInMap(x, y - 1, z) == -1) {
-                                    setBlockInMap((byte) (i + 1), x, y - 1, z);
-                                }
-                                if (getBlockInMap(x, y, z - 1) == -1) {
-                                    setBlockInMap((byte) (i + 1), x, y, z - 1);
-                                }
-                                if (getBlockInMap(x + 1, y, z) == -1) {
-                                    setBlockInMap((byte) (i + 1), x + 1, y, z);
-                                }
-                                if (getBlockInMap(x, y + 1, z) == -1) {
-                                    setBlockInMap((byte) (i + 1), x, y + 1, z);
-                                }
-                                if (getBlockInMap(x, y, z + 1) == -1) {
-                                    setBlockInMap((byte) (i + 1), x, y, z + 1);
-                                }
-                            }
+                        if (getBlockInMap(x - 1, y, z) == -1) {
+                            setBlockInMap((byte) (i + 1), x - 1, y, z);
+                        }
+                        if (getBlockInMap(x, y - 1, z) == -1) {
+                            setBlockInMap((byte) (i + 1), x, y - 1, z);
+                        }
+                        if (getBlockInMap(x, y, z - 1) == -1) {
+                            setBlockInMap((byte) (i + 1), x, y, z - 1);
+                        }
+                        if (getBlockInMap(x + 1, y, z) == -1) {
+                            setBlockInMap((byte) (i + 1), x + 1, y, z);
+                        }
+                        if (getBlockInMap(x, y + 1, z) == -1) {
+                            setBlockInMap((byte) (i + 1), x, y + 1, z);
+                        }
+                        if (getBlockInMap(x, y, z + 1) == -1) {
+                            setBlockInMap((byte) (i + 1), x, y, z + 1);
                         }
                     }
                 }
             }
+        }
 
-            if (getBlockInMap(4, 4, 4) < 0) { // leaf decay
-                LeavesDecayEvent decayEvent = new LeavesDecayEvent(block);
-                EventFactory.getInstance().callEvent(decayEvent);
-                if (!decayEvent.isCancelled()) {
-                    block.breakNaturally();
-                }
-            } else { // cancel decay check on this leaves block
-                state.setRawData((byte) (state.getRawData() & -0x09));
-                state.update(true);
+        if (getBlockInMap(4, 4, 4) < 0) { // leaf decay
+            LeavesDecayEvent decayEvent = new LeavesDecayEvent(block);
+            EventFactory.getInstance().callEvent(decayEvent);
+            if (!decayEvent.isCancelled()) {
+                block.breakNaturally();
             }
+        } else { // cancel decay check on this leaves block
+            state.setRawData((byte) (state.getRawData() & -0x09));
+            state.update(true);
         }
     }
 

--- a/src/main/java/net/glowstone/block/blocktype/BlockLiquid.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLiquid.java
@@ -118,39 +118,38 @@ public abstract class BlockLiquid extends BlockType {
     }
 
     private void calculateFlow(GlowBlock block) {
-        if (!block.getState().isFlowed()) {
-            GlowBlockState state = block.getState();
-            // see if we can flow down
-            if (block.getY() > 0) {
-                if (calculateTarget(block.getRelative(DOWN), DOWN, true)) {
-                    if (!block.getRelative(UP).isLiquid()
-                        && Byte.compare(state.getRawData(), STRENGTH_SOURCE) == 0) {
-                        for (BlockFace face : SIDES) {
-                            calculateTarget(block.getRelative(face), face, true);
-                        }
-                    }
-                } else {
-                    // we can't flow down, or if we're a source block, let's flow horizontally
-                    // search 5 blocks out
-                    for (int j = 1; j < 6; j++) {
-                        // from each horizontal face
-                        for (BlockFace face : SIDES) {
-                            if (calculateTarget(block.getRelative(face, j).getRelative(DOWN), face,
-                                false) && calculateTarget(block.getRelative(face), face, true)) {
-                                state.setFlowed(true);
-                            }
-                        }
-                        // if we already found a match at this radius, stop
-                        if (state.isFlowed()) {
-                            return;
-                        }
-                    }
-                    for (BlockFace face : SIDES) {
-                        calculateTarget(block.getRelative(face), face, true);
-                    }
-                    state.setFlowed(true);
+        // see if we can flow down
+        if (block.getState().isFlowed() || block.getY() <= 0) {
+            return;
+        }
+        GlowBlockState state = block.getState();
+        if (calculateTarget(block.getRelative(DOWN), DOWN, true)) {
+            if (!block.getRelative(UP).isLiquid()
+                && Byte.compare(state.getRawData(), STRENGTH_SOURCE) == 0) {
+                for (BlockFace face : SIDES) {
+                    calculateTarget(block.getRelative(face), face, true);
                 }
             }
+        } else {
+            // we can't flow down, or if we're a source block, let's flow horizontally
+            // search 5 blocks out
+            for (int j = 1; j < 6; j++) {
+                // from each horizontal face
+                for (BlockFace face : SIDES) {
+                    if (calculateTarget(block.getRelative(face, j).getRelative(DOWN), face,
+                        false) && calculateTarget(block.getRelative(face), face, true)) {
+                        state.setFlowed(true);
+                    }
+                }
+                // if we already found a match at this radius, stop
+                if (state.isFlowed()) {
+                    return;
+                }
+            }
+            for (BlockFace face : SIDES) {
+                calculateTarget(block.getRelative(face), face, true);
+            }
+            state.setFlowed(true);
         }
     }
 

--- a/src/main/java/net/glowstone/block/blocktype/BlockMushroom.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockMushroom.java
@@ -96,14 +96,13 @@ public class BlockMushroom extends BlockNeedsAttached implements IBlockGrowable 
             int x;
             int y;
             int z;
-            int i = 0;
+            int nearbyShrooms = 0;
             for (x = block.getX() - 4; x <= block.getX() + 4; x++) {
                 for (z = block.getZ() - 4; z <= block.getZ() + 4; z++) {
                     for (y = block.getY() - 1; y <= block.getY() + 1; y++) {
-                        if (world.getBlockAt(x, y, z).getType() == mushroomType) {
-                            if (++i > 4) {
-                                return;
-                            }
+                        if (world.getBlockAt(x, y, z).getType() == mushroomType
+                                && ++nearbyShrooms > 4) {
+                            return;
                         }
                     }
                 }
@@ -120,7 +119,7 @@ public class BlockMushroom extends BlockNeedsAttached implements IBlockGrowable 
             x = block.getX();
             y = block.getY();
             z = block.getZ();
-            for (i = 0; i < 4; i++) {
+            for (int i = 0; i < 4; i++) {
                 if (world.getBlockAt(nx, ny, nz).getType() == Material.AIR
                     && canPlaceAt(world.getBlockAt(nx, ny, nz), BlockFace.DOWN)) {
                     x = nx;

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstone.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstone.java
@@ -138,7 +138,7 @@ public class BlockRedstone extends BlockNeedsAttached {
                 case LEVER:
                     Lever lever = (Lever) target.getState().getData();
                     if (lever.isPowered()) {
-                        updateDataTo15(me);
+                        setFullyPowered(me);
                         return;
                     }
                     break;
@@ -146,27 +146,27 @@ public class BlockRedstone extends BlockNeedsAttached {
                 case WOOD_BUTTON:
                     Button button = (Button) target.getState().getData();
                     if (button.isPowered()) {
-                        updateDataTo15(me);
+                        setFullyPowered(me);
                         return;
                     }
                     break;
                 case DIODE_BLOCK_ON:
                     Diode diode = (Diode) target.getState().getData();
                     if (face == diode.getFacing().getOppositeFace()) {
-                        updateDataTo15(me);
+                        setFullyPowered(me);
                         return;
                     }
                     break;
                 case REDSTONE_BLOCK:
                 case REDSTONE_TORCH_ON:
-                    updateDataTo15(me);
+                    setFullyPowered(me);
                     return;
                 case OBSERVER:
                     boolean powered = BlockObserver.isPowered(target);
                     BlockFace outputFace = BlockObserver.getFace(target).getOppositeFace();
                     if (powered && target.getRelative(outputFace).getLocation()
                         .equals(me.getLocation())) {
-                        updateDataTo15(me);
+                        setFullyPowered(me);
                         return;
                     }
                     break;
@@ -176,7 +176,7 @@ public class BlockRedstone extends BlockNeedsAttached {
                     }
                     if (target.getRelative(BlockFace.DOWN).getType()
                             == Material.REDSTONE_TORCH_ON) {
-                        updateDataTo15(me);
+                        setFullyPowered(me);
                         return;
                     }
                     for (BlockFace face2 : ADJACENT) {
@@ -184,21 +184,21 @@ public class BlockRedstone extends BlockNeedsAttached {
                         if (target2.getType() == Material.DIODE_BLOCK_ON
                             && ((Diode) target2.getState().getData()).getFacing() == target2
                             .getFace(target)) {
-                            updateDataTo15(me);
+                            setFullyPowered(me);
                             return;
                         } else if (target2.getType() == Material.STONE_BUTTON
                             || target2.getType() == Material.WOOD_BUTTON) {
                             Button button2 = (Button) target2.getState().getData();
                             if (button2.isPowered() && button2.getAttachedFace() == target2
                                 .getFace(target)) {
-                                updateDataTo15(me);
+                                setFullyPowered(me);
                                 return;
                             }
                         } else if (target2.getType() == Material.LEVER) {
                             Lever lever2 = (Lever) target2.getState().getData();
                             if (lever2.isPowered() && lever2.getAttachedFace() == target2
                                 .getFace(target)) {
-                                updateDataTo15(me);
+                                setFullyPowered(me);
                                 return;
                             }
                         }
@@ -235,23 +235,25 @@ public class BlockRedstone extends BlockNeedsAttached {
 
         if (power != me.getData()) {
             me.setData(power);
-            extraUpdate(me);
+            updateConnected(me);
             new PulseTask(me, true, 1, true).startPulseTask();
         }
     }
 
     /**
-     * Sets the block data to 15 and calls {@link #extraUpdate(GlowBlock)} if it wasn't already 15.
-     * @param me the block to update
+     * Sets a redstone dust block to the fully-powered state and, if it wasn't already in that
+     * state, updates connected blocks so that power propagates.
+     *
+     * @param block the block to update
      */
-    protected void updateDataTo15(GlowBlock me) {
-        if (me.getData() != 15) {
-            me.setData((byte) 15);
-            extraUpdate(me);
+    protected static void setFullyPowered(GlowBlock block) {
+        if (block.getData() != 15) {
+            block.setData((byte) 15);
+            updateConnected(block);
         }
     }
 
-    private void extraUpdate(GlowBlock block) {
+    private static void updateConnected(GlowBlock block) {
         ItemTable itemTable = ItemTable.instance();
         for (BlockFace face : calculateConnections(block)) {
             GlowBlock target = block.getRelative(face);

--- a/src/main/java/net/glowstone/block/blocktype/BlockRedstone.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockRedstone.java
@@ -138,10 +138,7 @@ public class BlockRedstone extends BlockNeedsAttached {
                 case LEVER:
                     Lever lever = (Lever) target.getState().getData();
                     if (lever.isPowered()) {
-                        if (me.getData() != 15) {
-                            me.setData((byte) 15);
-                            extraUpdate(me);
-                        }
+                        updateDataTo15(me);
                         return;
                     }
                     break;
@@ -149,83 +146,60 @@ public class BlockRedstone extends BlockNeedsAttached {
                 case WOOD_BUTTON:
                     Button button = (Button) target.getState().getData();
                     if (button.isPowered()) {
-                        if (me.getData() != 15) {
-                            me.setData((byte) 15);
-                            extraUpdate(me);
-                        }
+                        updateDataTo15(me);
                         return;
                     }
                     break;
                 case DIODE_BLOCK_ON:
                     Diode diode = (Diode) target.getState().getData();
                     if (face == diode.getFacing().getOppositeFace()) {
-                        if (me.getData() != 15) {
-                            me.setData((byte) 15);
-                            extraUpdate(me);
-                        }
+                        updateDataTo15(me);
                         return;
                     }
                     break;
                 case REDSTONE_BLOCK:
                 case REDSTONE_TORCH_ON:
-                    if (me.getData() != 15) {
-                        me.setData((byte) 15);
-                        extraUpdate(me);
-                    }
+                    updateDataTo15(me);
                     return;
                 case OBSERVER:
                     boolean powered = BlockObserver.isPowered(target);
                     BlockFace outputFace = BlockObserver.getFace(target).getOppositeFace();
                     if (powered && target.getRelative(outputFace).getLocation()
                         .equals(me.getLocation())) {
-                        if (me.getData() != 15) {
-                            me.setData((byte) 15);
-                            extraUpdate(me);
-                        }
+                        updateDataTo15(me);
                         return;
                     }
                     break;
                 default:
-                    if (target.getType().isSolid() && target.getRelative(BlockFace.DOWN).getType()
-                        == Material.REDSTONE_TORCH_ON) {
-                        if (me.getData() != 15) {
-                            me.setData((byte) 15);
-                            extraUpdate(me);
-                        }
+                    if (!target.getType().isSolid()) {
+                        continue;
+                    }
+                    if (target.getRelative(BlockFace.DOWN).getType()
+                            == Material.REDSTONE_TORCH_ON) {
+                        updateDataTo15(me);
                         return;
                     }
-                    if (target.getType().isSolid()) {
-                        for (BlockFace face2 : ADJACENT) {
-                            GlowBlock target2 = target.getRelative(face2);
-                            if (target2.getType() == Material.DIODE_BLOCK_ON
-                                && ((Diode) target2.getState().getData()).getFacing() == target2
+                    for (BlockFace face2 : ADJACENT) {
+                        GlowBlock target2 = target.getRelative(face2);
+                        if (target2.getType() == Material.DIODE_BLOCK_ON
+                            && ((Diode) target2.getState().getData()).getFacing() == target2
+                            .getFace(target)) {
+                            updateDataTo15(me);
+                            return;
+                        } else if (target2.getType() == Material.STONE_BUTTON
+                            || target2.getType() == Material.WOOD_BUTTON) {
+                            Button button2 = (Button) target2.getState().getData();
+                            if (button2.isPowered() && button2.getAttachedFace() == target2
                                 .getFace(target)) {
-                                if (me.getData() != 15) {
-                                    me.setData((byte) 15);
-                                    extraUpdate(me);
-                                }
+                                updateDataTo15(me);
                                 return;
-                            } else if (target2.getType() == Material.STONE_BUTTON
-                                || target2.getType() == Material.WOOD_BUTTON) {
-                                Button button2 = (Button) target2.getState().getData();
-                                if (button2.isPowered() && button2.getAttachedFace() == target2
-                                    .getFace(target)) {
-                                    if (me.getData() != 15) {
-                                        me.setData((byte) 15);
-                                        extraUpdate(me);
-                                    }
-                                    return;
-                                }
-                            } else if (target2.getType() == Material.LEVER) {
-                                Lever lever2 = (Lever) target2.getState().getData();
-                                if (lever2.isPowered() && lever2.getAttachedFace() == target2
-                                    .getFace(target)) {
-                                    if (me.getData() != 15) {
-                                        me.setData((byte) 15);
-                                        extraUpdate(me);
-                                    }
-                                    return;
-                                }
+                            }
+                        } else if (target2.getType() == Material.LEVER) {
+                            Lever lever2 = (Lever) target2.getState().getData();
+                            if (lever2.isPowered() && lever2.getAttachedFace() == target2
+                                .getFace(target)) {
+                                updateDataTo15(me);
+                                return;
                             }
                         }
                     }
@@ -263,6 +237,17 @@ public class BlockRedstone extends BlockNeedsAttached {
             me.setData(power);
             extraUpdate(me);
             new PulseTask(me, true, 1, true).startPulseTask();
+        }
+    }
+
+    /**
+     * Sets the block data to 15 and calls {@link #extraUpdate(GlowBlock)} if it wasn't already 15.
+     * @param me the block to update
+     */
+    protected void updateDataTo15(GlowBlock me) {
+        if (me.getData() != 15) {
+            me.setData((byte) 15);
+            extraUpdate(me);
         }
     }
 

--- a/src/main/java/net/glowstone/block/blocktype/BlockVine.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockVine.java
@@ -113,65 +113,65 @@ public class BlockVine extends BlockClimbable {
         if (ThreadLocalRandom.current().nextInt(4) == 0) {
             GlowBlockState state = block.getState();
             MaterialData data = state.getData();
-            if (data instanceof Vine) {
-                Vine vine = (Vine) data;
-                boolean hasNearVineBlocks = hasNearVineBlocks(block);
-                BlockFace face = ADJACENT[ThreadLocalRandom.current().nextInt(ADJACENT.length)];
-                if (block.getY() < 255 && face == BlockFace.UP && block.getRelative(face)
-                    .isEmpty()) {
-                    if (!hasNearVineBlocks) {
-                        Vine v = (Vine) data;
-                        for (BlockFace f : HORIZONTAL_FACES) {
-                            if (ThreadLocalRandom.current().nextInt(2) == 0 || !block.getRelative(f)
-                                .getRelative(face).getType().isSolid()) {
-                                v.removeFromFace(f);
-                            }
-                        }
-                        putVineOnHorizontalBlockFace(block.getRelative(face), v, block);
-                    }
-                } else if (Arrays.asList(HORIZONTAL_FACES).contains(face) && !vine.isOnFace(face)) {
-                    if (!hasNearVineBlocks) {
-                        GlowBlock b = block.getRelative(face);
-                        if (b.isEmpty()) {
-                            BlockFace clockwiseFace = getClockwiseFace(face);
-                            BlockFace counterClockwiseFace = getCounterClockwiseFace(face);
-                            GlowBlock clockwiseBlock = b.getRelative(clockwiseFace);
-                            GlowBlock counterClockwiseBlock = b.getRelative(counterClockwiseFace);
-                            boolean isOnCwFace = vine.isOnFace(clockwiseFace);
-                            boolean isOnCcwFace = vine.isOnFace(counterClockwiseFace);
-                            if (isOnCwFace && clockwiseBlock.getType().isSolid()) {
-                                putVine(b, new Vine(clockwiseFace), block);
-                            } else if (isOnCcwFace && counterClockwiseBlock.getType().isSolid()) {
-                                putVine(b, new Vine(counterClockwiseFace), block);
-                            } else if (isOnCwFace && clockwiseBlock.isEmpty() && block
-                                .getRelative(clockwiseFace).getType().isSolid()) {
-                                putVine(clockwiseBlock, new Vine(face.getOppositeFace()), block);
-                            } else if (isOnCcwFace && counterClockwiseBlock.isEmpty() && block
-                                .getRelative(counterClockwiseFace).getType().isSolid()) {
-                                putVine(counterClockwiseBlock, new Vine(face.getOppositeFace()),
-                                    block);
-                            } else if (b.getRelative(BlockFace.UP).getType().isSolid()) {
-                                putVine(b, new Vine(), block);
-                            }
-                        } else if (b.getType().isOccluding()) {
-                            vine.putOnFace(face);
-                            putVine(block, vine, null);
-                        }
-                    }
-                } else if (block.getY() > 1) {
-                    GlowBlock b = block.getRelative(BlockFace.DOWN);
+            if (!(data instanceof Vine)) {
+                warnMaterialData(Vine.class, data);
+                return;
+            }
+            Vine vine = (Vine) data;
+            boolean hasNearVineBlocks = hasNearVineBlocks(block);
+            BlockFace face = ADJACENT[ThreadLocalRandom.current().nextInt(ADJACENT.length)];
+            if (block.getY() < 255 && face == BlockFace.UP && block.getRelative(face)
+                .isEmpty()) {
+                if (!hasNearVineBlocks) {
                     Vine v = (Vine) data;
-                    if (b.getType() == Material.VINE || b.isEmpty()) {
-                        for (BlockFace f : HORIZONTAL_FACES) {
-                            if (ThreadLocalRandom.current().nextInt(2) == 0) {
-                                v.removeFromFace(f);
-                            }
+                    for (BlockFace f : HORIZONTAL_FACES) {
+                        if (ThreadLocalRandom.current().nextInt(2) == 0 || !block.getRelative(f)
+                            .getRelative(face).getType().isSolid()) {
+                            v.removeFromFace(f);
                         }
-                        putVineOnHorizontalBlockFace(b, v, b.isEmpty() ? block : null);
+                    }
+                    putVineOnHorizontalBlockFace(block.getRelative(face), v, block);
+                }
+            } else if (Arrays.asList(HORIZONTAL_FACES).contains(face) && !vine.isOnFace(face)) {
+                if (!hasNearVineBlocks) {
+                    GlowBlock b = block.getRelative(face);
+                    if (b.isEmpty()) {
+                        BlockFace clockwiseFace = getClockwiseFace(face);
+                        BlockFace counterClockwiseFace = getCounterClockwiseFace(face);
+                        GlowBlock clockwiseBlock = b.getRelative(clockwiseFace);
+                        GlowBlock counterClockwiseBlock = b.getRelative(counterClockwiseFace);
+                        boolean isOnCwFace = vine.isOnFace(clockwiseFace);
+                        boolean isOnCcwFace = vine.isOnFace(counterClockwiseFace);
+                        if (isOnCwFace && clockwiseBlock.getType().isSolid()) {
+                            putVine(b, new Vine(clockwiseFace), block);
+                        } else if (isOnCcwFace && counterClockwiseBlock.getType().isSolid()) {
+                            putVine(b, new Vine(counterClockwiseFace), block);
+                        } else if (isOnCwFace && clockwiseBlock.isEmpty() && block
+                            .getRelative(clockwiseFace).getType().isSolid()) {
+                            putVine(clockwiseBlock, new Vine(face.getOppositeFace()), block);
+                        } else if (isOnCcwFace && counterClockwiseBlock.isEmpty() && block
+                            .getRelative(counterClockwiseFace).getType().isSolid()) {
+                            putVine(counterClockwiseBlock, new Vine(face.getOppositeFace()),
+                                block);
+                        } else if (b.getRelative(BlockFace.UP).getType().isSolid()) {
+                            putVine(b, new Vine(), block);
+                        }
+                    } else if (b.getType().isOccluding()) {
+                        vine.putOnFace(face);
+                        putVine(block, vine, null);
                     }
                 }
-            } else {
-                warnMaterialData(Vine.class, data);
+            } else if (block.getY() > 1) {
+                GlowBlock b = block.getRelative(BlockFace.DOWN);
+                Vine v = (Vine) data;
+                if (b.getType() == Material.VINE || b.isEmpty()) {
+                    for (BlockFace f : HORIZONTAL_FACES) {
+                        if (ThreadLocalRandom.current().nextInt(2) == 0) {
+                            v.removeFromFace(f);
+                        }
+                    }
+                    putVineOnHorizontalBlockFace(b, v, b.isEmpty() ? block : null);
+                }
             }
         }
     }

--- a/src/main/java/net/glowstone/chunk/ChunkManager.java
+++ b/src/main/java/net/glowstone/chunk/ChunkManager.java
@@ -83,7 +83,7 @@ public final class ChunkManager {
         biomeGrid = MapLayer.initialize(
                 world.getSeed(), world.getEnvironment(), world.getWorldType());
     }
-    
+
     /**
      * Gets a chunk object representing the specified coordinates, which might not yet be loaded.
      *
@@ -290,11 +290,8 @@ public final class ChunkManager {
                         int maxHeight = chunkData.getMaxHeight();
                         for (int k = 0; k < maxHeight; ++k) {
                             MaterialData materialData = chunkData.getTypeAndData(i, k, j);
-                            if (materialData != null) {
-                                glowChunkData.setBlock(i, k, j, materialData);
-                            } else {
-                                glowChunkData.setBlock(i, k, j, new MaterialData(Material.AIR));
-                            }
+                            glowChunkData.setBlock(i, k, j, materialData == null
+                                    ? new MaterialData(Material.AIR) : materialData);
                         }
                     }
                 }

--- a/src/main/java/net/glowstone/command/minecraft/ClearCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/ClearCommand.java
@@ -187,36 +187,35 @@ public class ClearCommand extends VanillaCommand {
                 ChatColor.RED + "Could not clear the inventory of " + player.getName()
                     + ", no items to remove");
             return false;
+        }
+        if (material == null) {
+            player.getInventory().clear();
         } else {
-            if (material == null) {
-                player.getInventory().clear();
-            } else {
-                int remaining = maxCount;
-                for (ItemStack stack : player.getInventory().getContents()) {
-                    if (stack.getType() == material && (data == -1 || data == stack.getData()
-                        .getData())) {
-                        // matches type and data
-                        if (maxCount == -1) {
-                            player.getInventory().remove(stack);
-                        } else if (maxCount == 0) {
-                            sender.sendMessage(player.getName() + " has " + count
-                                + " items that match the criteria");
-                            return true;
-                        } else {
-                            for (int i = 0; i < stack.getAmount(); i++) {
-                                if (remaining > 0) {
-                                    stack.setAmount(stack.getAmount() - 1);
-                                    remaining--;
-                                }
+            int remaining = maxCount;
+            for (ItemStack stack : player.getInventory().getContents()) {
+                if (stack.getType() == material && (data == -1 || data == stack.getData()
+                    .getData())) {
+                    // matches type and data
+                    if (maxCount == -1) {
+                        player.getInventory().remove(stack);
+                    } else if (maxCount == 0) {
+                        sender.sendMessage(player.getName() + " has " + count
+                            + " items that match the criteria");
+                        return true;
+                    } else {
+                        for (int i = 0; i < stack.getAmount(); i++) {
+                            if (remaining > 0) {
+                                stack.setAmount(stack.getAmount() - 1);
+                                remaining--;
                             }
                         }
                     }
                 }
             }
-            sender.sendMessage(
-                "Cleared the inventory of " + player.getName() + ", removing " + count + " items");
-            return true;
         }
+        sender.sendMessage(
+            "Cleared the inventory of " + player.getName() + ", removing " + count + " items");
+        return true;
     }
 
     @Override

--- a/src/main/java/net/glowstone/command/minecraft/TpCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/TpCommand.java
@@ -29,12 +29,11 @@ public class TpCommand extends VanillaCommand {
         if (!testPermission(sender)) {
             return false;
         }
-        if (args.length == 0) {
-            sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
-            return false;
-        }
-        if (args.length <= 2) {
-            if (args.length == 1) {
+        switch (args.length) {
+            case 0:
+                sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
+                return false;
+            case 1:
                 Entity from;
                 if (sender instanceof Player) {
                     from = (Entity) sender;
@@ -71,7 +70,7 @@ public class TpCommand extends VanillaCommand {
                         return true;
                     }
                 }
-            } else {
+            case 2:
                 Entity destination;
                 String fromName = args[0];
                 String destName = args[1];
@@ -147,11 +146,10 @@ public class TpCommand extends VanillaCommand {
                         .getName(destination));
                     return true;
                 }
-            }
-        } else {
-            sender
-                .sendMessage(ChatColor.RED + "Coordinate-based teleporting is not supported yet!");
-            return false;
+            default:
+                sender.sendMessage(
+                        ChatColor.RED + "Coordinate-based teleporting is not supported yet!");
+                return false;
         }
     }
 }

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -827,14 +827,16 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                 player.setHealth(1.0);
                 active = true;
                 return;
-            } else if (!InventoryUtil.isEmpty(offHand) && offHand.getType() == Material.TOTEM) {
+            }
+            if (!InventoryUtil.isEmpty(offHand) && offHand.getType() == Material.TOTEM) {
                 player.getInventory().setItemInOffHand(InventoryUtil.createEmptyStack());
                 player.setHealth(1.0);
                 active = true;
                 return;
             }
-            List<ItemStack> items = new ArrayList<>();
-            if (!world.getGameRuleMap().getBoolean("keepInventory")) {
+            List<ItemStack> items;
+            boolean dropInventory = !world.getGameRuleMap().getBoolean("keepInventory");
+            if (dropInventory) {
                 items = Arrays.stream(player.getInventory().getContents())
                         .filter(stack -> !InventoryUtil.isEmpty(stack))
                         .collect(Collectors.toList());
@@ -844,8 +846,10 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                     player.getDisplayName() + " died.");
             EventFactory.getInstance().callEvent(event);
             server.broadcastMessage(event.getDeathMessage());
-            for (ItemStack item : items) {
-                world.dropItemNaturally(getLocation(), item);
+            if (dropInventory) {
+                for (ItemStack item : items) {
+                    world.dropItemNaturally(getLocation(), item);
+                }
             }
             player.setShoulderEntityRight(null);
             player.setShoulderEntityLeft(null);

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -834,7 +834,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                 active = true;
                 return;
             }
-            List<ItemStack> items;
+            List<ItemStack> items = null;
             boolean dropInventory = !world.getGameRuleMap().getBoolean("keepInventory");
             if (dropInventory) {
                 items = Arrays.stream(player.getInventory().getContents())

--- a/src/main/java/net/glowstone/generator/NetherGenerator.java
+++ b/src/main/java/net/glowstone/generator/NetherGenerator.java
@@ -273,38 +273,38 @@ public class NetherGenerator extends GlowChunkGenerator {
         for (int y = 127; y >= 0; y--) {
             if (y <= random.nextInt(5) || y >= 127 - random.nextInt(5)) {
                 chunkData.setBlock(x, y, z, Material.BEDROCK);
-            } else {
-                Material mat = chunkData.getType(x, y, z);
-                if (mat == Material.AIR) {
-                    deep = -1;
-                } else if (mat == Material.NETHERRACK) {
-                    if (deep == -1) {
-                        if (surfaceHeight <= 0) {
-                            topMat = Material.AIR;
+                continue;
+            }
+            Material mat = chunkData.getType(x, y, z);
+            if (mat == Material.AIR) {
+                deep = -1;
+            } else if (mat == Material.NETHERRACK) {
+                if (deep == -1) {
+                    if (surfaceHeight <= 0) {
+                        topMat = Material.AIR;
+                        groundMat = Material.NETHERRACK;
+                    } else if (y >= 60 && y <= 65) {
+                        topMat = Material.NETHERRACK;
+                        groundMat = Material.NETHERRACK;
+                        if (gravel) {
+                            topMat = Material.GRAVEL;
                             groundMat = Material.NETHERRACK;
-                        } else if (y >= 60 && y <= 65) {
-                            topMat = Material.NETHERRACK;
-                            groundMat = Material.NETHERRACK;
-                            if (gravel) {
-                                topMat = Material.GRAVEL;
-                                groundMat = Material.NETHERRACK;
-                            }
-                            if (soulSand) {
-                                topMat = Material.SOUL_SAND;
-                                groundMat = Material.SOUL_SAND;
-                            }
                         }
+                        if (soulSand) {
+                            topMat = Material.SOUL_SAND;
+                            groundMat = Material.SOUL_SAND;
+                        }
+                    }
 
-                        deep = surfaceHeight;
-                        if (y >= 63) {
-                            chunkData.setBlock(x, y, z, topMat);
-                        } else {
-                            chunkData.setBlock(x, y, z, groundMat);
-                        }
-                    } else if (deep > 0) {
-                        deep--;
+                    deep = surfaceHeight;
+                    if (y >= 63) {
+                        chunkData.setBlock(x, y, z, topMat);
+                    } else {
                         chunkData.setBlock(x, y, z, groundMat);
                     }
+                } else if (deep > 0) {
+                    deep--;
+                    chunkData.setBlock(x, y, z, groundMat);
                 }
             }
         }

--- a/src/main/java/net/glowstone/generator/decorators/nether/GlowstoneDecorator.java
+++ b/src/main/java/net/glowstone/generator/decorators/nether/GlowstoneDecorator.java
@@ -34,30 +34,32 @@ public class GlowstoneDecorator extends BlockDecorator {
             int sourceY = 4 + random.nextInt(120);
 
             Block block = world.getBlockAt(sourceX, sourceY, sourceZ);
-            if (block.isEmpty()
-                && block.getRelative(BlockFace.UP).getType() == Material.NETHERRACK) {
-                BlockState state = block.getState();
-                state.setType(Material.GLOWSTONE);
-                state.update(true);
+            if (!block.isEmpty()
+                    || block.getRelative(BlockFace.UP).getType() != Material.NETHERRACK) {
+                continue;
+            }
+            BlockState state = block.getState();
+            state.setType(Material.GLOWSTONE);
+            state.update(true);
 
-                for (int j = 0; j < 1500; j++) {
-                    int x = sourceX + random.nextInt(8) - random.nextInt(8);
-                    int z = sourceZ + random.nextInt(8) - random.nextInt(8);
-                    int y = sourceY - random.nextInt(12);
-                    block = world.getBlockAt(x, y, z);
-                    if (block.isEmpty()) {
-                        int glowstoneBlockCount = 0;
-                        for (BlockFace face : SIDES) {
-                            if (block.getRelative(face).getType() == Material.GLOWSTONE) {
-                                glowstoneBlockCount++;
-                            }
-                        }
-                        if (glowstoneBlockCount == 1) {
-                            state = block.getState();
-                            state.setType(Material.GLOWSTONE);
-                            state.update(true);
-                        }
+            for (int j = 0; j < 1500; j++) {
+                int x = sourceX + random.nextInt(8) - random.nextInt(8);
+                int z = sourceZ + random.nextInt(8) - random.nextInt(8);
+                int y = sourceY - random.nextInt(12);
+                block = world.getBlockAt(x, y, z);
+                if (!block.isEmpty()) {
+                    continue;
+                }
+                int glowstoneBlockCount = 0;
+                for (BlockFace face : SIDES) {
+                    if (block.getRelative(face).getType() == Material.GLOWSTONE) {
+                        glowstoneBlockCount++;
                     }
+                }
+                if (glowstoneBlockCount == 1) {
+                    state = block.getState();
+                    state.setType(Material.GLOWSTONE);
+                    state.update(true);
                 }
             }
         }

--- a/src/main/java/net/glowstone/generator/ground/MesaGroundGenerator.java
+++ b/src/main/java/net/glowstone/generator/ground/MesaGroundGenerator.java
@@ -13,7 +13,7 @@ public class MesaGroundGenerator extends GroundGenerator {
 
     protected static final MaterialData RED_SAND = new MaterialData(Material.SAND, (byte) 1);
     protected static final MaterialData ORANGE_STAINED_CLAY = new MaterialData(
-        Material.STAINED_CLAY, (byte) 1);
+            Material.STAINED_CLAY, (byte) 1);
 
     private final MesaType type;
     private final int[] colorLayer = new int[64];
@@ -41,7 +41,7 @@ public class MesaGroundGenerator extends GroundGenerator {
 
     private void initialize(long seed) {
         if (seed != this.seed || colorNoise == null || canyonScaleNoise == null
-            || canyonHeightNoise == null) {
+                || canyonHeightNoise == null) {
             Random random = new Random(seed);
             colorNoise = new SimplexOctaveGenerator(random, 1);
             colorNoise.setScale(1 / 512.0D);
@@ -57,7 +57,7 @@ public class MesaGroundGenerator extends GroundGenerator {
 
     @Override
     public void generateTerrainColumn(ChunkData chunkData, World world, Random random, int x, int z,
-        Biome biome, double surfaceNoise) {
+            Biome biome, double surfaceNoise) {
 
         initialize(world.getSeed());
 
@@ -67,14 +67,15 @@ public class MesaGroundGenerator extends GroundGenerator {
         MaterialData groundMat = groundMaterial;
 
         int surfaceHeight = Math
-            .max((int) (surfaceNoise / 3.0D + 3.0D + random.nextDouble() * 0.25D), 1);
+                .max((int) (surfaceNoise / 3.0D + 3.0D + random.nextDouble() * 0.25D), 1);
         boolean colored = Math.cos(surfaceNoise / 3.0D * Math.PI) <= 0;
         double bryceCanyonHeight = 0;
         if (type == MesaType.BRYCE) {
             int noiseX = (x & 0xFFFFFFF0) + (z & 0xF);
             int noiseZ = (z & 0xFFFFFFF0) + (x & 0xF);
             double noiseCanyonHeight = Math
-                .min(Math.abs(surfaceNoise), canyonHeightNoise.noise(noiseX, noiseZ, 0.5D, 2.0D));
+                    .min(Math.abs(surfaceNoise),
+                            canyonHeightNoise.noise(noiseX, noiseZ, 0.5D, 2.0D));
             if (noiseCanyonHeight > 0) {
                 double heightScale = Math.abs(canyonScaleNoise.noise(noiseX, noiseZ, 0.5D, 2.0D));
                 bryceCanyonHeight = Math.pow(noiseCanyonHeight, 2) * 2.5D;
@@ -102,42 +103,43 @@ public class MesaGroundGenerator extends GroundGenerator {
                 Material mat = chunkData.getType(x, y, z);
                 if (mat == Material.AIR) {
                     deep = -1;
-                } else if (mat == Material.STONE) {
-                    if (deep == -1) {
-                        groundSet = false;
-                        if (y >= seaLevel - 5 && y <= seaLevel) {
-                            groundMat = groundMaterial;
-                        }
+                } else if (mat != Material.STONE) {
+                    continue;
+                }
+                if (deep == -1) {
+                    groundSet = false;
+                    if (y >= seaLevel - 5 && y <= seaLevel) {
+                        groundMat = groundMaterial;
+                    }
 
-                        deep = surfaceHeight + Math.max(0, y - seaLevel - 1);
-                        if (y >= seaLevel - 2) {
-                            if (type == MesaType.FOREST && y > seaLevel + 22 + (surfaceHeight
+                    deep = surfaceHeight + Math.max(0, y - seaLevel - 1);
+                    if (y >= seaLevel - 2) {
+                        if (type == MesaType.FOREST && y > seaLevel + 22 + (surfaceHeight
                                 << 1)) {
-                                topMat = colored ? GRASS : COARSE_DIRT;
-                                chunkData.setBlock(x, y, z, topMat);
-                            } else if (y > seaLevel + 2 + surfaceHeight) {
-                                int color = colorLayer[(y + (int) Math
+                            topMat = colored ? GRASS : COARSE_DIRT;
+                            chunkData.setBlock(x, y, z, topMat);
+                        } else if (y > seaLevel + 2 + surfaceHeight) {
+                            int color = colorLayer[(y + (int) Math
                                     .round(colorNoise.noise(chunkX, chunkX, 0.5D, 2.0D) * 2.0D))
                                     % colorLayer.length];
-                                setColoredGroundLayer(chunkData, x, y, z,
+                            setColoredGroundLayer(chunkData, x, y, z,
                                     y < seaLevel || y > 128 ? 1 : colored ? color : -1);
-                            } else {
-                                chunkData.setBlock(x, y, z, topMaterial);
-                                groundSet = true;
-                            }
                         } else {
-                            chunkData.setBlock(x, y, z, groundMat);
+                            chunkData.setBlock(x, y, z, topMaterial);
+                            groundSet = true;
                         }
-                    } else if (deep > 0) {
-                        deep--;
-                        if (groundSet) {
-                            chunkData.setBlock(x, y, z, groundMaterial);
-                        } else {
-                            int color = colorLayer[(y + (int) Math
+                    } else {
+                        chunkData.setBlock(x, y, z, groundMat);
+                    }
+                } else if (deep > 0) {
+                    deep--;
+                    if (groundSet) {
+                        chunkData.setBlock(x, y, z, groundMaterial);
+                    } else {
+                        int color = colorLayer[(y + (int) Math
                                 .round(colorNoise.noise(chunkX, chunkX, 0.5D, 2.0D) * 2.0D))
                                 % colorLayer.length];
-                            setColoredGroundLayer(chunkData, x, y, z, color);
-                        }
+                        setColoredGroundLayer(chunkData, x, y, z, color);
                     }
                 }
             }
@@ -153,7 +155,7 @@ public class MesaGroundGenerator extends GroundGenerator {
     }
 
     private void setRandomLayerColor(Random random, int minLayerCount, int minLayerHeight,
-        int color) {
+            int color) {
         for (int i = 0; i < random.nextInt(4) + minLayerCount; i++) {
             int j = random.nextInt(colorLayer.length);
             int k = 0;

--- a/src/main/java/net/glowstone/generator/ground/MesaGroundGenerator.java
+++ b/src/main/java/net/glowstone/generator/ground/MesaGroundGenerator.java
@@ -88,6 +88,7 @@ public class MesaGroundGenerator extends GroundGenerator {
         }
 
         int chunkX = x;
+        int chunkZ = z;
         x &= 0xF;
         z &= 0xF;
 
@@ -119,8 +120,9 @@ public class MesaGroundGenerator extends GroundGenerator {
                             topMat = colored ? GRASS : COARSE_DIRT;
                             chunkData.setBlock(x, y, z, topMat);
                         } else if (y > seaLevel + 2 + surfaceHeight) {
-                            int color = colorLayer[(y + (int) Math
-                                    .round(colorNoise.noise(chunkX, chunkX, 0.5D, 2.0D) * 2.0D))
+                            int color = colorLayer[
+                                    (y + (int) Math.round(
+                                            colorNoise.noise(chunkX, chunkZ, 0.5D, 2.0D) * 2.0D))
                                     % colorLayer.length];
                             setColoredGroundLayer(chunkData, x, y, z,
                                     y < seaLevel || y > 128 ? 1 : colored ? color : -1);
@@ -136,8 +138,9 @@ public class MesaGroundGenerator extends GroundGenerator {
                     if (groundSet) {
                         chunkData.setBlock(x, y, z, groundMaterial);
                     } else {
-                        int color = colorLayer[(y + (int) Math
-                                .round(colorNoise.noise(chunkX, chunkX, 0.5D, 2.0D) * 2.0D))
+                        int color = colorLayer[
+                                (y + (int) Math.round(
+                                        colorNoise.noise(chunkX, chunkZ, 0.5D, 2.0D) * 2.0D))
                                 % colorLayer.length];
                         setColoredGroundLayer(chunkData, x, y, z, color);
                     }

--- a/src/main/java/net/glowstone/generator/objects/BlockPatch.java
+++ b/src/main/java/net/glowstone/generator/objects/BlockPatch.java
@@ -20,9 +20,6 @@ import org.bukkit.material.types.DoublePlantSpecies;
 public class BlockPatch implements TerrainObject {
 
     private static final int MIN_RADIUS = 2;
-    private static final List<Material> PLANT_TYPES = ImmutableList.of(
-            Material.LONG_GRASS, Material.YELLOW_FLOWER, Material.RED_ROSE,
-            Material.DOUBLE_PLANT, Material.BROWN_MUSHROOM, Material.RED_MUSHROOM);
     private final Material type;
     private final int horizRadius;
     private final int vertRadius;
@@ -46,34 +43,26 @@ public class BlockPatch implements TerrainObject {
     public boolean generate(World world, Random random, int sourceX, int sourceY, int sourceZ) {
         boolean succeeded = false;
         int n = random.nextInt(horizRadius - MIN_RADIUS) + MIN_RADIUS;
+        int nsquared = n * n;
         for (int x = sourceX - n; x <= sourceX + n; x++) {
             for (int z = sourceZ - n; z <= sourceZ + n; z++) {
-                if ((x - sourceX) * (x - sourceX) + (z - sourceZ) * (z - sourceZ) <= n * n) {
-                    for (int y = sourceY - vertRadius; y <= sourceY + vertRadius; y++) {
-                        Block block = world.getBlockAt(x, y, z);
-                        if (overridables.contains(block.getType())) {
-                            Block blockAbove = block.getRelative(BlockFace.UP);
-                            Material mat = blockAbove.getType();
-                            if (PLANT_TYPES.contains(mat)) {
-                                if (mat == Material.DOUBLE_PLANT) {
-                                    MaterialData data = blockAbove.getState().getData();
-                                    if (data instanceof DoublePlant && ((DoublePlant) data)
-                                                .getSpecies() == DoublePlantSpecies.PLANT_APEX) {
-                                        blockAbove.getRelative(BlockFace.UP)
-                                            .setType(Material.AIR);
-                                    }
-                                }
-                                blockAbove.setType(Material.AIR);
-                                break;
-                            }
-                            BlockState state = block.getState();
-                            state.setType(type);
-                            state.setData(new MaterialData(type));
-                            state.update(true);
-                            succeeded = true;
-                            break;
-                        }
+                if ((x - sourceX) * (x - sourceX) + (z - sourceZ) * (z - sourceZ) > nsquared) {
+                    continue;
+                }
+                for (int y = sourceY - vertRadius; y <= sourceY + vertRadius; y++) {
+                    Block block = world.getBlockAt(x, y, z);
+                    if (!overridables.contains(block.getType())) {
+                        continue;
                     }
+                    if (TerrainObject.killPlantAbove(block)) {
+                        break;
+                    }
+                    BlockState state = block.getState();
+                    state.setType(type);
+                    state.setData(new MaterialData(type));
+                    state.update(true);
+                    succeeded = true;
+                    break;
                 }
             }
         }

--- a/src/main/java/net/glowstone/generator/objects/BlockPatch.java
+++ b/src/main/java/net/glowstone/generator/objects/BlockPatch.java
@@ -1,17 +1,13 @@
 package net.glowstone.generator.objects;
 
-import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
-import org.bukkit.material.DoublePlant;
 import org.bukkit.material.MaterialData;
-import org.bukkit.material.types.DoublePlantSpecies;
 
 /**
  * A patch replaces specified blocks within a cylinder. It will delete flowers, tall grass and

--- a/src/main/java/net/glowstone/generator/objects/Lake.java
+++ b/src/main/java/net/glowstone/generator/objects/Lake.java
@@ -1,9 +1,8 @@
 package net.glowstone.generator.objects;
 
-import com.google.common.collect.ImmutableSortedSet;
 import java.util.Arrays;
 import java.util.Random;
-import java.util.SortedSet;
+import net.glowstone.block.GlowBlock;
 import net.glowstone.constants.GlowBiomeClimate;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -19,9 +18,6 @@ public class Lake implements TerrainObject {
     private static final double MAX_DIAMETER = 16.0D;
     private static final double MAX_HEIGHT = 8.0D;
     private static final int MAX_BLOCKS = (int) (MAX_DIAMETER * MAX_DIAMETER * MAX_HEIGHT);
-    private static final SortedSet<Material> PLANT_TYPES =
-            ImmutableSortedSet.of(Material.LONG_GRASS, Material.YELLOW_FLOWER,
-        Material.RED_ROSE, Material.DOUBLE_PLANT, Material.BROWN_MUSHROOM, Material.RED_MUSHROOM);
     private static final Biome[] MYCEL_BIOMES = {Biome.MUSHROOM_ISLAND,
         Biome.MUSHROOM_ISLAND_SHORE};
     private final Material type;
@@ -90,19 +86,7 @@ public class Lake implements TerrainObject {
                     }
                     if (y >= (int) MAX_HEIGHT / 2) {
                         type = Material.AIR;
-                        if (PLANT_TYPES.contains(blockAboveType)) {
-                            if (blockAboveType == Material.DOUBLE_PLANT) {
-                                Block blockAboveBlock = blockAbove
-                                        .getRelative(BlockFace.UP);
-                                MaterialData blockAboveData
-                                        = blockAboveBlock.getState().getData();
-                                if (blockAboveData instanceof DoublePlant
-                                        && ((DoublePlant) blockAboveData).getSpecies()
-                                                == DoublePlantSpecies.PLANT_APEX) {
-                                    blockAboveBlock.setType(Material.AIR);
-                                }
-                            }
-                            blockAbove.setType(Material.AIR);
+                        if (TerrainObject.killPlantAbove(block)) {
                             break;
                         }
                         if (this.type == Material.STATIONARY_WATER && (

--- a/src/main/java/net/glowstone/generator/objects/Lake.java
+++ b/src/main/java/net/glowstone/generator/objects/Lake.java
@@ -2,16 +2,12 @@ package net.glowstone.generator.objects;
 
 import java.util.Arrays;
 import java.util.Random;
-import net.glowstone.block.GlowBlock;
 import net.glowstone.constants.GlowBiomeClimate;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.material.DoublePlant;
-import org.bukkit.material.MaterialData;
-import org.bukkit.material.types.DoublePlantSpecies;
 
 public class Lake implements TerrainObject {
 

--- a/src/main/java/net/glowstone/generator/objects/StoneBoulder.java
+++ b/src/main/java/net/glowstone/generator/objects/StoneBoulder.java
@@ -3,7 +3,6 @@ package net.glowstone.generator.objects;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Random;
 import java.util.SortedSet;
-import net.glowstone.block.GlowBlock;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;

--- a/src/main/java/net/glowstone/generator/objects/StoneBoulder.java
+++ b/src/main/java/net/glowstone/generator/objects/StoneBoulder.java
@@ -3,37 +3,32 @@ package net.glowstone.generator.objects;
 import com.google.common.collect.ImmutableSortedSet;
 import java.util.Random;
 import java.util.SortedSet;
+import net.glowstone.block.GlowBlock;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
-import org.bukkit.material.DoublePlant;
 import org.bukkit.material.MaterialData;
-import org.bukkit.material.types.DoublePlantSpecies;
 
 public class StoneBoulder implements TerrainObject {
 
-    private static final Material[] GROUND_TYPES = {Material.GRASS, Material.DIRT, Material.STONE};
-    private static final SortedSet<Material> PLANT_TYPES = ImmutableSortedSet
-            .of(Material.LONG_GRASS, Material.YELLOW_FLOWER, Material.RED_ROSE,
-                    Material.DOUBLE_PLANT, Material.BROWN_MUSHROOM, Material.RED_MUSHROOM);
+    private static final SortedSet<Material> GROUND_TYPES = ImmutableSortedSet
+            .of(Material.GRASS, Material.DIRT, Material.STONE);
 
     @Override
     public boolean generate(World world, Random random, int sourceX, int sourceY, int sourceZ) {
         boolean groundReached = false;
-        while (!groundReached && sourceY > 3) {
-            Block block = world.getBlockAt(sourceX, sourceY - 1, sourceZ);
-            if (!block.isEmpty()) {
-                for (Material mat : GROUND_TYPES) {
-                    if (mat == block.getType()) {
-                        groundReached = true;
-                        sourceY++;
-                        break;
-                    }
-                }
-            }
+        while (sourceY > 3) {
             sourceY--;
+            Block block = world.getBlockAt(sourceX, sourceY, sourceZ);
+            if (block.isEmpty()) {
+                continue;
+            }
+            if (GROUND_TYPES.contains(block.getType())) {
+                groundReached = true;
+                sourceY++;
+                break;
+            }
         }
         if (!groundReached || !world.getBlockAt(sourceX, sourceY, sourceZ).isEmpty()) {
             return false;
@@ -43,32 +38,24 @@ public class StoneBoulder implements TerrainObject {
             int radiusZ = random.nextInt(2);
             int radiusY = random.nextInt(2);
             float f = (radiusX + radiusZ + radiusY) * 0.333F + 0.5F;
+            float fsquared = f * f;
             for (int x = -radiusX; x <= radiusX; x++) {
+                float xsquared = x * x;
                 for (int z = -radiusZ; z <= radiusZ; z++) {
+                    float zsquared = z * z;
                     for (int y = -radiusY; y <= radiusY; y++) {
-                        if (x * x + z * z + y * y > f * f) {
+                        if (xsquared + zsquared + y * y > fsquared) {
                             continue;
                         }
                         BlockState state = world
                                 .getBlockAt(sourceX + x, sourceY + y, sourceZ + z).getState();
-                        Block blockAbove = state.getBlock().getRelative(BlockFace.UP);
-                        Material mat = blockAbove.getType();
-                        if (PLANT_TYPES.contains(mat)) {
-                            if (mat == Material.DOUBLE_PLANT) {
-                                MaterialData dataAbove = blockAbove.getState().getData();
-                                if (dataAbove instanceof DoublePlant
-                                        && ((DoublePlant) dataAbove).getSpecies()
-                                        == DoublePlantSpecies.PLANT_APEX) {
-                                    blockAbove.getRelative(BlockFace.UP)
-                                            .setType(Material.AIR);
-                                }
-                            }
-                            blockAbove.setType(Material.AIR);
-                            break;
+                        if (!TerrainObject.killPlantAbove(state.getBlock())) {
+                            // FIXME: Is it a bug to suppress the cobblestone beneath where a plant
+                            // previously stood?!
+                            state.setType(Material.MOSSY_COBBLESTONE);
+                            state.setData(new MaterialData(Material.MOSSY_COBBLESTONE));
+                            state.update(true);
                         }
-                        state.setType(Material.MOSSY_COBBLESTONE);
-                        state.setData(new MaterialData(Material.MOSSY_COBBLESTONE));
-                        state.update(true);
                     }
                 }
             }
@@ -78,4 +65,5 @@ public class StoneBoulder implements TerrainObject {
         }
         return true;
     }
+
 }

--- a/src/main/java/net/glowstone/generator/objects/TerrainObject.java
+++ b/src/main/java/net/glowstone/generator/objects/TerrainObject.java
@@ -7,7 +7,6 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.BlockState;
 import org.bukkit.material.DoublePlant;
 import org.bukkit.material.MaterialData;
 import org.bukkit.material.types.DoublePlantSpecies;

--- a/src/main/java/net/glowstone/generator/objects/TerrainObject.java
+++ b/src/main/java/net/glowstone/generator/objects/TerrainObject.java
@@ -1,7 +1,16 @@
 package net.glowstone.generator.objects;
 
+import com.google.common.collect.ImmutableSortedSet;
 import java.util.Random;
+import java.util.SortedSet;
+import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.material.DoublePlant;
+import org.bukkit.material.MaterialData;
+import org.bukkit.material.types.DoublePlantSpecies;
 
 // TODO: Use this interface to reduce duplicate code in BlockPopulator subclasses.
 // TODO: Refactor GenericTree to implement this class.
@@ -11,6 +20,39 @@ import org.bukkit.World;
  */
 @FunctionalInterface
 public interface TerrainObject {
+    /**
+     * Plant block types.
+     */
+    SortedSet<Material> PLANT_TYPES = ImmutableSortedSet
+            .of(Material.LONG_GRASS, Material.YELLOW_FLOWER, Material.RED_ROSE,
+                    Material.DOUBLE_PLANT, Material.BROWN_MUSHROOM, Material.RED_MUSHROOM);
+
+    /**
+     * Removes the grass, shrub, flower or mushroom directly above the given block, if present. Does
+     * not drop an item.
+     *
+     * @param block the block to update
+     * @return true if a plant was removed; false if none was present
+     */
+    static boolean killPlantAbove(Block block) {
+        Block blockAbove = block.getRelative(BlockFace.UP);
+        Material mat = blockAbove.getType();
+        if (PLANT_TYPES.contains(mat)) {
+            if (mat == Material.DOUBLE_PLANT) {
+                MaterialData dataAbove = blockAbove.getState().getData();
+                if (dataAbove instanceof DoublePlant
+                        && ((DoublePlant) dataAbove).getSpecies()
+                        == DoublePlantSpecies.PLANT_APEX) {
+                    blockAbove.getRelative(BlockFace.UP)
+                            .setType(Material.AIR);
+                }
+            }
+            blockAbove.setType(Material.AIR);
+            return true;
+        }
+        return false;
+    }
+
     /**
      * Generates this feature.
      *

--- a/src/main/java/net/glowstone/generator/objects/trees/BigOakTree.java
+++ b/src/main/java/net/glowstone/generator/objects/trees/BigOakTree.java
@@ -61,13 +61,12 @@ public class BigOakTree extends GenericTree {
                     for (int z = -nodeDistance; z <= nodeDistance; z++) {
                         double sizeX = Math.abs(x) + 0.5D;
                         double sizeZ = Math.abs(z) + 0.5D;
-                        if (sizeX * sizeX + sizeZ * sizeZ <= size * size) {
-                            if (overridables.contains(blockTypeAt(
-                                    node.getX() + x, node.getY() + y, node.getZ() + z, world))) {
-                                delegate.setTypeAndRawData(world, node.getX() + x,
-                                        node.getY() + y, node.getZ() + z, Material.LEAVES,
-                                        leavesType);
-                            }
+                        if (sizeX * sizeX + sizeZ * sizeZ <= size * size && overridables.contains(
+                                blockTypeAt(node.getX() + x, node.getY() + y, node.getZ() + z,
+                                        world))) {
+                            delegate.setTypeAndRawData(world, node.getX() + x,
+                                    node.getY() + y, node.getZ() + z, Material.LEAVES,
+                                    leavesType);
                         }
                     }
                 }

--- a/src/main/java/net/glowstone/generator/objects/trees/BrownMushroomTree.java
+++ b/src/main/java/net/glowstone/generator/objects/trees/BrownMushroomTree.java
@@ -48,17 +48,16 @@ public class BrownMushroomTree extends GenericTree {
             // check for block collision on horizontal slices
             for (int x = baseX - radius; x <= baseX + radius; x++) {
                 for (int z = baseZ - radius; z <= baseZ + radius; z++) {
-                    if (y >= 0 && y < 256) {
-                        // skip source block check
-                        if (y != baseY || x != baseX || z != baseZ) {
-                            // we can overlap leaves around
-                            Material type = blockTypeAt(x, y, z, world);
-                            if (!overridables.contains(type)) {
-                                return false;
-                            }
-                        }
-                    } else { // height out of range
+                    if (y < 0 || y >= 256) { // height out of range
                         return false;
+                    }
+                    // skip source block check
+                    if (y != baseY || x != baseX || z != baseZ) {
+                        // we can overlap leaves around
+                        Material type = blockTypeAt(x, y, z, world);
+                        if (!overridables.contains(type)) {
+                            return false;
+                        }
                     }
                 }
             }

--- a/src/main/java/net/glowstone/generator/objects/trees/DarkOakTree.java
+++ b/src/main/java/net/glowstone/generator/objects/trees/DarkOakTree.java
@@ -69,20 +69,21 @@ public class DarkOakTree extends GenericTree {
             }
 
             Material material = blockTypeAt(centerX, blockY + y, centerZ, world);
-            if (material == Material.AIR || material == Material.LEAVES) {
-                trunkTopY = blockY + y;
-                // SELF, SOUTH, EAST, SOUTH EAST
-                delegate.setTypeAndRawData(world, centerX, blockY + y, centerZ,
-                    Material.LOG_2, 1);
-                delegate
-                    .setTypeAndRawData(world, centerX, blockY + y, centerZ + 1,
-                        Material.LOG_2, 1);
-                delegate
-                    .setTypeAndRawData(world, centerX + 1, blockY + y, centerZ,
-                        Material.LOG_2, 1);
-                delegate.setTypeAndRawData(world, centerX + 1, blockY + y,
-                    centerZ + 1, Material.LOG_2, 1);
+            if (material != Material.AIR && material != Material.LEAVES) {
+                continue;
             }
+            trunkTopY = blockY + y;
+            // SELF, SOUTH, EAST, SOUTH EAST
+            delegate.setTypeAndRawData(world, centerX, blockY + y, centerZ,
+                Material.LOG_2, 1);
+            delegate
+                .setTypeAndRawData(world, centerX, blockY + y, centerZ + 1,
+                    Material.LOG_2, 1);
+            delegate
+                .setTypeAndRawData(world, centerX + 1, blockY + y, centerZ,
+                    Material.LOG_2, 1);
+            delegate.setTypeAndRawData(world, centerX + 1, blockY + y,
+                centerZ + 1, Material.LOG_2, 1);
         }
 
         // generates leaves
@@ -113,27 +114,28 @@ public class DarkOakTree extends GenericTree {
         // generates some trunk excrescences
         for (int x = -1; x <= 2; x++) {
             for (int z = -1; z <= 2; z++) {
-                if ((x == -1 || z == -1 || x == 2 || z == 2) && random.nextInt(3) == 0) {
-                    for (int y = 0; y < random.nextInt(3) + 2; y++) {
-                        Material material = blockTypeAt(
-                                blockX + x, trunkTopY - y - 1, blockZ + z, world);
-                        if (material == Material.AIR || material == Material.LEAVES) {
-                            delegate.setTypeAndRawData(world, blockX + x,
-                                trunkTopY - y - 1, blockZ + z, Material.LOG_2, 1);
-                        }
+                if ((x != -1 && z != -1 && x != 2 && z != 2) || random.nextInt(3) != 0) {
+                    continue;
+                }
+                for (int y = 0; y < random.nextInt(3) + 2; y++) {
+                    Material material = blockTypeAt(
+                            blockX + x, trunkTopY - y - 1, blockZ + z, world);
+                    if (material == Material.AIR || material == Material.LEAVES) {
+                        delegate.setTypeAndRawData(world, blockX + x,
+                            trunkTopY - y - 1, blockZ + z, Material.LOG_2, 1);
                     }
+                }
 
-                    // leaves below the canopy
-                    for (int i = -1; i <= 1; i++) {
-                        for (int j = -1; j <= 1; j++) {
-                            setLeaves(centerX + x + i, trunkTopY, centerZ + z + j, world);
-                        }
+                // leaves below the canopy
+                for (int i = -1; i <= 1; i++) {
+                    for (int j = -1; j <= 1; j++) {
+                        setLeaves(centerX + x + i, trunkTopY, centerZ + z + j, world);
                     }
-                    for (int i = -2; i <= 2; i++) {
-                        for (int j = -2; j <= 2; j++) {
-                            if (Math.abs(i) < 2 || Math.abs(j) < 2) {
-                                setLeaves(centerX + x + i, trunkTopY - 1, centerZ + z + j, world);
-                            }
+                }
+                for (int i = -2; i <= 2; i++) {
+                    for (int j = -2; j <= 2; j++) {
+                        if (Math.abs(i) < 2 || Math.abs(j) < 2) {
+                            setLeaves(centerX + x + i, trunkTopY - 1, centerZ + z + j, world);
                         }
                     }
                 }

--- a/src/main/java/net/glowstone/generator/objects/trees/MegaPineTree.java
+++ b/src/main/java/net/glowstone/generator/objects/trees/MegaPineTree.java
@@ -64,23 +64,24 @@ public class MegaPineTree extends MegaRedwoodTree {
     private void generatePodzolPatch(int sourceX, int sourceY, int sourceZ, World world) {
         for (int x = -2; x <= 2; x++) {
             for (int z = -2; z <= 2; z++) {
-                if (Math.abs(x) != 2 || Math.abs(z) != 2) {
-                    for (int y = 2; y >= -3; y--) {
-                        Block block = world
-                            .getBlockAt(sourceX + x, sourceY + y, sourceZ + z);
-                        if (block.getType() == Material.GRASS || block.getType() == Material.DIRT) {
-                            BlockState state = block.getState();
-                            state.setType(Material.DIRT);
-                            DirtType dirtType = DirtType.PODZOL;
-                            if (world.getBlockAt(sourceX + x, sourceY + y + 1, sourceZ + z)
-                                .getType().isOccluding()) {
-                                dirtType = DirtType.NORMAL;
-                            }
-                            state.setData(new Dirt(dirtType));
-                            state.update(true);
-                        } else if (!block.isEmpty() && sourceY + y < sourceY) {
-                            break;
+                if (Math.abs(x) == 2 && Math.abs(z) == 2) {
+                    continue;
+                }
+                for (int y = 2; y >= -3; y--) {
+                    Block block = world
+                        .getBlockAt(sourceX + x, sourceY + y, sourceZ + z);
+                    if (block.getType() == Material.GRASS || block.getType() == Material.DIRT) {
+                        BlockState state = block.getState();
+                        state.setType(Material.DIRT);
+                        DirtType dirtType = DirtType.PODZOL;
+                        if (world.getBlockAt(sourceX + x, sourceY + y + 1, sourceZ + z)
+                            .getType().isOccluding()) {
+                            dirtType = DirtType.NORMAL;
                         }
+                        state.setData(new Dirt(dirtType));
+                        state.update(true);
+                    } else if (!block.isEmpty() && sourceY + y < sourceY) {
+                        break;
                     }
                 }
             }

--- a/src/main/java/net/glowstone/generator/objects/trees/SwampTree.java
+++ b/src/main/java/net/glowstone/generator/objects/trees/SwampTree.java
@@ -38,6 +38,9 @@ public class SwampTree extends CocoaTree {
     @Override
     public boolean canPlace(int baseX, int baseY, int baseZ, World world) {
         for (int y = baseY; y <= baseY + 1 + height; y++) {
+            if (y < 0 || y >= 256) { // height out of range
+                return false;
+            }
             // Space requirement
             int radius = 1; // default radius if above first block
             if (y == baseY) {
@@ -48,20 +51,17 @@ public class SwampTree extends CocoaTree {
             // check for block collision on horizontal slices
             for (int x = baseX - radius; x <= baseX + radius; x++) {
                 for (int z = baseZ - radius; z <= baseZ + radius; z++) {
-                    if (y >= 0 && y < 256) {
-                        // we can overlap some blocks around
-                        Material type = blockTypeAt(x, y, z, world);
-                        if (!overridables.contains(type)) {
-                            // the trunk can be immersed by 1 block of water
-                            if (type == Material.WATER || type == Material.STATIONARY_WATER) {
-                                if (y > baseY) {
-                                    return false;
-                                }
-                            } else {
-                                return false;
-                            }
+                    // we can overlap some blocks around
+                    Material type = blockTypeAt(x, y, z, world);
+                    if (overridables.contains(type)) {
+                        continue;
+                    }
+                    // the trunk can be immersed by 1 block of water
+                    if (type == Material.WATER || type == Material.STATIONARY_WATER) {
+                        if (y > baseY) {
+                            return false;
                         }
-                    } else { // height out of range
+                    } else {
                         return false;
                     }
                 }

--- a/src/main/java/net/glowstone/generator/populators/StructurePopulator.java
+++ b/src/main/java/net/glowstone/generator/populators/StructurePopulator.java
@@ -32,23 +32,25 @@ public class StructurePopulator extends BlockPopulator {
             boolean placed = false;
             for (int x = cx - 8; x <= cx + 8 && !placed; x++) {
                 for (int z = cz - 8; z <= cz + 8 && !placed; z++) {
-                    if (world.getChunkAt(x, z).isLoaded() || world.getChunkAt(x, z).load(true)) {
-                        random.setSeed(x * randX + z * randZ ^ world.getSeed());
-                        Map<Integer, GlowStructure> structures = ((GlowWorld) world)
-                            .getStructures();
-                        int key = GlowChunk.Key.of(x, z).hashCode();
-                        if (!structures.containsKey(key)) {
-                            for (StructureStore<?> store : StructureStorage.getStructureStores()) {
-                                GlowStructure structure = store
-                                    .createNewStructure((GlowWorld) world, random, x, z);
-                                if (structure.shouldGenerate(random)) {
-                                    structure.setDirty(true);
-                                    structures.put(key, structure);
-                                    GlowServer.logger.finer("structure in chunk " + x + "," + z);
-                                    placed = true;
-                                    break;
-                                }
-                            }
+                    if (!world.getChunkAt(x, z).isLoaded() && !world.getChunkAt(x, z).load(true)) {
+                        continue;
+                    }
+                    random.setSeed(x * randX + z * randZ ^ world.getSeed());
+                    Map<Integer, GlowStructure> structures = ((GlowWorld) world)
+                        .getStructures();
+                    int key = GlowChunk.Key.of(x, z).hashCode();
+                    if (structures.containsKey(key)) {
+                        continue;
+                    }
+                    for (StructureStore<?> store : StructureStorage.getStructureStores()) {
+                        GlowStructure structure = store
+                            .createNewStructure((GlowWorld) world, random, x, z);
+                        if (structure.shouldGenerate(random)) {
+                            structure.setDirty(true);
+                            structures.put(key, structure);
+                            GlowServer.logger.finer("structure in chunk " + x + "," + z);
+                            placed = true;
+                            break;
                         }
                     }
                 }

--- a/src/main/java/net/glowstone/inventory/GlowEnchantingInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowEnchantingInventory.java
@@ -61,32 +61,35 @@ public class GlowEnchantingInventory extends GlowInventory implements Enchanting
                     }
                     copyPosition(location, loc);
                     loc.add(x, 0, z);
-                    if (loc.getBlock().isEmpty()) {
-                        loc.add(0, 1, 0);
-                        if (loc.getBlock().isEmpty()) {
-                            copyPosition(location, loc);
+                    if (!loc.getBlock().isEmpty()) {
+                        continue;
+                    }
+                    loc.add(0, 1, 0);
+                    if (!loc.getBlock().isEmpty()) {
+                        continue;
+                    }
+                    copyPosition(location, loc);
 
-                            //diagonal and straight
-                            loc.add(x << 1, y, z << 1);
-                            if (loc.getBlock().getType() == Material.BOOKSHELF) {
-                                count++;
-                            }
+                    //diagonal and straight
+                    loc.add(x << 1, y, z << 1);
+                    if (loc.getBlock().getType() == Material.BOOKSHELF) {
+                        count++;
+                    }
 
-                            if (x != 0 && z != 0) {
-                                //one block diagonal and one straight
-                                copyPosition(location, loc);
-                                loc.add(x << 1, y, z);
-                                if (loc.getBlock().getType() == Material.BOOKSHELF) {
-                                    ++count;
-                                }
+                    if (x == 0 || z == 0) {
+                        continue;
+                    }
+                    //one block diagonal and one straight
+                    copyPosition(location, loc);
+                    loc.add(x << 1, y, z);
+                    if (loc.getBlock().getType() == Material.BOOKSHELF) {
+                        ++count;
+                    }
 
-                                copyPosition(location, loc);
-                                loc.add(x, y, z << 1);
-                                if (loc.getBlock().getType() == Material.BOOKSHELF) {
-                                    ++count;
-                                }
-                            }
-                        }
+                    copyPosition(location, loc);
+                    loc.add(x, y, z << 1);
+                    if (loc.getBlock().getType() == Material.BOOKSHELF) {
+                        ++count;
                     }
                 }
             }


### PR DESCRIPTION
Eliminates deeply-nested ifs using break/continue/return statements. Extracts method `TerrainObject.killPlantAbove(Block)`, which was both duplicated and overly nested, and de-duplicates the PLANT_TYPES collection that it uses.

This PR reduces the nesting depth to 5 or less within 20 of the 27 methods where it currently exceeds that number, found using the "Overly nested method" inspection in IntelliJ IDEA.

Also fixes apparent bugs in MesaGroundGenerator where `colorNoise::noise` was being called with the X coordinate as both X and Y parameters, which would have caused horizontal stripes in mesas where colored terracotta was present.