### PR TITLE
Fire VehicleEnterEvent (fixes part of #922)

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -54,6 +54,7 @@ import org.bukkit.block.PistonMoveReaction;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Vehicle;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityPortalEnterEvent;
@@ -62,6 +63,7 @@ import org.bukkit.event.entity.EntityPortalExitEvent;
 import org.bukkit.event.entity.EntityUnleashEvent;
 import org.bukkit.event.entity.EntityUnleashEvent.UnleashReason;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.bukkit.event.vehicle.VehicleEnterEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataStore;
 import org.bukkit.metadata.MetadataStoreBase;
@@ -1262,8 +1264,15 @@ public abstract class GlowEntity implements Entity {
             glowPassenger.vehicle.removePassenger(passenger);
         }
 
-        EntityMountEvent event = new EntityMountEvent(passenger, this);
-        EventFactory.getInstance().callEvent(event);
+        if (this instanceof Vehicle) {
+            VehicleEnterEvent event = EventFactory.getInstance().callEvent(
+                    new VehicleEnterEvent((Vehicle) this, passenger));
+            if (event.isCancelled()) {
+                return false;
+            }
+        }
+        EntityMountEvent event = EventFactory.getInstance().callEvent(
+                new EntityMountEvent(passenger, this));
         if (event.isCancelled()) {
             return false;
         }

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -836,6 +836,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             world.playSound(location, deathSound, getSoundVolume(), getSoundPitch());
         }
         playEffect(EntityEffect.DEATH);
+        leaveVehicle();
         if (this instanceof GlowPlayer) {
             GlowPlayer player = (GlowPlayer) this;
             ItemStack mainHand = player.getInventory().getItemInMainHand();


### PR DESCRIPTION
The `VehicleEnterEvent` is now fired when a player enters a boat, minecart, etc.  This has been tested and works accordingly.

**This commit also fixes the following bug:**
 - Any `GlowLivingEntity` that dies while riding a vehicle will leave the vehicle before their death is registered; this fix was crucial to my testing and I thought it should be in the same commit.

Thanks!