### PR TITLE
Prevent inlining of constants

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -143,6 +143,7 @@ import net.glowstone.util.CompatibilityBundle;
 import net.glowstone.util.GlowHelpMap;
 import net.glowstone.util.GlowServerIcon;
 import net.glowstone.util.GlowUnsafeValues;
+import net.glowstone.util.NoInline;
 import net.glowstone.util.OpenCompute;
 import net.glowstone.util.SecurityUtils;
 import net.glowstone.util.ShutdownMonitorThread;

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -229,11 +229,11 @@ public class GlowServer implements Server {
     /**
      * The game version supported by the server.
      */
-    public static final String GAME_VERSION = "1.12.2";
+    public static final String GAME_VERSION = NoInline.of("1.12.2");
     /**
      * The protocol version supported by the server.
      */
-    public static final int PROTOCOL_VERSION = 340;
+    public static final int PROTOCOL_VERSION = NoInline.of(340);
     /**
      * A list of all the active {@link net.glowstone.net.GlowSession}s.
      */

--- a/src/main/java/net/glowstone/util/NoInline.java
+++ b/src/main/java/net/glowstone/util/NoInline.java
@@ -1,0 +1,42 @@
+package net.glowstone.util;
+
+/**
+ * Identity methods used to prevent inlining of constant.
+ */
+public class NoInline {
+    public static boolean of(boolean value) {
+        return value;
+    }
+
+    public static byte of(byte value) {
+        return value;
+    }
+
+    public static short of(short value) {
+        return value;
+    }
+
+    public static char of(char value) {
+        return value;
+    }
+
+    public static int of(int value) {
+        return value;
+    }
+
+    public static long of(long value) {
+        return value;
+    }
+
+    public static float of(float value) {
+        return value;
+    }
+
+    public static double of(double value) {
+        return value;
+    }
+
+    public static <T> T of(T value) {
+        return value;
+    }
+}


### PR DESCRIPTION
The java compiler inlines uses of constants. That can cause bugs.

Here's an example:
``` java
System.out.println("This is a minecraft " + GlowServer.GAME_VERSION + " server.");
```
This code does not print the game version of the running server. It prints the version of the server jar-file it was compiled against.

A similar example can be seen [here](https://github.com/GlowstoneMC/ProtocolLib/blob/7dc822cadeb2b927cae77cb5066b7b2effbaae96/modules/API/src/main/java/com/comphenix/protocol/utility/PlatformUtil.java#L26)

When calling an identity method (e.g. `NoInline.of(...)`), javac recognizes that the value is not constant and will not inline uses of that constant.

This must be done with all constants that might/will change at some point in time (e.g. `GlowServer.GAME_VERSION` or `GlowServer.PROTOCOL_VERSION`).

If there are more such constant, please apply the change for those too.