### PR TITLE
Add ClearCommandTest, and refactor *CommandTest

### DIFF
--- a/src/main/java/net/glowstone/command/minecraft/ClearCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/ClearCommand.java
@@ -182,7 +182,12 @@ public class ClearCommand extends VanillaCommand {
     private boolean clearAll(CommandSender sender, Player player, Material material, int data,
         int maxCount) {
         int count = countAllItems(player.getInventory(), material, data, maxCount);
-        if (count == 0 && maxCount != 0) {
+        if (maxCount == 0) {
+            sender.sendMessage(player.getName() + " has " + count
+                    + " items that match the criteria");
+            return true;
+        }
+        if (count == 0) {
             sender.sendMessage(
                 ChatColor.RED + "Could not clear the inventory of " + player.getName()
                     + ", no items to remove");
@@ -198,10 +203,6 @@ public class ClearCommand extends VanillaCommand {
                     // matches type and data
                     if (maxCount == -1) {
                         player.getInventory().remove(stack);
-                    } else if (maxCount == 0) {
-                        sender.sendMessage(player.getName() + " has " + count
-                            + " items that match the criteria");
-                        return true;
                     } else {
                         int oldAmount = stack.getAmount();
                         int removed = Math.min(oldAmount, remaining);

--- a/src/main/java/net/glowstone/inventory/GlowInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowInventory.java
@@ -527,6 +527,20 @@ public class GlowInventory implements Inventory {
 
     }
 
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(getClass().getSimpleName());
+        sb.append(" for ").append(getHolder()).append(":\n");
+        for (GlowInventorySlot slot : slots) {
+            ItemStack item = slot.getItem();
+            SlotType type = slot.getType();
+            if (type != SlotType.CONTAINER || !InventoryUtil.isEmpty(item)) {
+                sb.append(item).append(" in ").append(slot.getType()).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // Contains
 

--- a/src/test/java/net/glowstone/TestUtils.java
+++ b/src/test/java/net/glowstone/TestUtils.java
@@ -29,9 +29,14 @@ public class TestUtils {
                 matches += item.getAmount();
             }
         }
+        /* TODO once ItemStack.toString() is fixed for tests:
         assertEquals(
-                String.format("Expected exactly %d items but found %d, matching %s against:%n%s",
+                String.format("Expected exactly %d items but found %d, matching {%s} against:%n%s",
                         expectedMatches, matches, filter, inventory), expectedMatches, matches);
+        */
+        assertEquals(
+                String.format("Expected exactly %d items but found %d, matching {%s}",
+                        expectedMatches, matches, filter), expectedMatches, matches);
     }
 
     /**

--- a/src/test/java/net/glowstone/TestUtils.java
+++ b/src/test/java/net/glowstone/TestUtils.java
@@ -1,0 +1,76 @@
+package net.glowstone;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+import java.util.function.Predicate;
+import org.bukkit.Material;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Static methods used in multiple packages, but only by tests.
+ */
+public class TestUtils {
+
+    /**
+     * Asserts that exactly the expected number of items matching a predicate are in the given
+     * inventory, summed across all stacks.
+     *
+     * @param inventory the inventory to scan
+     * @param expectedMatches the number of matching items to expect
+     * @param filter the predicate that determines which items match
+     */
+    public static void checkInventory(Inventory inventory, int expectedMatches,
+            Predicate<ItemStack> filter) {
+        int matches = 0;
+        for (ItemStack item : inventory.getContents()) {
+            if (item != null && filter.test(item)) {
+                matches += item.getAmount();
+            }
+        }
+        assertEquals(
+                String.format("Expected exactly %d items but found %d, matching %s against:%n%s",
+                        expectedMatches, matches, filter, inventory), expectedMatches, matches);
+    }
+
+    /**
+     * Returns a {@link Predicate} matching items of one specific type, with a friendly {@link
+     * #toString()} implementation.
+     *
+     * @param type the type to match
+     * @return a Predicate for matching items
+     */
+    public static Predicate<ItemStack> itemTypeMatcher(final Material type) {
+        return new Predicate<ItemStack>() {
+            @Override
+            public boolean test(ItemStack item) {
+                return item.getType() == type;
+            }
+            @Override
+            public String toString() {
+                return "items of type " + type;
+            }
+        };
+    }
+
+    /**
+     * Returns a {@link Predicate} matching items of a collection of specific types, with a friendly
+     * {@link #toString()} implementation.
+     *
+     * @param types the types to match any of
+     * @return a Predicate for matching items
+     */
+    public static Predicate<ItemStack> itemTypeMatcher(final Collection<Material> types) {
+        return new Predicate<ItemStack>() {
+            @Override
+            public boolean test(ItemStack item) {
+                return types.contains(item.getType());
+            }
+            @Override
+            public String toString() {
+                return "items of types " + types;
+            }
+        };
+    }
+}

--- a/src/test/java/net/glowstone/command/minecraft/ClearCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/ClearCommandTest.java
@@ -15,21 +15,18 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class ClearCommandTest extends CommandTestWithFakePlayers {
+public class ClearCommandTest extends CommandTestWithFakePlayers<ClearCommand> {
     private GlowPlayerInventory inventory;
 
     public ClearCommandTest() {
-        super("ChuckNorris");
+        super(ClearCommand::new, "ChuckNorris");
     }
 
     @Override
     @Before
     public void before() {
         super.before();
-        /* FIXME: Intended to prevent NPE in ItemStack.toString(), but causes failures: */
         when(Bukkit.getItemFactory()).thenReturn(GlowItemFactory.instance());
-        /**/
-        command = new ClearCommand();
         inventory = new GlowPlayerInventory(fakePlayers[0]);
         inventory.setItemInMainHand(new ItemStack(Material.DIRT, 32));
         inventory.setItemInOffHand(new ItemStack(Material.DIAMOND_AXE, 1, (short) 30));

--- a/src/test/java/net/glowstone/command/minecraft/ClearCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/ClearCommandTest.java
@@ -1,0 +1,88 @@
+package net.glowstone.command.minecraft;
+
+import static net.glowstone.TestUtils.checkInventory;
+import static net.glowstone.TestUtils.itemTypeMatcher;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import net.glowstone.inventory.GlowItemFactory;
+import net.glowstone.inventory.GlowPlayerInventory;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ClearCommandTest extends CommandTestWithFakePlayers {
+    private GlowPlayerInventory inventory;
+
+    public ClearCommandTest() {
+        super("ChuckNorris");
+    }
+
+    @Override
+    @Before
+    public void before() {
+        super.before();
+        /* FIXME: Intended to prevent NPE in ItemStack.toString(), but causes failures: */
+        when(Bukkit.getItemFactory()).thenReturn(GlowItemFactory.instance());
+        /**/
+        command = new ClearCommand();
+        inventory = new GlowPlayerInventory(fakePlayers[0]);
+        inventory.setItemInMainHand(new ItemStack(Material.DIRT, 32));
+        inventory.setItemInOffHand(new ItemStack(Material.DIAMOND_AXE, 1, (short) 30));
+        inventory.setItem(9, new ItemStack(Material.DIRT, 64));
+        inventory.setItem(10, new ItemStack(Material.DIAMOND));
+        inventory.setItem(11, new ItemStack(Material.DIAMOND_AXE));
+        when(fakePlayers[0].getInventory()).thenReturn(inventory);
+    }
+
+    @Test
+    public void testClearAll() {
+        assertTrue(command.execute(opSender, "label", new String[]{"ChuckNorris"}));
+        checkInventory(inventory, 0, item -> true); // should be empty
+    }
+
+    @Test
+    public void testCountOnly() {
+        assertTrue(command.execute(opSender, "label",
+                new String[]{"ChuckNorris", "minecraft:diamond_axe", "-1", "0"}));
+        Mockito.verify(opSender)
+                .sendMessage(eq("ChuckNorris has 2 items that match the criteria"));
+        checkInventory(inventory, 96, itemTypeMatcher(Material.DIRT));
+        checkInventory(inventory, 2, itemTypeMatcher(Material.DIAMOND_AXE));
+        checkInventory(inventory, 1, itemTypeMatcher(Material.DIAMOND));
+    }
+
+    @Test
+    public void testClearSpecificItemAll() {
+        assertTrue(command.execute(opSender, "label",
+                new String[]{"ChuckNorris", "minecraft:diamond_axe", "-1", "-1"}));
+        checkInventory(inventory, 96, itemTypeMatcher(Material.DIRT));
+        checkInventory(inventory, 0, itemTypeMatcher(Material.DIAMOND_AXE));
+        checkInventory(inventory, 1, itemTypeMatcher(Material.DIAMOND));
+    }
+
+    @Test
+    public void testClearSpecificItemLimited() {
+        assertTrue(command.execute(opSender, "label",
+                new String[]{"ChuckNorris", "minecraft:dirt", "-1", "50"}));
+        checkInventory(inventory, 46, itemTypeMatcher(Material.DIRT));
+        checkInventory(inventory, 2, itemTypeMatcher(Material.DIAMOND_AXE));
+        checkInventory(inventory, 1, itemTypeMatcher(Material.DIAMOND));
+    }
+
+    @Test
+    public void testClearSpecificItemSpecificData() {
+        assertTrue(command.execute(opSender, "label",
+                new String[]{"ChuckNorris", "minecraft:diamond_axe", "30", "-1"}));
+        checkInventory(inventory, 96, itemTypeMatcher(Material.DIRT));
+        checkInventory(inventory, 0,
+                itemTypeMatcher(Material.DIAMOND_AXE).and(item -> item.getDurability() == 30));
+        checkInventory(inventory, 1,
+                itemTypeMatcher(Material.DIAMOND_AXE).and(item -> item.getDurability() == 0));
+        checkInventory(inventory, 1, itemTypeMatcher(Material.DIAMOND));
+    }
+}

--- a/src/test/java/net/glowstone/command/minecraft/CommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/CommandTest.java
@@ -70,8 +70,6 @@ public abstract class CommandTest<T extends Command> {
             Mockito.doReturn(ImmutableList.copyOf(players)).when(server).getOnlinePlayers();
         }
         if (world != null) {
-            // Can't use ImmutableList here because we're building List<Entity> from GlowPlayer[]
-            // FIXME: Redefine World.getEntities() to return List<? extends Entity>
             when(world.getEntities()).thenReturn(ImmutableList.copyOf(players));
         }
         return players;

--- a/src/test/java/net/glowstone/command/minecraft/CommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/CommandTest.java
@@ -1,0 +1,37 @@
+package net.glowstone.command.minecraft;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+
+import net.glowstone.command.CommandUtils;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Bukkit.class, CommandUtils.class})
+public abstract class CommandTest {
+    protected CommandSender sender;
+    protected Command command;
+
+    @Test
+    public void testExecuteFailsWithoutPermission() {
+        assertThat(command.execute(sender, "label", new String[0]), is(false));
+        Mockito.verify(sender).sendMessage(eq(ChatColor.RED
+            + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error."));
+    }
+
+    @Before
+    public void before() {
+        sender = PowerMockito.mock(CommandSender.class);
+    }
+}

--- a/src/test/java/net/glowstone/command/minecraft/CommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/CommandTest.java
@@ -7,8 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import com.google.common.collect.ImmutableList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
@@ -19,7 +18,6 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,10 +29,15 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, CommandUtils.class})
-public abstract class CommandTest {
+public abstract class CommandTest<T extends Command> {
     protected CommandSender sender;
     protected CommandSender opSender;
-    protected Command command;
+    protected T command;
+    protected final Supplier<T> commandSupplier;
+
+    protected CommandTest(Supplier<T> commandSupplier) {
+        this.commandSupplier = commandSupplier;
+    }
 
     @Test
     public void testExecuteFailsWithoutPermission() {
@@ -45,6 +48,7 @@ public abstract class CommandTest {
 
     @Before
     public void before() {
+        command = commandSupplier.get();
         sender = PowerMockito.mock(CommandSender.class);
         opSender = PowerMockito.mock(CommandSender.class);
         Mockito.when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);

--- a/src/test/java/net/glowstone/command/minecraft/CommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/CommandTest.java
@@ -21,6 +21,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest({Bukkit.class, CommandUtils.class})
 public abstract class CommandTest {
     protected CommandSender sender;
+    protected CommandSender opSender;
     protected Command command;
 
     @Test
@@ -33,5 +34,7 @@ public abstract class CommandTest {
     @Before
     public void before() {
         sender = PowerMockito.mock(CommandSender.class);
+        opSender = PowerMockito.mock(CommandSender.class);
+        Mockito.when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
     }
 }

--- a/src/test/java/net/glowstone/command/minecraft/CommandTestWithFakePlayers.java
+++ b/src/test/java/net/glowstone/command/minecraft/CommandTestWithFakePlayers.java
@@ -1,0 +1,29 @@
+package net.glowstone.command.minecraft;
+
+import net.glowstone.GlowServer;
+import net.glowstone.GlowWorld;
+import net.glowstone.entity.GlowPlayer;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.powermock.api.mockito.PowerMockito;
+
+public abstract class CommandTestWithFakePlayers extends CommandTest {
+    private final String[] names;
+    protected GlowWorld world;
+    protected GlowServer server;
+    protected GlowPlayer[] fakePlayers;
+    protected Location location;
+
+    protected CommandTestWithFakePlayers(String... names) {
+        this.names = names;
+    }
+
+    @Override
+    public void before() {
+        super.before();
+        server = PowerMockito.mock(GlowServer.class);
+        world = PowerMockito.mock(GlowWorld.class);
+        location = new Location(world, 10.5, 20.0, 30.5);
+        fakePlayers = prepareMockPlayers(location, server, world, names);
+    }
+}

--- a/src/test/java/net/glowstone/command/minecraft/CommandTestWithFakePlayers.java
+++ b/src/test/java/net/glowstone/command/minecraft/CommandTestWithFakePlayers.java
@@ -1,20 +1,22 @@
 package net.glowstone.command.minecraft;
 
+import java.util.function.Supplier;
 import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.Location;
-import org.bukkit.entity.Player;
+import org.bukkit.command.Command;
 import org.powermock.api.mockito.PowerMockito;
 
-public abstract class CommandTestWithFakePlayers extends CommandTest {
+public abstract class CommandTestWithFakePlayers<T extends Command> extends CommandTest<T> {
     private final String[] names;
     protected GlowWorld world;
     protected GlowServer server;
     protected GlowPlayer[] fakePlayers;
     protected Location location;
 
-    protected CommandTestWithFakePlayers(String... names) {
+    protected CommandTestWithFakePlayers(Supplier<T> commandSupplier, String... names) {
+        super(commandSupplier);
         this.names = names;
     }
 

--- a/src/test/java/net/glowstone/command/minecraft/PlaySoundCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/PlaySoundCommandTest.java
@@ -26,19 +26,18 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, CommandUtils.class})
-public class PlaySoundCommandTest extends CommandTestWithFakePlayers {
+public class PlaySoundCommandTest extends CommandTestWithFakePlayers<PlaySoundCommand> {
 
     protected CommandSender opPlayer;
 
     public PlaySoundCommandTest() {
-        super("player1", "player2", "thePlayer3");
+        super(PlaySoundCommand::new, "player1", "player2", "thePlayer3");
     }
 
     @Before
     public void before() {
         super.before();
         opPlayer = PowerMockito.mock(Player.class);
-        command = new PlaySoundCommand();
         Mockito.when(sender.getServer()).thenReturn(server);
         Mockito.when(opSender.getServer()).thenReturn(server);
         Mockito.when(opPlayer.hasPermission(Mockito.anyString())).thenReturn(true);

--- a/src/test/java/net/glowstone/command/minecraft/PlaySoundCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/PlaySoundCommandTest.java
@@ -39,14 +39,12 @@ public class PlaySoundCommandTest extends CommandTest {
 
     private GlowServer server;
 
-    protected CommandSender opSender;
     protected CommandSender opPlayer;
 
     @Before
     public void before() {
         super.before();
         command = new PlaySoundCommand();
-        opSender = PowerMockito.mock(CommandSender.class);
         opPlayer = PowerMockito.mock(Player.class);
         server = PowerMockito.mock(GlowServer.class);
         world = PowerMockito.mock(GlowWorld.class);
@@ -66,7 +64,6 @@ public class PlaySoundCommandTest extends CommandTest {
         Mockito.when(fakePlayer2.getType()).thenReturn(EntityType.PLAYER);
         Mockito.when(fakePlayer3.getType()).thenReturn(EntityType.PLAYER);
 
-        Mockito.when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
         Mockito.when(opSender.getServer()).thenReturn(server);
 
         Mockito.when(opPlayer.hasPermission(Mockito.anyString())).thenReturn(true);

--- a/src/test/java/net/glowstone/command/minecraft/PlaySoundCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/PlaySoundCommandTest.java
@@ -7,19 +7,14 @@ import static org.mockito.Matchers.eq;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
-import net.glowstone.GlowServer;
-import net.glowstone.GlowWorld;
 import net.glowstone.command.CommandUtils;
-import net.glowstone.entity.GlowPlayer;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,56 +26,24 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, CommandUtils.class})
-public class PlaySoundCommandTest extends CommandTest {
-
-    private Player fakePlayer1, fakePlayer2, fakePlayer3;
-
-    private GlowWorld world;
-
-    private GlowServer server;
+public class PlaySoundCommandTest extends CommandTestWithFakePlayers {
 
     protected CommandSender opPlayer;
+
+    public PlaySoundCommandTest() {
+        super("player1", "player2", "thePlayer3");
+    }
 
     @Before
     public void before() {
         super.before();
-        command = new PlaySoundCommand();
         opPlayer = PowerMockito.mock(Player.class);
-        server = PowerMockito.mock(GlowServer.class);
-        world = PowerMockito.mock(GlowWorld.class);
-
-        fakePlayer1 = PowerMockito.mock(GlowPlayer.class);
-        fakePlayer2 = PowerMockito.mock(GlowPlayer.class);
-        fakePlayer3 = PowerMockito.mock(GlowPlayer.class);
-
-        final Location location = new Location(world, 10.5, 20.0, 30.5);
-        Mockito.when(fakePlayer1.getName()).thenReturn("player1");
-        Mockito.when(fakePlayer2.getName()).thenReturn("player2");
-        Mockito.when(fakePlayer3.getName()).thenReturn("thePlayer3");
-        Mockito.when(fakePlayer1.getLocation()).thenReturn(location);
-        Mockito.when(fakePlayer2.getLocation()).thenReturn(location);
-        Mockito.when(fakePlayer3.getLocation()).thenReturn(location);
-        Mockito.when(fakePlayer1.getType()).thenReturn(EntityType.PLAYER);
-        Mockito.when(fakePlayer2.getType()).thenReturn(EntityType.PLAYER);
-        Mockito.when(fakePlayer3.getType()).thenReturn(EntityType.PLAYER);
-
+        command = new PlaySoundCommand();
+        Mockito.when(sender.getServer()).thenReturn(server);
         Mockito.when(opSender.getServer()).thenReturn(server);
-
         Mockito.when(opPlayer.hasPermission(Mockito.anyString())).thenReturn(true);
         Mockito.when(opPlayer.getName()).thenReturn("ChuckNorris");
         Mockito.when(((Entity) opPlayer).getLocation()).thenReturn(location);
-
-        Mockito.doReturn(ImmutableList.of(fakePlayer1, fakePlayer2, fakePlayer3))
-            .when(server).getOnlinePlayers();
-
-        Mockito.when(world.getEntities())
-            .thenReturn(ImmutableList.of(fakePlayer1, fakePlayer2, fakePlayer3));
-
-        PowerMockito.mockStatic(Bukkit.class);
-        Mockito.when(Bukkit.getPlayerExact("player1")).thenReturn(fakePlayer1);
-        Mockito.when(Bukkit.getPlayerExact("player2")).thenReturn(fakePlayer2);
-        Mockito.when(Bukkit.getPlayerExact("thePlayer3")).thenReturn(fakePlayer3);
-
         PowerMockito.stub(PowerMockito.method(CommandUtils.class, "getWorld", CommandSender.class))
             .toReturn(world);
     }

--- a/src/test/java/net/glowstone/command/minecraft/PlaySoundCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/PlaySoundCommandTest.java
@@ -31,7 +31,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, CommandUtils.class})
-public class PlaySoundCommandTest {
+public class PlaySoundCommandTest extends CommandTest {
 
     private Player fakePlayer1, fakePlayer2, fakePlayer3;
 
@@ -39,14 +39,13 @@ public class PlaySoundCommandTest {
 
     private GlowServer server;
 
-    private CommandSender sender, opSender, opPlayer;
-
-    private Command command;
+    protected CommandSender opSender;
+    protected CommandSender opPlayer;
 
     @Before
     public void before() {
+        super.before();
         command = new PlaySoundCommand();
-        sender = PowerMockito.mock(CommandSender.class);
         opSender = PowerMockito.mock(CommandSender.class);
         opPlayer = PowerMockito.mock(Player.class);
         server = PowerMockito.mock(GlowServer.class);
@@ -87,13 +86,6 @@ public class PlaySoundCommandTest {
 
         PowerMockito.stub(PowerMockito.method(CommandUtils.class, "getWorld", CommandSender.class))
             .toReturn(world);
-    }
-
-    @Test
-    public void testExecuteFailsWithoutPermission() {
-        assertThat(command.execute(sender, "label", new String[0]), is(false));
-        Mockito.verify(sender).sendMessage(eq(ChatColor.RED
-            + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error."));
     }
 
     @Test

--- a/src/test/java/net/glowstone/command/minecraft/SetIdleTimeoutCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SetIdleTimeoutCommandTest.java
@@ -15,11 +15,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 
-public class SetIdleTimeoutCommandTest {
+public class SetIdleTimeoutCommandTest extends CommandTest {
 
-    private CommandSender sender, opSender;
-
-    private Command command;
+    private CommandSender opSender;
 
     @BeforeEach
     public void before() {
@@ -29,15 +27,6 @@ public class SetIdleTimeoutCommandTest {
 
         Mockito.when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
         ServerProvider.setMockServer(PowerMockito.mock(GlowServer.class));
-    }
-
-    @Test
-    public void testExecuteFailsWithoutPermission() {
-        final boolean commandResult = command.execute(sender, "label", new String[0]);
-
-        MatcherAssert.assertThat(commandResult, is(false));
-        Mockito.verify(sender).sendMessage(eq(ChatColor.RED
-            + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error."));
     }
 
     @Test

--- a/src/test/java/net/glowstone/command/minecraft/SetIdleTimeoutCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SetIdleTimeoutCommandTest.java
@@ -13,14 +13,16 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 
-public class SetIdleTimeoutCommandTest extends CommandTest {
+public class SetIdleTimeoutCommandTest extends CommandTest<SetIdleTimeoutCommand> {
+
+    public SetIdleTimeoutCommandTest() {
+        super(SetIdleTimeoutCommand::new);
+    }
 
     @Before
     @Override
     public void before() {
         super.before();
-        command = new SetIdleTimeoutCommand();
-
         ServerProvider.setMockServer(PowerMockito.mock(GlowServer.class));
     }
 

--- a/src/test/java/net/glowstone/command/minecraft/SetIdleTimeoutCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SetIdleTimeoutCommandTest.java
@@ -7,25 +7,20 @@ import java.util.Collections;
 import net.glowstone.GlowServer;
 import net.glowstone.ServerProvider;
 import org.bukkit.ChatColor;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
 import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 
 public class SetIdleTimeoutCommandTest extends CommandTest {
 
-    private CommandSender opSender;
-
-    @BeforeEach
+    @Before
+    @Override
     public void before() {
-        sender = PowerMockito.mock(CommandSender.class);
-        opSender = PowerMockito.mock(CommandSender.class);
+        super.before();
         command = new SetIdleTimeoutCommand();
 
-        Mockito.when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
         ServerProvider.setMockServer(PowerMockito.mock(GlowServer.class));
     }
 

--- a/src/test/java/net/glowstone/command/minecraft/SetWorldSpawnCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SetWorldSpawnCommandTest.java
@@ -23,18 +23,16 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({CommandUtils.class})
-public class SetWorldSpawnCommandTest {
+public class SetWorldSpawnCommandTest extends CommandTest {
 
-    private CommandSender sender, opSender, opPlayer;
+    protected CommandSender opPlayer;
 
     private GlowWorld world;
 
-    private Command command;
-
     @Before
+    @Override
     public void before() {
-        sender = PowerMockito.mock(CommandSender.class);
-        opSender = PowerMockito.mock(CommandSender.class);
+        super.before();
         opPlayer = PowerMockito.mock(Player.class);
         world = PowerMockito.mock(GlowWorld.class);
         command = new SetWorldSpawnCommand();
@@ -50,13 +48,6 @@ public class SetWorldSpawnCommandTest {
 
         PowerMockito.stub(PowerMockito.method(CommandUtils.class, "getWorld", CommandSender.class))
             .toReturn(world);
-    }
-
-    @Test
-    public void testExecuteFailsWithoutPermission() {
-        assertThat(command.execute(sender, "label", new String[0]), is(false));
-        Mockito.verify(sender).sendMessage(eq(ChatColor.RED
-            + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error."));
     }
 
     @Test

--- a/src/test/java/net/glowstone/command/minecraft/SetWorldSpawnCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SetWorldSpawnCommandTest.java
@@ -33,19 +33,12 @@ public class SetWorldSpawnCommandTest extends CommandTest {
     @Override
     public void before() {
         super.before();
-        opPlayer = PowerMockito.mock(Player.class);
         world = PowerMockito.mock(GlowWorld.class);
+        opPlayer = prepareMockPlayers(
+                new Location(world, 10.5, 20.0, 30.5), null, world, "ChuckNorris")[0];
         command = new SetWorldSpawnCommand();
-
-        Mockito.when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
-
         Mockito.when(opPlayer.hasPermission(Mockito.anyString())).thenReturn(true);
-        Mockito.when(opPlayer.getName()).thenReturn("ChuckNorris");
-        Mockito.when(((Entity) opPlayer).getLocation())
-            .thenReturn(new Location(world, 10.5, 20.0, 30.5));
-
         Mockito.when(world.getMaxHeight()).thenReturn(50);
-
         PowerMockito.stub(PowerMockito.method(CommandUtils.class, "getWorld", CommandSender.class))
             .toReturn(world);
     }

--- a/src/test/java/net/glowstone/command/minecraft/SetWorldSpawnCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SetWorldSpawnCommandTest.java
@@ -9,10 +9,7 @@ import net.glowstone.GlowWorld;
 import net.glowstone.command.CommandUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,11 +20,15 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({CommandUtils.class})
-public class SetWorldSpawnCommandTest extends CommandTest {
+public class SetWorldSpawnCommandTest extends CommandTest<SetWorldSpawnCommand> {
 
     protected CommandSender opPlayer;
 
     private GlowWorld world;
+
+    public SetWorldSpawnCommandTest() {
+        super(SetWorldSpawnCommand::new);
+    }
 
     @Before
     @Override
@@ -36,7 +37,6 @@ public class SetWorldSpawnCommandTest extends CommandTest {
         world = PowerMockito.mock(GlowWorld.class);
         opPlayer = prepareMockPlayers(
                 new Location(world, 10.5, 20.0, 30.5), null, world, "ChuckNorris")[0];
-        command = new SetWorldSpawnCommand();
         Mockito.when(opPlayer.hasPermission(Mockito.anyString())).thenReturn(true);
         Mockito.when(world.getMaxHeight()).thenReturn(50);
         PowerMockito.stub(PowerMockito.method(CommandUtils.class, "getWorld", CommandSender.class))

--- a/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
@@ -27,13 +27,11 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, CommandUtils.class})
-public class SpawnPointCommandTest {
+public class SpawnPointCommandTest extends CommandTest {
 
-    private CommandSender sender, opSender, opPlayer;
+    private CommandSender opPlayer;
 
     private Player fakePlayer1, fakePlayer2, fakePlayer3;
-
-    private Command command;
 
     private GlowWorld world;
 
@@ -41,14 +39,12 @@ public class SpawnPointCommandTest {
 
     @Before
     public void before() {
+        super.before();
         server = PowerMockito.mock(GlowServer.class);
-
         fakePlayer1 = PowerMockito.mock(Player.class);
         fakePlayer2 = PowerMockito.mock(Player.class);
         fakePlayer3 = PowerMockito.mock(Player.class);
 
-        sender = PowerMockito.mock(CommandSender.class);
-        opSender = PowerMockito.mock(CommandSender.class);
         opPlayer = PowerMockito.mock(Player.class);
         world = PowerMockito.mock(GlowWorld.class);
         command = new SpawnPointCommand();
@@ -64,7 +60,6 @@ public class SpawnPointCommandTest {
         Mockito.when(fakePlayer2.getType()).thenReturn(EntityType.PLAYER);
         Mockito.when(fakePlayer3.getType()).thenReturn(EntityType.PLAYER);
 
-        Mockito.when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
         Mockito.when(opSender.getServer()).thenReturn(server);
 
         Mockito.when(opPlayer.hasPermission(Mockito.anyString())).thenReturn(true);

--- a/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
@@ -6,16 +6,12 @@ import static org.mockito.Matchers.eq;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
-import net.glowstone.GlowServer;
-import net.glowstone.GlowWorld;
 import net.glowstone.command.CommandUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,12 +23,12 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, CommandUtils.class})
-public class SpawnPointCommandTest extends CommandTestWithFakePlayers {
+public class SpawnPointCommandTest extends CommandTestWithFakePlayers<SpawnPointCommand> {
 
     private CommandSender opPlayer;
 
     public SpawnPointCommandTest() {
-        super("player1", "player2", "thePlayer3");
+        super(SpawnPointCommand::new, "player1", "player2", "thePlayer3");
     }
 
     @Before
@@ -40,7 +36,6 @@ public class SpawnPointCommandTest extends CommandTestWithFakePlayers {
         super.before();
 
         opPlayer = PowerMockito.mock(Player.class);
-        command = new SpawnPointCommand();
         Mockito.when(opSender.getServer()).thenReturn(server);
         Mockito.when(opPlayer.hasPermission(Mockito.anyString())).thenReturn(true);
         Mockito.when(opPlayer.getName()).thenReturn("ChuckNorris");

--- a/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/SpawnPointCommandTest.java
@@ -27,57 +27,25 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Bukkit.class, CommandUtils.class})
-public class SpawnPointCommandTest extends CommandTest {
+public class SpawnPointCommandTest extends CommandTestWithFakePlayers {
 
     private CommandSender opPlayer;
 
-    private Player fakePlayer1, fakePlayer2, fakePlayer3;
-
-    private GlowWorld world;
-
-    private GlowServer server;
+    public SpawnPointCommandTest() {
+        super("player1", "player2", "thePlayer3");
+    }
 
     @Before
     public void before() {
         super.before();
-        server = PowerMockito.mock(GlowServer.class);
-        fakePlayer1 = PowerMockito.mock(Player.class);
-        fakePlayer2 = PowerMockito.mock(Player.class);
-        fakePlayer3 = PowerMockito.mock(Player.class);
 
         opPlayer = PowerMockito.mock(Player.class);
-        world = PowerMockito.mock(GlowWorld.class);
         command = new SpawnPointCommand();
-
-        final Location location = new Location(world, 10.5, 20.0, 30.5);
-        Mockito.when(fakePlayer1.getName()).thenReturn("player1");
-        Mockito.when(fakePlayer2.getName()).thenReturn("player2");
-        Mockito.when(fakePlayer3.getName()).thenReturn("thePlayer3");
-        Mockito.when(fakePlayer1.getLocation()).thenReturn(location);
-        Mockito.when(fakePlayer2.getLocation()).thenReturn(location);
-        Mockito.when(fakePlayer3.getLocation()).thenReturn(location);
-        Mockito.when(fakePlayer1.getType()).thenReturn(EntityType.PLAYER);
-        Mockito.when(fakePlayer2.getType()).thenReturn(EntityType.PLAYER);
-        Mockito.when(fakePlayer3.getType()).thenReturn(EntityType.PLAYER);
-
         Mockito.when(opSender.getServer()).thenReturn(server);
-
         Mockito.when(opPlayer.hasPermission(Mockito.anyString())).thenReturn(true);
         Mockito.when(opPlayer.getName()).thenReturn("ChuckNorris");
         Mockito.when(((Entity) opPlayer).getLocation()).thenReturn(location);
-
-        Mockito.doReturn(ImmutableList.of(fakePlayer1, fakePlayer2, fakePlayer3))
-            .when(server).getOnlinePlayers();
-
         Mockito.when(world.getMaxHeight()).thenReturn(50);
-        Mockito.when(world.getEntities())
-            .thenReturn(ImmutableList.of(fakePlayer1, fakePlayer2, fakePlayer3));
-
-        PowerMockito.mockStatic(Bukkit.class);
-        Mockito.when(Bukkit.getPlayerExact("player1")).thenReturn(fakePlayer1);
-        Mockito.when(Bukkit.getPlayerExact("player2")).thenReturn(fakePlayer2);
-        Mockito.when(Bukkit.getPlayerExact("thePlayer3")).thenReturn(fakePlayer3);
-
         PowerMockito.stub(PowerMockito.method(CommandUtils.class, "getWorld", CommandSender.class))
             .toReturn(world);
     }

--- a/src/test/java/net/glowstone/command/minecraft/StopCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/StopCommandTest.java
@@ -14,29 +14,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class StopCommandTest {
+public class StopCommandTest extends CommandTest {
     private GlowServer server;
 
-    private CommandSender sender, opSender;
-
-    private Command command;
-
     @BeforeEach
+    @Override
     public void before() {
+        super.before();
         command = new StopCommand();
-        sender = Mockito.mock(CommandSender.class);
-        opSender = Mockito.mock(CommandSender.class);
         server = Mockito.mock(GlowServer.class);
         ServerProvider.setMockServer(server);
-        when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
         when(opSender.getServer()).thenReturn(server);
-    }
-
-    @Test
-    public void testExecuteFailsWithoutPermission() {
-        assertThat(command.execute(sender, "label", new String[0]), is(false));
-        Mockito.verify(sender).sendMessage(eq(ChatColor.RED
-                + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error."));
     }
 
     @Test

--- a/src/test/java/net/glowstone/command/minecraft/StopCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/StopCommandTest.java
@@ -7,21 +7,21 @@ import static org.mockito.Mockito.when;
 
 import net.glowstone.GlowServer;
 import net.glowstone.ServerProvider;
-import org.bukkit.ChatColor;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-public class StopCommandTest extends CommandTest {
+public class StopCommandTest extends CommandTest<StopCommand> {
     private GlowServer server;
+
+    public StopCommandTest() {
+        super(StopCommand::new);
+    }
 
     @BeforeEach
     @Override
     public void before() {
         super.before();
-        command = new StopCommand();
         server = Mockito.mock(GlowServer.class);
         ServerProvider.setMockServer(server);
         when(opSender.getServer()).thenReturn(server);

--- a/src/test/java/net/glowstone/command/minecraft/TestForBlocksCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/TestForBlocksCommandTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Objects;
 import net.glowstone.GlowWorld;
 import net.glowstone.testutils.InMemoryBlockStorage;
 import org.bukkit.ChatColor;
@@ -17,16 +16,19 @@ import org.junit.Before;
 import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
 
-public class TestForBlocksCommandTest extends CommandTest {
+public class TestForBlocksCommandTest extends CommandTest<TestForBlocksCommand> {
     private InMemoryBlockStorage blockStorage;
     private Player opPlayer;
     private GlowWorld world;
+
+    public TestForBlocksCommandTest() {
+        super(TestForBlocksCommand::new);
+    }
 
     @Override
     @Before
     public void before() {
         super.before();
-        command = new TestForBlocksCommand();
         blockStorage = new InMemoryBlockStorage();
         opPlayer = PowerMockito.mock(Player.class);
         world = PowerMockito.mock(GlowWorld.class);

--- a/src/test/java/net/glowstone/command/minecraft/TestForBlocksCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/TestForBlocksCommandTest.java
@@ -6,24 +6,26 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Objects;
 import net.glowstone.GlowWorld;
 import net.glowstone.testutils.InMemoryBlockStorage;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.powermock.api.mockito.PowerMockito;
 
-public class TestForBlocksCommandTest {
-    private TestForBlocksCommand command;
+public class TestForBlocksCommandTest extends CommandTest {
     private InMemoryBlockStorage blockStorage;
     private Player opPlayer;
     private GlowWorld world;
 
-    @BeforeEach
-    public void before() throws Exception {
+    @Override
+    @Before
+    public void before() {
+        super.before();
         command = new TestForBlocksCommand();
         blockStorage = new InMemoryBlockStorage();
         opPlayer = PowerMockito.mock(Player.class);

--- a/src/test/java/net/glowstone/command/minecraft/ToggleDownfallCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/ToggleDownfallCommandTest.java
@@ -20,14 +20,11 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({CommandUtils.class})
-public class ToggleDownfallCommandTest {
+public class ToggleDownfallCommandTest extends CommandTest {
 
     private World world;
 
-    private Command command;
-
-    private CommandSender sender, opSender;
-
+    @Override
     @Before
     public void before() {
         world = PowerMockito.mock(GlowWorld.class);
@@ -38,11 +35,6 @@ public class ToggleDownfallCommandTest {
         Mockito.when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
         PowerMockito.stub(PowerMockito.method(CommandUtils.class, "getWorld", CommandSender.class))
             .toReturn(world);
-    }
-
-    @Test
-    public void testExecuteFailsWithoutPermission() {
-        assertThat(command.execute(sender, "label", new String[0]), is(false));
     }
 
     @Test

--- a/src/test/java/net/glowstone/command/minecraft/ToggleDownfallCommandTest.java
+++ b/src/test/java/net/glowstone/command/minecraft/ToggleDownfallCommandTest.java
@@ -8,7 +8,6 @@ import java.util.Collections;
 import net.glowstone.GlowWorld;
 import net.glowstone.command.CommandUtils;
 import org.bukkit.World;
-import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,19 +19,19 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({CommandUtils.class})
-public class ToggleDownfallCommandTest extends CommandTest {
+public class ToggleDownfallCommandTest extends CommandTest<ToggleDownfallCommand> {
 
     private World world;
+
+    public ToggleDownfallCommandTest() {
+        super(ToggleDownfallCommand::new);
+    }
 
     @Override
     @Before
     public void before() {
+        super.before();
         world = PowerMockito.mock(GlowWorld.class);
-        command = new ToggleDownfallCommand();
-        sender = PowerMockito.mock(CommandSender.class);
-        opSender = PowerMockito.mock(CommandSender.class);
-
-        Mockito.when(opSender.hasPermission(Mockito.anyString())).thenReturn(true);
         PowerMockito.stub(PowerMockito.method(CommandUtils.class, "getWorld", CommandSender.class))
             .toReturn(world);
     }


### PR DESCRIPTION
Extracts the superclass CommandTest, makes all the existing command tests extend it (some via a new helper class CommandTestWithFakePlayers), and pulls up testExecuteFailsWithoutPermission (adding it to one or two command tests that lacked it). Adds ClearCommandTest.