### PR TITLE
Fix SheepDyeWoolEvent cancellation visual glitch

### DIFF
--- a/src/main/java/net/glowstone/entity/meta/MetadataMap.java
+++ b/src/main/java/net/glowstone/entity/meta/MetadataMap.java
@@ -42,6 +42,17 @@ public class MetadataMap implements DynamicallyTypedMapWithFloats<MetadataIndex>
      * @param value the new value
      */
     public void set(MetadataIndex index, Object value) {
+        set(index, value, false);
+    }
+
+    /**
+     * Sets the value of a metadata field.
+     *
+     * @param index the field to set
+     * @param value the new value
+     * @param force if the value should be forced as a change regardless of equality
+     */
+    public void set(MetadataIndex index, Object value, boolean force) {
         // take numbers down to the correct precision
         if (value != null) {
             if (value instanceof Number) {
@@ -72,7 +83,7 @@ public class MetadataMap implements DynamicallyTypedMapWithFloats<MetadataIndex>
         }
 
         Object prev = map.put(index, value);
-        if (!Objects.equals(prev, value)) {
+        if (force || !Objects.equals(prev, value)) {
             changes.add(new Entry(index, value));
         }
     }

--- a/src/main/java/net/glowstone/entity/passive/GlowSheep.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowSheep.java
@@ -1,8 +1,6 @@
 package net.glowstone.entity.passive;
 
 import com.google.common.collect.Sets;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.Getter;
@@ -10,8 +8,6 @@ import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowAnimal;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.meta.MetadataIndex;
-import net.glowstone.entity.meta.MetadataMap;
-import net.glowstone.net.message.play.entity.EntityMetadataMessage;
 import net.glowstone.net.message.play.player.InteractEntityMessage;
 import net.glowstone.util.InventoryUtil;
 import org.bukkit.DyeColor;
@@ -130,11 +126,7 @@ public class GlowSheep extends GlowAnimal implements Sheep {
                     SheepDyeWoolEvent dyeEvent = EventFactory.getInstance().callEvent(
                             new SheepDyeWoolEvent(this, color));
                     if (dyeEvent.isCancelled()) {
-                        List<MetadataMap.Entry> entryList = new ArrayList<>();
-                        entryList.add(new MetadataMap.Entry(
-                                MetadataIndex.SHEEP_DATA, getColorByte()));
-                        player.getSession().send(new EntityMetadataMessage(
-                                getEntityId(), entryList));
+                        metadata.set(MetadataIndex.SHEEP_DATA, getColorByte(), true);
                         player.updateInventory();
                         return false;
                     }

--- a/src/main/java/net/glowstone/entity/passive/GlowSheep.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowSheep.java
@@ -123,7 +123,8 @@ public class GlowSheep extends GlowAnimal implements Sheep {
                     Dye dye = (Dye) hand.getData();
                     DyeColor color = dye.getColor();
 
-                    SheepDyeWoolEvent dyeEvent = new SheepDyeWoolEvent(this, color);
+                    SheepDyeWoolEvent dyeEvent = EventFactory.getInstance().callEvent(
+                            new SheepDyeWoolEvent(this, color));
                     if (dyeEvent.isCancelled()) {
                         return false;
                     }

--- a/src/main/java/net/glowstone/entity/passive/GlowSheep.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowSheep.java
@@ -135,6 +135,7 @@ public class GlowSheep extends GlowAnimal implements Sheep {
                                 MetadataIndex.SHEEP_DATA, getColorByte()));
                         player.getSession().send(new EntityMetadataMessage(
                                 getEntityId(), entryList));
+                        player.updateInventory();
                         return false;
                     }
 

--- a/src/main/java/net/glowstone/entity/passive/GlowSheep.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowSheep.java
@@ -1,6 +1,8 @@
 package net.glowstone.entity.passive;
 
 import com.google.common.collect.Sets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.Getter;
@@ -8,6 +10,8 @@ import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowAnimal;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.meta.MetadataIndex;
+import net.glowstone.entity.meta.MetadataMap;
+import net.glowstone.net.message.play.entity.EntityMetadataMessage;
 import net.glowstone.net.message.play.player.InteractEntityMessage;
 import net.glowstone.util.InventoryUtil;
 import org.bukkit.DyeColor;
@@ -126,6 +130,11 @@ public class GlowSheep extends GlowAnimal implements Sheep {
                     SheepDyeWoolEvent dyeEvent = EventFactory.getInstance().callEvent(
                             new SheepDyeWoolEvent(this, color));
                     if (dyeEvent.isCancelled()) {
+                        List<MetadataMap.Entry> entryList = new ArrayList<>();
+                        entryList.add(new MetadataMap.Entry(
+                                MetadataIndex.SHEEP_DATA, getColorByte()));
+                        player.getSession().send(new EntityMetadataMessage(
+                                getEntityId(), entryList));
                         return false;
                     }
 


### PR DESCRIPTION
There appears to be a client-server desync which causes the client to think the sheep is dyed even when the server has not told the client so, and is only returned to normal until relogging. The updated behaviour sends the original metadata immediately, and the sheep appears as before dying the wool was attempted.