### PR TITLE
Fire EntityTeleportEvent (fixes part of #922)

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -458,10 +458,12 @@ public abstract class GlowEntity implements Entity {
         checkNotNull(location.getWorld(), "location's world cannot be null");
         if (!(this instanceof GlowPlayer)) {
             // TODO: Properly test when Enderman teleportation is implemented.
-            if (EventFactory.getInstance().callEvent(
-                    new EntityTeleportEvent(this, getLocation(), location)).isCancelled()) {
+            EntityTeleportEvent event = EventFactory.getInstance().callEvent(
+                    new EntityTeleportEvent(this, getLocation(), location));
+            if (event.isCancelled()) {
                 return false;
             }
+            location = event.getTo();
         }
         worldLock.writeLock().lock();
         try {

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -60,6 +60,7 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityPortalEnterEvent;
 import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.entity.EntityPortalExitEvent;
+import org.bukkit.event.entity.EntityTeleportEvent;
 import org.bukkit.event.entity.EntityUnleashEvent;
 import org.bukkit.event.entity.EntityUnleashEvent.UnleashReason;
 import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
@@ -455,6 +456,13 @@ public abstract class GlowEntity implements Entity {
     public boolean teleport(Location location) {
         checkNotNull(location, "location cannot be null");
         checkNotNull(location.getWorld(), "location's world cannot be null");
+        if (!(this instanceof GlowPlayer)) {
+            // TODO: Properly test when Enderman teleportation is implemented.
+            if (EventFactory.getInstance().callEvent(
+                    new EntityTeleportEvent(this, getLocation(), location)).isCancelled()) {
+                return false;
+            }
+        }
         worldLock.writeLock().lock();
         try {
             if (location.getWorld() != world) {

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -454,8 +454,6 @@ public abstract class GlowEntity implements Entity {
     // Internals
     @Override
     public boolean teleport(Location location) {
-        checkNotNull(location, "location cannot be null");
-        checkNotNull(location.getWorld(), "location's world cannot be null");
         if (!(this instanceof GlowPlayer)) {
             // TODO: Properly test when Enderman teleportation is implemented.
             EntityTeleportEvent event = EventFactory.getInstance().callEvent(
@@ -465,6 +463,8 @@ public abstract class GlowEntity implements Entity {
             }
             location = event.getTo();
         }
+        checkNotNull(location, "location cannot be null");
+        checkNotNull(location.getWorld(), "location's world cannot be null");
         worldLock.writeLock().lock();
         try {
             if (location.getWorld() != world) {

--- a/src/test/java/net/glowstone/entity/GlowEntityTest.java
+++ b/src/test/java/net/glowstone/entity/GlowEntityTest.java
@@ -129,10 +129,10 @@ public abstract class GlowEntityTest<T extends GlowEntity> {
                 .thenAnswer(RETURN_FIRST_ARG);
         oldEventFactory = EventFactory.getInstance();
         EventFactory.setInstance(eventFactory);
+        when(eventFactory.callEvent(any(Event.class))).thenAnswer(RETURN_FIRST_ARG);
         if (createEntityInSuperSetUp()) {
             entity = entityCreator.apply(location);
         }
-        when(eventFactory.callEvent(any(Event.class))).thenAnswer(RETURN_FIRST_ARG);
         when(eventFactory.onEntityDamage(any(EntityDamageEvent.class))).thenAnswer(
                 RETURN_FIRST_ARG);
         inventory = new GlowPlayerInventory(player);


### PR DESCRIPTION
The `EntityTeleportEvent` is now fired when a `GlowEntity` that is **not** a `GlowPlayer` attempts to teleport, as stated by its [documentation](https://glowstone.net/jd/glowkit/org/bukkit/event/entity/EntityTeleportEvent.html).

This has **not** been tested, as Enderman teleportation has not yet been implemented, but a `TODO` comment has been added for whenever that occurs.

Thanks!