### PR TITLE
Fire InventoryOpenEvent (fixes part of #922)

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowHumanEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowHumanEntity.java
@@ -440,7 +440,7 @@ public abstract class GlowHumanEntity extends GlowLivingEntity implements HumanE
         return (GlowInventory) getOpenInventory().getTopInventory();
     }
 
-    private void resetInventoryView() {
+    void resetInventoryView() {
         openInventory(new GlowInventoryView(this));
     }
 

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3047,7 +3047,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                 new InventoryOpenEvent(view));
             if (event.isCancelled()) {
                 // close the inventory but don't fire the InventoryCloseEvent
-                openInventory(new GlowInventoryView(this));
+                resetInventoryView();
                 return;
             }
             String title = view.getTitle();

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -160,6 +160,7 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerAchievementAwardedEvent;
 import org.bukkit.event.player.PlayerBedEnterEvent;
@@ -3042,6 +3043,13 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         invMonitor = new InventoryMonitor(getOpenInventory());
         int viewId = invMonitor.getId();
         if (viewId != 0) {
+            InventoryOpenEvent event = EventFactory.getInstance().callEvent(
+                new InventoryOpenEvent(view));
+            if (event.isCancelled()) {
+                // close the inventory but don't fire the InventoryCloseEvent
+                openInventory(new GlowInventoryView(this));
+                return;
+            }
             String title = view.getTitle();
             boolean defaultTitle = Objects.equals(view.getType().getDefaultTitle(), title);
             if (view.getTopInventory() instanceof PlayerInventory && defaultTitle) {


### PR DESCRIPTION
The `InventoryOpenEvent` is now fired when a player opens a chest, furnace, dispenser, etc.  The event does **not** fire when opening their own inventory (as expected) nor when closing any of the opened inventories.

This has been tested and works accordingly.

Thanks!