### PR TITLE
Fix #940 and mining-speed inconsistencies

### DIFF
--- a/src/main/java/net/glowstone/chunk/GlowChunk.java
+++ b/src/main/java/net/glowstone/chunk/GlowChunk.java
@@ -825,6 +825,10 @@ public class GlowChunk implements Chunk {
             return keys.computeIfAbsent(id, l -> new Key(x, z));
         }
 
+        public static Key to(Chunk chunk) {
+            return of(chunk.getX(), chunk.getZ());
+        }
+
         @Override
         public int hashCode() {
             return hashCode;

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3539,8 +3539,10 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         digging.breakNaturally(tool);
         // Send block status to clients
         Location dugLocation = digging.getLocation();
-        world.getRawPlayers().parallelStream().forEach(player -> player.sendBlockChange(dugLocation,
-                Material.AIR, (byte) 0));
+        // OK to use sequential stream here, because sendBlockChange is async
+        world.getRawPlayers().stream()
+                .filter(player -> player.canSeeChunk(GlowChunk.Key.to(dugLocation.getChunk())))
+                .forEach(player -> player.sendBlockChange(dugLocation, Material.AIR, (byte) 0));
         setDigging(null);
     }
 

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -66,6 +66,7 @@ import net.glowstone.entity.passive.GlowFishingHook;
 import net.glowstone.inventory.GlowInventory;
 import net.glowstone.inventory.GlowInventoryView;
 import net.glowstone.inventory.InventoryMonitor;
+import net.glowstone.inventory.MaterialToolType;
 import net.glowstone.inventory.ToolType;
 import net.glowstone.inventory.crafting.PlayerRecipeMonitor;
 import net.glowstone.io.PlayerDataService.PlayerReader;
@@ -3418,7 +3419,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                 } else {
                     ToolType effectiveTool = block.getMaterialValues().getTool();
                     if (effectiveTool != null && effectiveTool.matches(toolType)) {
-                        double miningMultiplier = effectiveTool.getMiningMultiplier();
+                        double miningMultiplier = ToolType.getMiningMultiplier(toolType);
                         int efficiencyLevel = tool.getEnchantmentLevel(Enchantment.DIG_SPEED);
                         if (efficiencyLevel > 0) {
                             miningMultiplier += efficiencyLevel * efficiencyLevel + 1;

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -151,6 +151,7 @@ import org.bukkit.boss.BossBar;
 import org.bukkit.configuration.serialization.DelegateDeserialization;
 import org.bukkit.conversations.Conversation;
 import org.bukkit.conversations.ConversationAbandonedEvent;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
@@ -3412,8 +3413,12 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                 } else {
                     ToolType effectiveTool = block.getMaterialValues().getTool();
                     if (effectiveTool != null && effectiveTool.matches(toolType)) {
-                        breakingTimeMultiplier = 1.5 / effectiveTool.getMiningMultiplier();
-                        // TODO: Efficiency enchantment
+                        double miningMultiplier = effectiveTool.getMiningMultiplier();
+                        int efficiencyLevel = tool.getEnchantmentLevel(Enchantment.DIG_SPEED);
+                        if (efficiencyLevel > 0) {
+                            miningMultiplier += efficiencyLevel * efficiencyLevel + 1;
+                        }
+                        breakingTimeMultiplier = 1.5 / miningMultiplier;
                     }
                 }
             }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3437,7 +3437,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             }
             // TODO: Mining Fatigue; Slowness; effect of underwater digging
             totalDiggingTicks = (long)
