### PR TITLE
Fire PlayerToggleFlightEvent (fixes part of #922)

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -133,6 +133,7 @@ import net.glowstone.net.GameServer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.SessionRegistry;
 import net.glowstone.net.message.play.player.AdvancementsMessage;
+import net.glowstone.net.message.play.player.PlayerAbilitiesMessage;
 import net.glowstone.net.message.status.StatusRequestMessage;
 import net.glowstone.net.query.QueryServer;
 import net.glowstone.net.rcon.RconServer;
@@ -2120,7 +2121,6 @@ public class GlowServer implements Server {
                 .nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes()), false));
     }
 
-
     @Override
     public void savePlayers() {
         getOnlinePlayers().forEach(Player::saveData);
@@ -2199,6 +2199,15 @@ public class GlowServer implements Server {
     @Override
     public GlowWorld getWorld(String name) {
         return worlds.getWorld(name);
+    }
+
+    public void sendPlayerAbilities(GlowPlayer player) {
+        boolean creative = player.getGameMode() == GameMode.CREATIVE;
+        int flags = (creative ? 8 : 0) | (player.getAllowFlight() ? 4 : 0)
+                | (player.isFlying() ? 2 : 0) | (creative ? 1 : 0);
+        // division is conversion from Bukkit to MC units
+        player.getSession().send(new PlayerAbilitiesMessage(flags,
+                player.getFlySpeed() / 2F, player.getWalkSpeed() / 2F));
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -2196,11 +2196,12 @@ public class GlowServer implements Server {
                 .collect(Collectors.toSet());
     }
 
-    @Override
-    public GlowWorld getWorld(String name) {
-        return worlds.getWorld(name);
-    }
-
+    /**
+     * Sends a {@link GlowPlayer} their abilities regarding
+     * flying and walking.
+     *
+     * @param player The player who is being sent their abilities.
+     */
     public void sendPlayerAbilities(GlowPlayer player) {
         boolean creative = player.getGameMode() == GameMode.CREATIVE;
         int flags = (creative ? 8 : 0) | (player.getAllowFlight() ? 4 : 0)
@@ -2208,6 +2209,11 @@ public class GlowServer implements Server {
         // division is conversion from Bukkit to MC units
         player.getSession().send(new PlayerAbilitiesMessage(flags,
                 player.getFlySpeed() / 2F, player.getWalkSpeed() / 2F));
+    }
+
+    @Override
+    public GlowWorld getWorld(String name) {
+        return worlds.getWorld(name);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -1644,11 +1644,13 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public void setFlying(boolean value) {
-        if (flying != (flying = value && canFly)) {
-            EventFactory.getInstance().callEvent(
-                    new PlayerToggleFlightEvent(this, flying));
+        boolean flying = value && canFly;
+        PlayerToggleFlightEvent event = EventFactory.getInstance().callEvent(
+                new PlayerToggleFlightEvent(this, flying));
+        if (!event.isCancelled()) {
+            this.flying = flying;
+            sendAbilities();
         }
-        sendAbilities();
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -175,7 +175,6 @@ import org.bukkit.event.player.PlayerResourcePackStatusEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
-import org.bukkit.event.player.PlayerToggleFlightEvent;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.event.player.PlayerToggleSprintEvent;
 import org.bukkit.event.player.PlayerUnregisterChannelEvent;
@@ -1644,13 +1643,8 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public void setFlying(boolean value) {
-        boolean flying = value && canFly;
-        PlayerToggleFlightEvent event = EventFactory.getInstance().callEvent(
-                new PlayerToggleFlightEvent(this, flying));
-        if (!event.isCancelled()) {
-            this.flying = flying;
-            sendAbilities();
-        }
+        flying = value && canFly;
+        sendAbilities();
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -175,6 +175,7 @@ import org.bukkit.event.player.PlayerResourcePackStatusEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.bukkit.event.player.PlayerToggleFlightEvent;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.event.player.PlayerToggleSprintEvent;
 import org.bukkit.event.player.PlayerUnregisterChannelEvent;
@@ -1643,7 +1644,10 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
     @Override
     public void setFlying(boolean value) {
-        flying = value && canFly;
+        if (flying != (flying = value && canFly)) {
+            EventFactory.getInstance().callEvent(
+                    new PlayerToggleFlightEvent(this, flying));
+        }
         sendAbilities();
     }
 

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -109,7 +109,6 @@ import net.glowstone.net.message.play.inv.OpenWindowMessage;
 import net.glowstone.net.message.play.inv.SetWindowContentsMessage;
 import net.glowstone.net.message.play.inv.SetWindowSlotMessage;
 import net.glowstone.net.message.play.inv.WindowPropertyMessage;
-import net.glowstone.net.message.play.player.PlayerAbilitiesMessage;
 import net.glowstone.net.message.play.player.ResourcePackSendMessage;
 import net.glowstone.net.message.play.player.UseBedMessage;
 import net.glowstone.scoreboard.GlowScoreboard;
@@ -678,7 +677,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         sendWeather();
         sendRainDensity();
         sendSkyDarkness();
-        sendAbilities();
+        getServer().sendPlayerAbilities(this);
 
         // send initial location
         session.send(new PositionRotationMessage(location));
@@ -1635,7 +1634,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         if (!canFly) {
             flying = false;
         }
-        sendAbilities();
+        getServer().sendPlayerAbilities(this);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -1644,26 +1643,19 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
     @Override
     public void setFlying(boolean value) {
         flying = value && canFly;
-        sendAbilities();
+        getServer().sendPlayerAbilities(this);
     }
 
     @Override
     public void setFlySpeed(float value) throws IllegalArgumentException {
         flySpeed = value;
-        sendAbilities();
+        getServer().sendPlayerAbilities(this);
     }
 
     @Override
     public void setWalkSpeed(float value) throws IllegalArgumentException {
         walkSpeed = value;
-        sendAbilities();
-    }
-
-    private void sendAbilities() {
-        boolean creative = getGameMode() == GameMode.CREATIVE;
-        int flags = (creative ? 8 : 0) | (canFly ? 4 : 0) | (flying ? 2 : 0) | (creative ? 1 : 0);
-        // division is conversion from Bukkit to MC units
-        session.send(new PlayerAbilitiesMessage(flags, flySpeed / 2f, walkSpeed / 2f));
+        getServer().sendPlayerAbilities(this);
     }
 
     @Override

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerAbilitiesHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerAbilitiesHandler.java
@@ -16,14 +16,14 @@ public final class PlayerAbilitiesHandler implements
         // other values should match what we've sent in the past but are ignored here
 
         GlowPlayer player = session.getPlayer();
-        if (!player.getAllowFlight()) {
-            return;
-        }
         boolean flying = (message.getFlags() & 0x02) != 0;
-        PlayerToggleFlightEvent event = EventFactory.getInstance().callEvent(
-                new PlayerToggleFlightEvent(player, flying));
-        if (!event.isCancelled()) {
-            player.setFlying(flying);
+        boolean isFlying = player.isFlying();
+        if (isFlying != flying) {
+            if (!flying || player.getAllowFlight()) {
+                PlayerToggleFlightEvent event = EventFactory.getInstance()
+                        .callEvent(new PlayerToggleFlightEvent(player, flying));
+                player.setFlying(event.isCancelled() ? isFlying : flying);
+            }
         }
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerAbilitiesHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerAbilitiesHandler.java
@@ -17,20 +17,26 @@ public final class PlayerAbilitiesHandler implements
         // other values should match what we've sent in the past but are ignored here
 
         GlowPlayer player = session.getPlayer();
-        boolean flying = (message.getFlags() & 0x02) != 0;
+        boolean flyingFlag = (message.getFlags() & 0x02) != 0;
+
+        // the current flying state
         boolean isFlying = player.isFlying();
         boolean canFly = player.getAllowFlight();
-        if (isFlying != flying) {
-            if (!flying || canFly) {
+        if (isFlying != flyingFlag) {
+            if (!flyingFlag || canFly) {
                 PlayerToggleFlightEvent event = EventFactory.getInstance()
-                        .callEvent(new PlayerToggleFlightEvent(player, flying));
-                boolean creative = player.getGameMode() == GameMode.CREATIVE;
-                int flags = (creative ? 8 : 0) | (canFly ? 4 : 0)
-                        | (isFlying ? 2 : 0) | (creative ? 1 : 0);
-                // division is conversion from Bukkit to MC units
-                session.send(new PlayerAbilitiesMessage(flags,
-                        player.getFlySpeed() / 2F,
-                        player.getWalkSpeed() / 2F));
+                        .callEvent(new PlayerToggleFlightEvent(player, flyingFlag));
+                if (event.isCancelled()) {
+                    boolean creative = player.getGameMode() == GameMode.CREATIVE;
+                    int flags = (creative ? 8 : 0) | (canFly ? 4 : 0)
+                            | (isFlying ? 2 : 0) | (creative ? 1 : 0);
+                    // division is conversion from Bukkit to MC units
+                    session.send(new PlayerAbilitiesMessage(flags,
+                            player.getFlySpeed() / 2F,
+                            player.getWalkSpeed() / 2F));
+                } else {
+                    player.setFlying(flyingFlag);
+                }
             }
         }
     }

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerAbilitiesHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerAbilitiesHandler.java
@@ -15,7 +15,6 @@ public final class PlayerAbilitiesHandler implements
 
         GlowPlayer player = session.getPlayer();
         boolean flying = (message.getFlags() & 0x02) != 0;
-
-        player.setFlying(player.getAllowFlight() && flying);
+        player.setFlying(flying);
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerAbilitiesHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerAbilitiesHandler.java
@@ -1,9 +1,11 @@
 package net.glowstone.net.handler.play.player;
 
 import com.flowpowered.network.MessageHandler;
+import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.PlayerAbilitiesMessage;
+import org.bukkit.event.player.PlayerToggleFlightEvent;
 
 public final class PlayerAbilitiesHandler implements
     MessageHandler<GlowSession, PlayerAbilitiesMessage> {
@@ -14,7 +16,14 @@ public final class PlayerAbilitiesHandler implements
         // other values should match what we've sent in the past but are ignored here
 
         GlowPlayer player = session.getPlayer();
+        if (!player.getAllowFlight()) {
+            return;
+        }
         boolean flying = (message.getFlags() & 0x02) != 0;
-        player.setFlying(flying);
+        PlayerToggleFlightEvent event = EventFactory.getInstance().callEvent(
+                new PlayerToggleFlightEvent(player, flying));
+        if (!event.isCancelled()) {
+            player.setFlying(flying);
+        }
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/PlayerAbilitiesHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/PlayerAbilitiesHandler.java
@@ -5,7 +5,6 @@ import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.net.GlowSession;
 import net.glowstone.net.message.play.player.PlayerAbilitiesMessage;
-import org.bukkit.GameMode;
 import org.bukkit.event.player.PlayerToggleFlightEvent;
 
 public final class PlayerAbilitiesHandler implements
@@ -23,17 +22,13 @@ public final class PlayerAbilitiesHandler implements
         boolean isFlying = player.isFlying();
         boolean canFly = player.getAllowFlight();
         if (isFlying != flyingFlag) {
+            // fire the event if either the player disabled flying,
+            // or enabled it and is allowed to fly
             if (!flyingFlag || canFly) {
                 PlayerToggleFlightEvent event = EventFactory.getInstance()
                         .callEvent(new PlayerToggleFlightEvent(player, flyingFlag));
                 if (event.isCancelled()) {
-                    boolean creative = player.getGameMode() == GameMode.CREATIVE;
-                    int flags = (creative ? 8 : 0) | (canFly ? 4 : 0)
-                            | (isFlying ? 2 : 0) | (creative ? 1 : 0);
-                    // division is conversion from Bukkit to MC units
-                    session.send(new PlayerAbilitiesMessage(flags,
-                            player.getFlySpeed() / 2F,
-                            player.getWalkSpeed() / 2F));
+                    session.getServer().sendPlayerAbilities(player);
                 } else {
                     player.setFlying(flyingFlag);
                 }


### PR DESCRIPTION
I have modified existing code to fire a `PlayerToggleFlightEvent` whenever `GlowPlayer#setFlying` is called **and** `flying` is toggled (i.e. calling `setFlying(true)` twice when `flying` was initially set to `false` will not fire the event twice).

This modification was tested with a simple plugin that monitored `PlayerToggleFlightEvent` and sent a message to the `Player` when they toggled their flight.

I also noticed that you were initially checking `GlowPlayer#getAllowFlight` within `PlayerAbilitiesHandler.java`, but `GlowPlayer#setFlying` already performs that check, so I removed it.

This is my first pull-request, so please let me know if there's anything else I should do.

Thank you!

 - Jacob G.