### PR TITLE
Fire EntityRemoveFromWorldEvent (fixes part of #922)

### DIFF
--- a/src/main/java/net/glowstone/entity/EntityManager.java
+++ b/src/main/java/net/glowstone/entity/EntityManager.java
@@ -2,6 +2,7 @@ package net.glowstone.entity;
 
 import static com.google.common.collect.Multimaps.newSetMultimap;
 
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import java.util.Collection;
@@ -12,6 +13,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
+
+import net.glowstone.EventFactory;
 import net.glowstone.chunk.GlowChunk;
 import net.glowstone.entity.physics.BoundingBox;
 import org.bukkit.Chunk;
@@ -93,6 +96,7 @@ public class EntityManager implements Iterable<GlowEntity> {
      * @param entity The entity.
      */
     void unregister(GlowEntity entity) {
+        EventFactory.getInstance().callEvent(new EntityRemoveFromWorldEvent(entity));
         entities.remove(entity.entityId);
         groupedEntities.remove(entity.getClass(), entity);
         ((GlowChunk) entity.location.getChunk()).getRawEntities().remove(entity);

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -1101,7 +1101,7 @@ public abstract class GlowEntity implements Entity {
         world.getEntityManager().unregister(this);
         server.getEntityIdManager().deallocate(this);
         this.setPassenger(null);
-
+        leaveVehicle();
         ImmutableList.copyOf(this.leashedEntities)
                 .forEach(e -> unleash(e, UnleashReason.HOLDER_GONE));
 

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -2,6 +2,7 @@ package net.glowstone.entity;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import com.flowpowered.network.Message;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -1093,6 +1094,7 @@ public abstract class GlowEntity implements Entity {
      */
     @Override
     public void remove() {
+        EventFactory.getInstance().callEvent(new EntityRemoveFromWorldEvent(this));
         removed = true;
         active = false;
         boundingBox = null;

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -2,7 +2,6 @@ package net.glowstone.entity;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import com.flowpowered.network.Message;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -1094,7 +1093,6 @@ public abstract class GlowEntity implements Entity {
      */
     @Override
     public void remove() {
-        EventFactory.getInstance().callEvent(new EntityRemoveFromWorldEvent(this));
         removed = true;
         active = false;
         boundingBox = null;

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -836,7 +836,6 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             world.playSound(location, deathSound, getSoundVolume(), getSoundPitch());
         }
         playEffect(EntityEffect.DEATH);
-        leaveVehicle();
         if (this instanceof GlowPlayer) {
             GlowPlayer player = (GlowPlayer) this;
             ItemStack mainHand = player.getInventory().getItemInMainHand();


### PR DESCRIPTION
The `EntityRemoveFromWorldEvent` is now fired when `GlowEntity#remove` is called.

This pull request also moves `leaveVehicle()` from `GlowLivingEntity#setHealth` (I added it in #939) to `GlowEntity#remove`, as it makes more sense for it to be there.

This has been tested and works accordingly.

Thanks!