-                (breakingTimeMultiplier * hardness * 20.0); // seconds to ticks
+                (breakingTimeMultiplier * hardness * 20.0 + 0.5); // seconds to ticks, round half-up
             logger.info(String.format(
                 "Breaking %s with %s takes %d ticks (hardness %.2f, time mult %.2f)",
                 block.getType(), getItemInHand().getType(), totalDiggingTicks,

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3454,7 +3454,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
     private void broadcastBlockBreakAnimation(GlowBlock block, int destroyStage) {
         GlowChunk.Key key = GlowChunk.Key.of(block.getX() >> 4, block.getZ() >> 4);
         block.getWorld().getRawPlayers().stream()
-                .filter(player -> player.canSeeChunk(key) && player != this)
+                .filter(player -> player != this && player.canSeeChunk(key))
                 .forEach(player -> player
                         .sendBlockBreakAnimation(block.getLocation(), destroyStage));
     }
@@ -3537,8 +3537,9 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         // Break the block
         digging.breakNaturally(tool);
         // Send block status to clients
-        world.getRawPlayers().parallelStream().forEach(player -> player.sendBlockChange(
-                digging.getLocation(), Material.AIR, (byte) 0));
+        Location dugLocation = digging.getLocation();
+        world.getRawPlayers().parallelStream().forEach(player -> player.sendBlockChange(dugLocation,
+                Material.AIR, (byte) 0));
         setDigging(null);
     }
 

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3402,7 +3402,6 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             broadcastBlockBreakAnimation(digging, 10);
         } else {
             double hardness = block.getMaterialValues().getHardness();
-            System.out.println(block.getType().toString() + " has hardness " + hardness);
             if (hardness >= Float.MAX_VALUE) {
                 // This block can't be broken by digging.
                 setDigging(null);

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3424,6 +3424,10 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             }
             // TODO: Mining Fatigue; Slowness; effect of underwater digging
             totalDiggingTicks = (long)(breakingTimeMultiplier * hardness);
+            logger.info(String.format(
+                "Breaking %s with %s takes %d ticks (hardness %.2f, time mult %.2f)",
+                block.getType(), getItemInHand().getType(), totalDiggingTicks,
+                hardness, breakingTimeMultiplier));
             // show other clients the block is beginning to crack
             broadcastBlockBreakAnimation(block, 0);
         }
@@ -3450,10 +3454,12 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         ++diggingTicks;
 
         if (diggingTicks < totalDiggingTicks) {
+            logger.info(String.format("Digging, tick %d of %d", diggingTicks, totalDiggingTicks));
             int stage = (int) (10 * (double) diggingTicks / totalDiggingTicks);
             broadcastBlockBreakAnimation(digging, stage);
             return;
         }
+        logger.info("Breaking " + digging);
         ItemStack tool = getItemInHand();
         short durability = tool.getDurability();
         short maxDurability = tool.getType().getMaxDurability();

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3511,15 +3511,15 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             for (int i = 0; i < baseDamage; i++) {
                 tool = InventoryUtil.damageItem(this, tool);
             }
-            // Force-update item
-            setItemInHand(tool);
-            // Break the block
-            digging.breakNaturally(tool);
-            // Send block status to clients
-            world.getRawPlayers().parallelStream().forEach(player -> player.sendBlockChange(
-                    digging.getLocation(), Material.AIR, (byte) 0));
-            setDigging(null);
         }
+        // Force-update item
+        setItemInHand(tool);
+        // Break the block
+        digging.breakNaturally(tool);
+        // Send block status to clients
+        world.getRawPlayers().parallelStream().forEach(player -> player.sendBlockChange(
+                digging.getLocation(), Material.AIR, (byte) 0));
+        setDigging(null);
     }
 
     /**

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3402,7 +3402,8 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
             broadcastBlockBreakAnimation(digging, 10);
         } else {
             double hardness = block.getMaterialValues().getHardness();
-            if (hardness < 0) {
+            System.out.println(block.getType().toString() + " has hardness " + hardness);
+            if (hardness >= Float.MAX_VALUE) {
                 // This block can't be broken by digging.
                 setDigging(null);
                 return;

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3536,7 +3536,6 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         // Force-update item
         setItemInHand(tool);
         // Break the block
-        broadcastBlockBreakAnimation(digging, 9);
         digging.breakNaturally(tool);
         // Send block status to clients
         world.getRawPlayers().parallelStream().forEach(player -> player.sendBlockChange(

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3461,9 +3461,10 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
 
     private void pulseDigging() {
         ++diggingTicks;
-
-        if (diggingTicks < totalDiggingTicks) {
-            int stage = (int) (10 * (double) diggingTicks / totalDiggingTicks);
+        if (diggingTicks <= totalDiggingTicks) {
+            // diggingTicks starts at 1 and progresses to totalDiggingTicks, but animation stages
+            // are 0 through 9, so subtract 1 from the current tick
+            int stage = (int) (10.0 * ((double) (diggingTicks - 1)) / totalDiggingTicks);
             broadcastBlockBreakAnimation(digging, stage);
             return;
         }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3536,6 +3536,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         // Force-update item
         setItemInHand(tool);
         // Break the block
+        broadcastBlockBreakAnimation(digging, 9);
         digging.breakNaturally(tool);
         // Send block status to clients
         world.getRawPlayers().parallelStream().forEach(player -> player.sendBlockChange(

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3413,9 +3413,11 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                     ToolType effectiveTool = block.getMaterialValues().getTool();
                     if (effectiveTool != null && effectiveTool.matches(toolType)) {
                         breakingTimeMultiplier = 1.5 / effectiveTool.getMiningMultiplier();
+                        // TODO: Efficiency enchantment
                     }
                 }
             }
+            // TODO: Mining Fatigue; Slowness; effect of underwater digging
             totalDiggingTicks = (long)(breakingTimeMultiplier * hardness);
             // show other clients the block is beginning to crack
             broadcastBlockBreakAnimation(block, 0);

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -3435,13 +3435,9 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                     }
                 }
             }
-            // TODO: Mining Fatigue; Slowness; effect of underwater digging
+            // TODO: status effects (e.g. Mining Fatigue, Slowness); effect of underwater digging
             totalDiggingTicks = (long)
                 (breakingTimeMultiplier * hardness * 20.0 + 0.5); // seconds to ticks, round half-up
-            logger.info(String.format(
-                "Breaking %s with %s takes %d ticks (hardness %.2f, time mult %.2f)",
-                block.getType(), getItemInHand().getType(), totalDiggingTicks,
-                hardness, breakingTimeMultiplier));
             // show other clients the block is beginning to crack
             broadcastBlockBreakAnimation(block, 0);
         }
@@ -3468,12 +3464,10 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         ++diggingTicks;
 
         if (diggingTicks < totalDiggingTicks) {
-            logger.info(String.format("Digging, tick %d of %d", diggingTicks, totalDiggingTicks));
             int stage = (int) (10 * (double) diggingTicks / totalDiggingTicks);
             broadcastBlockBreakAnimation(digging, stage);
             return;
         }
-        logger.info("Breaking " + digging);
         ItemStack tool = getItemInHand();
         short durability = tool.getDurability();
         short maxDurability = tool.getType().getMaxDurability();

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -66,7 +66,6 @@ import net.glowstone.entity.passive.GlowFishingHook;
 import net.glowstone.inventory.GlowInventory;
 import net.glowstone.inventory.GlowInventoryView;
 import net.glowstone.inventory.InventoryMonitor;
-import net.glowstone.inventory.MaterialToolType;
 import net.glowstone.inventory.ToolType;
 import net.glowstone.inventory.crafting.PlayerRecipeMonitor;
 import net.glowstone.io.PlayerDataService.PlayerReader;
@@ -3425,8 +3424,8 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
                             miningMultiplier += efficiencyLevel * efficiencyLevel + 1;
                         }
                         breakingTimeMultiplier = 1.5 / miningMultiplier;
-                    } else if (effectiveTool == null ||
-                            !effectiveTool.matches(Material.DIAMOND_PICKAXE)) {
+                    } else if (effectiveTool == null
+                            || !effectiveTool.matches(Material.DIAMOND_PICKAXE)) {
                         // If the current tool isn't optimal but can still mine the block, the
                         // multiplier is 1.5. Here, we assume for simplicity that this is true of
                         // all non-pickaxe blocks.

--- a/src/main/java/net/glowstone/inventory/ToolType.java
+++ b/src/main/java/net/glowstone/inventory/ToolType.java
@@ -1,5 +1,7 @@
 package net.glowstone.inventory;
 
+import java.util.EnumMap;
+import java.util.Map;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.bukkit.Material;
@@ -30,11 +32,7 @@ public enum ToolType implements MaterialMatcher {
     SPADE(Material.WOOD_SPADE, GOLD_SPADE, ToolMaterial.WOOD),
 
     // Swords
-    DIAMOND_SWORD(Material.DIAMOND_SWORD, null, ToolMaterial.DIAMOND),
-    IRON_SWORD(Material.IRON_SWORD, DIAMOND_SWORD, ToolMaterial.IRON),
-    STONE_SWORD(Material.STONE_SWORD, IRON_SWORD, ToolMaterial.STONE),
-    GOLD_SWORD(Material.GOLD_SWORD, STONE_SWORD, ToolMaterial.GOLD),
-    SWORD(Material.WOOD_SWORD, GOLD_SWORD, ToolMaterial.WOOD),
+    SWORD(Material.WOOD_SWORD, GOLD_SWORD, ToolMaterial.SWORD),
 
     // Shears
     SHEARS(Material.SHEARS, null, ToolMaterial.SHEARS);
@@ -47,6 +45,7 @@ public enum ToolType implements MaterialMatcher {
         this.bukkitMaterial = bukkitMaterial;
         this.better = better;
         this.toolMaterial = toolMaterial;
+        ToolMaterial.MINING_MULTIPLIERS.put(bukkitMaterial, toolMaterial.getMultiplier());
     }
 
     /**
@@ -65,8 +64,8 @@ public enum ToolType implements MaterialMatcher {
      *
      * @return the multiplier
      */
-    public double getMiningMultiplier() {
-        return this.toolMaterial.getMultiplier();
+    public static double getMiningMultiplier(Material tool) {
+        return ToolMaterial.MINING_MULTIPLIERS.getOrDefault(tool, 1.0);
     }
 
     @RequiredArgsConstructor
@@ -76,8 +75,15 @@ public enum ToolType implements MaterialMatcher {
         IRON(6),
         DIAMOND(8),
         GOLD(12),
-        SHEARS(1.5);
+        SHEARS(1.5),
+        SWORD(1.5);
 
+        /**
+         * Can't move to outer class, because Java is too stupid to initialize other static members
+         * before instantiating an enum.
+         */
+        static final Map<Material, Double> MINING_MULTIPLIERS
+            = new EnumMap<>(Material.class);
         @Getter
         private final double multiplier;
     }

--- a/src/main/java/net/glowstone/inventory/ToolType.java
+++ b/src/main/java/net/glowstone/inventory/ToolType.java
@@ -31,7 +31,11 @@ public enum ToolType implements MaterialMatcher {
     GOLD_SPADE(Material.GOLD_SPADE, STONE_SPADE, ToolMaterial.GOLD),
     SPADE(Material.WOOD_SPADE, GOLD_SPADE, ToolMaterial.WOOD),
 
-    // Swords
+    // Swords all have the same breaking speed
+    DIAMOND_SWORD(Material.DIAMOND_SWORD, null, ToolMaterial.SWORD),
+    IRON_SWORD(Material.IRON_SWORD, DIAMOND_SWORD, ToolMaterial.SWORD),
+    STONE_SWORD(Material.STONE_SWORD, IRON_SWORD, ToolMaterial.SWORD),
+    GOLD_SWORD(Material.GOLD_SWORD, STONE_SWORD, ToolMaterial.SWORD),
     SWORD(Material.WOOD_SWORD, GOLD_SWORD, ToolMaterial.SWORD),
 
     // Shears

--- a/src/main/java/net/glowstone/inventory/ToolType.java
+++ b/src/main/java/net/glowstone/inventory/ToolType.java
@@ -43,12 +43,10 @@ public enum ToolType implements MaterialMatcher {
 
     private final Material bukkitMaterial;
     private final ToolType better;
-    private final ToolMaterial toolMaterial;
 
     ToolType(Material bukkitMaterial, ToolType better, ToolMaterial toolMaterial) {
         this.bukkitMaterial = bukkitMaterial;
         this.better = better;
-        this.toolMaterial = toolMaterial;
         ToolMaterial.MINING_MULTIPLIERS.put(bukkitMaterial, toolMaterial.getMultiplier());
     }
 

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -100,12 +100,10 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
         } else if (message.getState() == DiggingMessage.CANCEL_DIGGING) {
             player.setDigging(null);
         } else if (message.getState() == DiggingMessage.FINISH_DIGGING) {
-            // Update client with block if digging isn't actually finished
+            // Update client with block
             // (FINISH_DIGGING is client's guess based on wall-clock time, not ticks, and is
             // untrusted)
-            if (!block.isEmpty()) {
-                player.sendBlockChange(block.getLocation(), block.getType(), block.getData());
-            }
+            player.sendBlockChange(block.getLocation(), block.getType(), block.getData());
         } else if (message.getState() == DiggingMessage.STATE_DROP_ITEM) {
             player.dropItemInHand(false);
             return;

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -1,5 +1,7 @@
 package net.glowstone.net.handler.play.player;
 
+import static net.glowstone.net.message.play.player.DiggingMessage.START_DIGGING;
+
 import com.flowpowered.network.MessageHandler;
 import java.util.Collection;
 import java.util.Objects;
@@ -51,92 +53,97 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
 
         boolean blockBroken = false;
         boolean revert = false;
-        if (message.getState() == DiggingMessage.START_DIGGING) {
-            if (block.equals(player.getDigging()) || block.isLiquid()) {
-                return;
-            }
-            // call interact event
-            Action action = Action.LEFT_CLICK_BLOCK;
-            Block eventBlock = block;
-            if (player.getLocation().distanceSquared(block.getLocation()) > 36
-                || block.getTypeId() == 0) {
-                action = Action.LEFT_CLICK_AIR;
-                eventBlock = null;
-            }
-            PlayerInteractEvent interactEvent = eventFactory
-                .onPlayerInteract(player, action, EquipmentSlot.HAND, eventBlock, face);
-
-            // blocks don't get interacted with on left click, so ignore that
-            // attempt to use item in hand, that is, dig up the block
-            if (!BlockPlacementHandler.selectResult(interactEvent.useItemInHand(), true)) {
-                // the event was cancelled, get out of here
-                revert = true;
-            } else if (player.getGameMode() != GameMode.SPECTATOR) {
-                player.setDigging(null);
-                // emit damage event - cancel by default if holding a sword
-                boolean instaBreak = player.getGameMode() == GameMode.CREATIVE
-                    || block.getMaterialValues().getHardness() == 0;
-                BlockDamageEvent damageEvent = new BlockDamageEvent(player, block,
-                    player.getItemInHand(), instaBreak);
-                if (player.getGameMode() == GameMode.CREATIVE && holding != null
-                    && EnchantmentTarget.WEAPON.includes(holding.getType())) {
-                    damageEvent.setCancelled(true);
+        switch (message.getState()) {
+            case START_DIGGING:
+                if (block.equals(player.getDigging()) || block.isLiquid()) {
+                    return;
                 }
-                eventFactory.callEvent(damageEvent);
+                // call interact event
+                Action action = Action.LEFT_CLICK_BLOCK;
+                Block eventBlock = block;
+                if (player.getLocation().distanceSquared(block.getLocation()) > 36
+                        || block.getTypeId() == 0) {
+                    action = Action.LEFT_CLICK_AIR;
+                    eventBlock = null;
+                }
+                PlayerInteractEvent interactEvent = eventFactory
+                        .onPlayerInteract(player, action, EquipmentSlot.HAND, eventBlock, face);
 
-                // follow orders
-                if (damageEvent.isCancelled()) {
+                // blocks don't get interacted with on left click, so ignore that
+                // attempt to use item in hand, that is, dig up the block
+                if (!BlockPlacementHandler.selectResult(interactEvent.useItemInHand(), true)) {
+                    // the event was cancelled, get out of here
                     revert = true;
-                } else {
-                    // in creative, break even if denied in the event, or the block
-                    // can never be broken (client does not send DONE_DIGGING).
-                    blockBroken = damageEvent.getInstaBreak();
-                    if (!blockBroken) {
-                        /// TODO: add a delay here based on hardness
-                        player.setDigging(block);
+                } else if (player.getGameMode() != GameMode.SPECTATOR) {
+                    player.setDigging(null);
+                    // emit damage event - cancel by default if holding a sword
+                    boolean instaBreak = player.getGameMode() == GameMode.CREATIVE
+                            || block.getMaterialValues().getHardness() == 0;
+                    BlockDamageEvent damageEvent = new BlockDamageEvent(player, block,
+                            player.getItemInHand(), instaBreak);
+                    if (player.getGameMode() == GameMode.CREATIVE && holding != null
+                            && EnchantmentTarget.WEAPON.includes(holding.getType())) {
+                        damageEvent.setCancelled(true);
+                    }
+                    eventFactory.callEvent(damageEvent);
+
+                    // follow orders
+                    if (damageEvent.isCancelled()) {
+                        revert = true;
+                    } else {
+                        // in creative, break even if denied in the event, or the block
+                        // can never be broken (client does not send DONE_DIGGING).
+                        blockBroken = damageEvent.getInstaBreak();
+                        if (!blockBroken) {
+                            /// TODO: add a delay here based on hardness
+                            player.setDigging(block);
+                        }
                     }
                 }
-            }
-        } else if (message.getState() == DiggingMessage.CANCEL_DIGGING) {
-            player.setDigging(null);
-        } else if (message.getState() == DiggingMessage.FINISH_DIGGING) {
-            // Update client with block
-            // (FINISH_DIGGING is client's guess based on wall-clock time, not ticks, and is
-            // untrusted)
-            player.sendBlockChange(block.getLocation(), block.getType(), block.getData());
-        } else if (message.getState() == DiggingMessage.STATE_DROP_ITEM) {
-            player.dropItemInHand(false);
-            return;
-        } else if (message.getState() == DiggingMessage.STATE_DROP_ITEMSTACK) {
-            player.dropItemInHand(true);
-            return;
-        } else if (message.getState() == DiggingMessage.STATE_SHOT_ARROW_FINISH_EATING
-            && player.getUsageItem() != null) {
-            if (Objects.equals(player.getUsageItem(), holding)) {
-                ItemType type = ItemTable.instance().getItem(player.getUsageItem().getType());
-                if (type != null && type instanceof ItemTimedUsage) {
-                    ((ItemTimedUsage) type).endUse(player, player.getUsageItem());
-                } else {
-                    // todo: inform the player that this item cannot be consumed/used
+                break;
+            case DiggingMessage.CANCEL_DIGGING:
+                player.setDigging(null);
+                break;
+            case DiggingMessage.FINISH_DIGGING:
+                // Update client with block
+                // (FINISH_DIGGING is client's guess based on wall-clock time, not ticks, and is
+                // untrusted)
+                player.sendBlockChange(block.getLocation(), block.getType(), block.getData());
+                break;
+            case DiggingMessage.STATE_DROP_ITEM:
+                player.dropItemInHand(false);
+                return;
+            case DiggingMessage.STATE_DROP_ITEMSTACK:
+                player.dropItemInHand(true);
+                return;
+            case DiggingMessage.STATE_SHOT_ARROW_FINISH_EATING:
+                if (player.getUsageItem() != null) {
+                    if (Objects.equals(player.getUsageItem(), holding)) {
+                        ItemType type = ItemTable.instance().getItem(player.getUsageItem().getType());
+                        if (type != null && type instanceof ItemTimedUsage) {
+                            ((ItemTimedUsage) type).endUse(player, player.getUsageItem());
+                        } else {
+                            // todo: inform the player that this item cannot be consumed/used
+                        }
+                    } else {
+                        // todo: verification against malicious clients
+                        // todo: inform player their item is wrong
+                    }
                 }
-            } else {
-                // todo: verification against malicious clients
-                // todo: inform player their item is wrong
-            }
-            return;
-        } else if (message.getState() == DiggingMessage.SWAP_ITEM_IN_HAND) {
-            ItemStack main = player.getInventory().getItemInMainHand();
-            ItemStack off = player.getInventory().getItemInOffHand();
-            PlayerSwapHandItemsEvent event = EventFactory.getInstance().callEvent(
-                    new PlayerSwapHandItemsEvent(player, off, main));
-            if (!event.isCancelled()) {
-                player.getInventory().setItemInOffHand(main);
-                player.getInventory().setItemInMainHand(off);
-                player.updateInventory();
-            }
-            return;
-        } else {
-            return;
+                return;
+            case DiggingMessage.SWAP_ITEM_IN_HAND:
+                ItemStack main = player.getInventory().getItemInMainHand();
+                ItemStack off = player.getInventory().getItemInOffHand();
+                PlayerSwapHandItemsEvent event = EventFactory.getInstance().callEvent(
+                        new PlayerSwapHandItemsEvent(player, off, main));
+                if (!event.isCancelled()) {
+                    player.getInventory().setItemInOffHand(main);
+                    player.getInventory().setItemInMainHand(off);
+                    player.updateInventory();
+                }
+                return;
+            default:
+                return;
         }
 
         if (blockBroken && !revert) {
@@ -150,7 +157,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
             MaterialData data = block.getState().getData();
             if (data instanceof DoublePlant) {
                 if (((DoublePlant) data).getSpecies() == DoublePlantSpecies.PLANT_APEX && block
-                    .getRelative(BlockFace.DOWN).getState().getData() instanceof DoublePlant) {
+                        .getRelative(BlockFace.DOWN).getState().getData() instanceof DoublePlant) {
                     block = block.getRelative(BlockFace.DOWN);
                 }
             }
@@ -162,11 +169,11 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
 
             // destroy the block
             if (!block.isEmpty() && !block.isLiquid() && (player.getGameMode() != GameMode.CREATIVE
-                || blockType instanceof BlockContainer) && world.getGameRuleMap()
-                .getBoolean("doTileDrops")) {
+                    || blockType instanceof BlockContainer) && world.getGameRuleMap()
+                    .getBoolean("doTileDrops")) {
                 Collection<ItemStack> drops = blockType.getDrops(block, holding);
                 if (blockType instanceof BlockContainer
-                    && player.getGameMode() == GameMode.CREATIVE) {
+                        && player.getGameMode() == GameMode.CREATIVE) {
                     drops = ((BlockContainer) blockType).getContentDrops(block);
                 }
                 for (ItemStack drop : drops) {
@@ -180,7 +187,7 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
 
             // STEP_SOUND actually is the block break particles
             world.playEffectExceptTo(block.getLocation(), Effect.STEP_SOUND, block.getTypeId(), 64,
-                player);
+                    player);
             GlowBlockState state = block.getState();
             block.setType(Material.AIR);
             if (blockType != null) {

--- a/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/DiggingHandler.java
@@ -117,11 +117,12 @@ public final class DiggingHandler implements MessageHandler<GlowSession, Digging
                 player.dropItemInHand(true);
                 return;
             case DiggingMessage.STATE_SHOT_ARROW_FINISH_EATING:
-                if (player.getUsageItem() != null) {
-                    if (Objects.equals(player.getUsageItem(), holding)) {
-                        ItemType type = ItemTable.instance().getItem(player.getUsageItem().getType());
+                final ItemStack usageItem = player.getUsageItem();
+                if (usageItem != null) {
+                    if (Objects.equals(usageItem, holding)) {
+                        ItemType type = ItemTable.instance().getItem(usageItem.getType());
                         if (type != null && type instanceof ItemTimedUsage) {
-                            ((ItemTimedUsage) type).endUse(player, player.getUsageItem());
+                            ((ItemTimedUsage) type).endUse(player, usageItem);
                         } else {
                             // todo: inform the player that this item cannot be consumed/used
                         }

--- a/src/test/java/net/glowstone/entity/GlowPlayerTest.java
+++ b/src/test/java/net/glowstone/entity/GlowPlayerTest.java
@@ -152,7 +152,9 @@ public class GlowPlayerTest extends GlowHumanEntityTest<GlowPlayer> {
         Material toolType = entity.getItemInHand().getType();
         try {
             entity.setDigging(block);
-            for (long i = 0; i < ticks; i++) {
+            // To spend N full ticks digging, player must be pulsed N+1 times, because setDigging is
+            // called in between ticks and a tick is the interval *between* two pulse() calls.
+            for (long i = 0; i < ticks + 1; i++) {
                 assertEquals(block, entity.getDigging());
                 verify(block, never()).breakNaturally(any(ItemStack.class));
                 entity.pulse();

--- a/src/test/java/net/glowstone/entity/GlowPlayerTest.java
+++ b/src/test/java/net/glowstone/entity/GlowPlayerTest.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.util.List;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.chunk.ChunkManager;
 import net.glowstone.chunk.ChunkManager.ChunkLock;
@@ -125,23 +126,25 @@ public class GlowPlayerTest extends GlowHumanEntityTest<GlowPlayer> {
 
     private void assertCannotDig() {
         for (ItemStack tool : BREAKING_TOOLS) {
-            player.setItemInHand(tool.clone());
-            player.setDigging(block);
-            assertNull(player.getDigging());
+            assertCannotDigWith(tool.clone());
         }
-        player.setItemInHand(null);
-        player.setDigging(block);
-        assertNull(player.getDigging());
+        assertCannotDigWith(null);
+    }
+
+    private void assertCannotDigWith(@Nullable ItemStack tool) {
+        entity.setItemInHand(tool);
+        entity.setDigging(block);
+        assertNull(entity.getDigging());
     }
 
     private void assertDiggingTimeEquals(long ticks) {
-        player.setDigging(block);
+        entity.setDigging(block);
         for (long i = 0; i < ticks; i++) {
-            assertEquals(block, player.getDigging());
-            player.pulse();
+            assertEquals(block, entity.getDigging());
+            entity.pulse();
         }
-        assertNull(player.getDigging());
-        verify(block).breakNaturally(player.getItemInHand());
+        assertNull(entity.getDigging());
+        verify(block).breakNaturally(entity.getItemInHand());
     }
 
     @Test

--- a/src/test/java/net/glowstone/entity/GlowPlayerTest.java
+++ b/src/test/java/net/glowstone/entity/GlowPlayerTest.java
@@ -137,6 +137,7 @@ public class GlowPlayerTest extends GlowHumanEntityTest<GlowPlayer> {
         fishingRodItem = new ItemStack(Material.FISHING_ROD);
         entity = entityCreator.apply(location);
         entity.setItemInHand(fishingRodItem);
+        entity.setDigging(null);
         when(session.getPlayer()).thenReturn(entity);
         when(world.getRawPlayers()).thenReturn(Collections.singletonList(entity));
     }

--- a/src/test/java/net/glowstone/entity/GlowPlayerTest.java
+++ b/src/test/java/net/glowstone/entity/GlowPlayerTest.java
@@ -48,6 +48,12 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public class GlowPlayerTest extends GlowHumanEntityTest<GlowPlayer> {
 
     /**
+     * Hide inherited field with this name, as a check: any reference to it in GlowPlayerTest should
+     * be to {@link #entity} instead.
+     */
+    protected final boolean player = false;
+
+    /**
      * Each breakable block can be broken with one of these.
      */
     private static final List<ItemStack> BREAKING_TOOLS = ImmutableList.of(
@@ -172,16 +178,18 @@ public class GlowPlayerTest extends GlowHumanEntityTest<GlowPlayer> {
 
     @Test
     public void testDigDirtWoodenShovel() {
-        player.setItemInHand(new ItemStack(Material.WOOD_SPADE));
+        entity.setItemInHand(new ItemStack(Material.WOOD_SPADE));
         when(block.getType()).thenReturn(Material.DIRT);
         assertDiggingTimeEquals(8);
     }
 
     @Test
-    public void testDigDirtDiamondShovel() {
-        player.setItemInHand(new ItemStack(Material.WOOD_SPADE));
-        when(block.getType()).thenReturn(Material.DIRT);
-        assertDiggingTimeEquals(2);
+    public void testDigDirtDiamondTools() {
+        for (ItemStack tool : BREAKING_TOOLS) {
+            entity.setItemInHand(tool.clone());
+            when(block.getType()).thenReturn(Material.DIRT);
+            assertDiggingTimeEquals(tool.getType() == Material.DIAMOND_SPADE ? 2 : 15);
+        }
     }
 
     @Test
@@ -192,16 +200,18 @@ public class GlowPlayerTest extends GlowHumanEntityTest<GlowPlayer> {
 
     @Test
     public void testDigStoneWoodenPickaxe() {
-        player.setItemInHand(new ItemStack(Material.WOOD_PICKAXE));
+        entity.setItemInHand(new ItemStack(Material.WOOD_PICKAXE));
         when(block.getType()).thenReturn(Material.STONE);
         assertDiggingTimeEquals(23);
     }
 
     @Test
-    public void testDigStoneDiamondPickaxe() {
-        player.setItemInHand(new ItemStack(Material.DIAMOND_PICKAXE));
-        when(block.getType()).thenReturn(Material.STONE);
-        assertDiggingTimeEquals(6);
+    public void testDigStoneDiamondTools() {
+        for (ItemStack tool : BREAKING_TOOLS) {
+            entity.setItemInHand(tool.clone());
+            when(block.getType()).thenReturn(Material.STONE);
+            assertDiggingTimeEquals(tool.getType() == Material.DIAMOND_PICKAXE ? 6 : 150);
+        }
     }
 
     @Test

--- a/src/test/java/net/glowstone/entity/GlowPlayerTest.java
+++ b/src/test/java/net/glowstone/entity/GlowPlayerTest.java
@@ -124,6 +124,7 @@ public class GlowPlayerTest extends GlowHumanEntityTest<GlowPlayer> {
         when(world.newChunkLock(anyString())).thenReturn(chunkLock);
         when(block.getType()).thenReturn(Material.AIR);
         when(block.getRelative(any(BlockFace.class))).thenReturn(block);
+        when(block.getMaterialValues()).thenCallRealMethod();
         fishingRodItem = new ItemStack(Material.FISHING_ROD);
         entity = entityCreator.apply(location);
         entity.setItemInHand(fishingRodItem);


### PR DESCRIPTION
Fixes #940. Also corrects some mining-speed discrepancies:

- Breaking without a tool was slower than vanilla for non-pickaxe blocks.
- Breaking with a better tool than necessary wasn't increasing breaking speed.
- Breaking speed with a sword doesn't depend in vanilla on the sword's material.
- Special handling for the ~~negative~~ extreme hardness of e.g. bedrock.
- A rounding error affected some tool/block combinations.
- Implements the Efficiency enchantment.