### PR TITLE
Fire PotionSplashEvent

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowAreaEffectCloud.java
+++ b/src/main/java/net/glowstone/entity/GlowAreaEffectCloud.java
@@ -50,8 +50,8 @@ public class GlowAreaEffectCloud extends GlowEntity implements AreaEffectCloud {
                         && temporaryImmunities.getOrDefault(entity, Long.MIN_VALUE) <= currentTick
                         && location.distanceSquared(entity.getLocation()) < radius * radius) {
                     customEffects.values().forEach(
-                            effect -> EntityUtils.applyPotionEffectWithIntensity(
-                                    effect, (LivingEntity) entity, 0.5, 0.25));
+                        effect -> EntityUtils.applyPotionEffectWithIntensity(
+                                effect, (LivingEntity) entity, 0.5, 0.25));
                     temporaryImmunities.put((LivingEntity) entity,
                             currentTick + reapplicationDelay);
                 }

--- a/src/main/java/net/glowstone/entity/GlowAreaEffectCloud.java
+++ b/src/main/java/net/glowstone/entity/GlowAreaEffectCloud.java
@@ -13,6 +13,7 @@ import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
 import net.glowstone.net.message.play.entity.SpawnObjectMessage;
+import net.glowstone.util.EntityUtils;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Particle;
@@ -48,7 +49,9 @@ public class GlowAreaEffectCloud extends GlowEntity implements AreaEffectCloud {
                 if (entity instanceof LivingEntity
                         && temporaryImmunities.getOrDefault(entity, Long.MIN_VALUE) <= currentTick
                         && location.distanceSquared(entity.getLocation()) < radius * radius) {
-                    ((LivingEntity) entity).addPotionEffects(customEffects.values());
+                    customEffects.values().forEach(
+                            effect -> EntityUtils.applyPotionEffectWithIntensity(
+                                    effect, (LivingEntity) entity, 0.5, 0.25));
                     temporaryImmunities.put((LivingEntity) entity,
                             currentTick + reapplicationDelay);
                 }

--- a/src/main/java/net/glowstone/entity/GlowPlayer.java
+++ b/src/main/java/net/glowstone/entity/GlowPlayer.java
@@ -114,6 +114,7 @@ import net.glowstone.net.message.play.player.UseBedMessage;
 import net.glowstone.scoreboard.GlowScoreboard;
 import net.glowstone.scoreboard.GlowTeam;
 import net.glowstone.util.Convert;
+import net.glowstone.util.EntityUtils;
 import net.glowstone.util.InventoryUtil;
 import net.glowstone.util.Position;
 import net.glowstone.util.StatisticMap;
@@ -158,7 +159,6 @@ import org.bukkit.entity.Projectile;
 import org.bukkit.entity.Villager;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityRegainHealthEvent;
-import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
@@ -840,13 +840,7 @@ public class GlowPlayer extends GlowHumanEntity implements Player {
         if (getHealth() < getMaxHealth() && !isDead()) {
             if (foodLevel >= 18 && ticksLived % 80 == 0
                     || world.getDifficulty() == Difficulty.PEACEFUL) {
-
-                EntityRegainHealthEvent event1
-                        = new EntityRegainHealthEvent(this, 1f, RegainReason.SATIATED);
-                EventFactory.getInstance().callEvent(event1);
-                if (!event1.isCancelled()) {
-                    setHealth(getHealth() + 1);
-                }
+                EntityUtils.heal(this, 1, EntityRegainHealthEvent.RegainReason.SATIATED);
                 exhaustion = Math.min(exhaustion + 3.0f, 40.0f);
 
                 saturation -= 3;

--- a/src/main/java/net/glowstone/entity/projectile/GlowLingeringPotion.java
+++ b/src/main/java/net/glowstone/entity/projectile/GlowLingeringPotion.java
@@ -39,13 +39,6 @@ public class GlowLingeringPotion extends GlowSplashPotion implements LingeringPo
             cloud.setColor(potionMeta.getColor());
             cloud.setBasePotionData(potionMeta.getBasePotionData());
             for (PotionEffect effect : getEffects()) {
-                // Cloud effects have only 1/4 the usual duration
-                PotionEffectType type = effect.getType();
-                if (!type.isInstant()) {
-                    effect = new PotionEffect(effect.getType(), effect.getDuration() / 4,
-                            effect.getAmplifier());
-                }
-                // TODO: else effect is 1/2 the usual
                 cloud.addCustomEffect(effect, true);
             }
         }

--- a/src/main/java/net/glowstone/entity/projectile/GlowLingeringPotion.java
+++ b/src/main/java/net/glowstone/entity/projectile/GlowLingeringPotion.java
@@ -9,7 +9,6 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 
 public class GlowLingeringPotion extends GlowSplashPotion implements LingeringPotion {
     public GlowLingeringPotion(Location location) {

--- a/src/main/java/net/glowstone/entity/projectile/GlowSplashPotion.java
+++ b/src/main/java/net/glowstone/entity/projectile/GlowSplashPotion.java
@@ -21,7 +21,8 @@ import org.bukkit.potion.PotionEffect;
 
 public class GlowSplashPotion extends GlowProjectile implements SplashPotion {
     private static final double MAX_VERTICAL_DISTANCE = 2.125;
-    private static final double MAX_DISTANCE_SQUARED = 16.0;
+    private static final double MAX_DISTANCE = 4.0;
+    private static final double MAX_DISTANCE_SQUARED = MAX_DISTANCE * MAX_DISTANCE;
     @Getter
     @Setter
     private ItemStack item;
@@ -47,17 +48,15 @@ public class GlowSplashPotion extends GlowProjectile implements SplashPotion {
         }
         double y = location.getY();
         Map<LivingEntity, Double> affectedIntensities = new HashMap<>();
-        world.getLivingEntities().stream().forEach(entity -> {
+        world.getNearbyEntities(location, MAX_DISTANCE, MAX_VERTICAL_DISTANCE, MAX_DISTANCE)
+                .stream()
+                .filter(LivingEntity.class::isInstance)
+                .forEach(entity -> {
             Location entityLoc = entity.getLocation();
-            double verticalOffset = entityLoc.getY() - y;
-            if (verticalOffset > MAX_VERTICAL_DISTANCE
-                    || verticalOffset < -MAX_VERTICAL_DISTANCE) {
-                return;
-            }
             double distFractionSquared = entityLoc.distanceSquared(location) / MAX_DISTANCE_SQUARED;
             if (distFractionSquared < 1) {
                 // intensity is 1 - (distance / max distance)
-                affectedIntensities.put(entity, 1 - Math.sqrt(distFractionSquared));
+                affectedIntensities.put((LivingEntity) entity, 1 - Math.sqrt(distFractionSquared));
             }
         });
         PotionSplashEvent event = EventFactory.getInstance().callEvent(
@@ -66,7 +65,8 @@ public class GlowSplashPotion extends GlowProjectile implements SplashPotion {
             for (LivingEntity splashed : event.getAffectedEntities()) {
                 for (PotionEffect effect : effects) {
                     double intensity = event.getIntensity(splashed);
-                    EntityUtils.applyPotionEffectWithIntensity(effect, splashed, intensity, intensity);
+                    EntityUtils.applyPotionEffectWithIntensity(
+                            effect, splashed, intensity, intensity);
                 }
             }
         }

--- a/src/main/java/net/glowstone/entity/projectile/GlowSplashPotion.java
+++ b/src/main/java/net/glowstone/entity/projectile/GlowSplashPotion.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.Setter;
 import net.glowstone.EventFactory;
 import net.glowstone.net.message.play.entity.SpawnObjectMessage;
+import net.glowstone.util.EntityUtils;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.LivingEntity;
@@ -62,18 +63,10 @@ public class GlowSplashPotion extends GlowProjectile implements SplashPotion {
         PotionSplashEvent event = EventFactory.getInstance().callEvent(
                 new PotionSplashEvent(this, affectedIntensities));
         if (!event.isCancelled()) {
-            for (LivingEntity entity : event.getAffectedEntities()) {
-                double intensity = event.getIntensity(entity);
-                for (PotionEffect effect : getEffects()) {
-                    // TODO: Apply intensity to Healing and Harming
-                    entity.addPotionEffect(intensity >= 1.0 ? effect : new PotionEffect(
-                            // FIXME: PotionEffect needs a builder class for situations like this
-                            effect.getType(),
-                            (int) (effect.getDuration() * intensity),
-                            effect.getAmplifier(),
-                            effect.isAmbient(),
-                            effect.hasParticles(),
-                            effect.getColor()));
+            for (LivingEntity splashed : event.getAffectedEntities()) {
+                for (PotionEffect effect : effects) {
+                    double intensity = event.getIntensity(splashed);
+                    EntityUtils.applyPotionEffectWithIntensity(effect, splashed, intensity, intensity);
                 }
             }
         }

--- a/src/main/java/net/glowstone/entity/projectile/GlowSplashPotion.java
+++ b/src/main/java/net/glowstone/entity/projectile/GlowSplashPotion.java
@@ -3,7 +3,6 @@ package net.glowstone.entity.projectile;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
@@ -47,19 +46,19 @@ public class GlowSplashPotion extends GlowProjectile implements SplashPotion {
         }
         double y = location.getY();
         Map<LivingEntity, Double> affectedIntensities = new HashMap<>();
-        for (LivingEntity entity : world.getLivingEntities()) {
-            Location entityLocation = entity.getLocation();
-            double verticalOffset = entityLocation.getY() - y;
-            if (verticalOffset <= MAX_VERTICAL_DISTANCE
-                    && verticalOffset >= -MAX_VERTICAL_DISTANCE) {
-                double distanceFractionSquared
-                        = entityLocation.distanceSquared(location) / MAX_DISTANCE_SQUARED;
-                if (distanceFractionSquared < 1) {
-                    // intensity is 1 - (distance / max distance)
-                    affectedIntensities.put(entity, 1 - Math.sqrt(distanceFractionSquared));
-                }
+        world.getLivingEntities().stream().forEach(entity -> {
+            Location entityLoc = entity.getLocation();
+            double verticalOffset = entityLoc.getY() - y;
+            if (verticalOffset > MAX_VERTICAL_DISTANCE
+                    || verticalOffset < -MAX_VERTICAL_DISTANCE) {
+                return;
             }
-        }
+            double distFractionSquared = entityLoc.distanceSquared(location) / MAX_DISTANCE_SQUARED;
+            if (distFractionSquared < 1) {
+                // intensity is 1 - (distance / max distance)
+                affectedIntensities.put(entity, 1 - Math.sqrt(distFractionSquared));
+            }
+        });
         PotionSplashEvent event = EventFactory.getInstance().callEvent(
                 new PotionSplashEvent(this, affectedIntensities));
         if (!event.isCancelled()) {

--- a/src/main/java/net/glowstone/entity/projectile/GlowSplashPotion.java
+++ b/src/main/java/net/glowstone/entity/projectile/GlowSplashPotion.java
@@ -52,13 +52,15 @@ public class GlowSplashPotion extends GlowProjectile implements SplashPotion {
                 .stream()
                 .filter(LivingEntity.class::isInstance)
                 .forEach(entity -> {
-            Location entityLoc = entity.getLocation();
-            double distFractionSquared = entityLoc.distanceSquared(location) / MAX_DISTANCE_SQUARED;
-            if (distFractionSquared < 1) {
-                // intensity is 1 - (distance / max distance)
-                affectedIntensities.put((LivingEntity) entity, 1 - Math.sqrt(distFractionSquared));
-            }
-        });
+                    Location entityLoc = entity.getLocation();
+                    double distFractionSquared = entityLoc.distanceSquared(location)
+                            / MAX_DISTANCE_SQUARED;
+                    if (distFractionSquared < 1) {
+                        // intensity is 1 - (distance / max distance)
+                        affectedIntensities.put((LivingEntity) entity,
+                                1 - Math.sqrt(distFractionSquared));
+                    }
+                });
         PotionSplashEvent event = EventFactory.getInstance().callEvent(
                 new PotionSplashEvent(this, affectedIntensities));
         if (!event.isCancelled()) {

--- a/src/main/java/net/glowstone/util/EntityUtils.java
+++ b/src/main/java/net/glowstone/util/EntityUtils.java
@@ -1,0 +1,72 @@
+package net.glowstone.util;
+
+import net.glowstone.EventFactory;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+public class EntityUtils {
+    /**
+     * Heals an entity by a specific amount.
+     *
+     * @param target the entity to heal
+     * @param amount the amount of health to regain
+     * @param reason the reason supplied to the {@link EntityRegainHealthEvent}
+     */
+    public static void heal(LivingEntity target, double amount,
+            EntityRegainHealthEvent.RegainReason reason) {
+        EntityRegainHealthEvent event
+                = new EntityRegainHealthEvent(target, amount, reason);
+        EventFactory.getInstance().callEvent(event);
+        if (!event.isCancelled()) {
+            target.setHealth(Math.min(
+                    target.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue(),
+                    target.getHealth() + amount));
+        }
+    }
+
+    /**
+     * Applies a potion effect with an intensity ranging from 0.0 for no effect to 1.0 for full
+     * effect.
+     *
+     * @param effect the effect
+     * @param target the target to apply the effect to
+     * @param instantIntensity the intensity multiplier if the effect is instantaneous
+     * @param durationIntensity the duration multiplier if the effect has a duration
+     */
+    public static void applyPotionEffectWithIntensity(
+            PotionEffect effect, LivingEntity target, double instantIntensity,
+            double durationIntensity) {
+        PotionEffectType type = effect.getType();
+        final int baseAmplifier = effect.getAmplifier();
+        if (type.equals(PotionEffectType.HEAL)) {
+            heal(target, (2 << baseAmplifier) * instantIntensity,
+                    EntityRegainHealthEvent.RegainReason.MAGIC);
+        } else if (type.equals(PotionEffectType.HARM)) {
+            target.damage(3 << baseAmplifier, EntityDamageEvent.DamageCause.MAGIC);
+        } else if (type.isInstant()) {
+            // Custom instant potion effect: can't partially apply, so scale amplifier down instead
+            // (but never reduce it to zero)
+            target.addPotionEffect((instantIntensity >= 1.0 || baseAmplifier <= 1)
+                    ? effect
+                    : new PotionEffect(
+                            type,
+                            0,
+                            Math.max(1, (int) (baseAmplifier * instantIntensity + 0.5)),
+                            effect.isAmbient(),
+                            effect.hasParticles(),
+                            effect.getColor()));
+        } else {
+            target.addPotionEffect(durationIntensity >= 1.0 ? effect : new PotionEffect(
+                    type,
+                    (int) (effect.getDuration() * durationIntensity),
+                    baseAmplifier,
+                    effect.isAmbient(),
+                    effect.hasParticles(),
+                    effect.getColor()));
+        }
+    }
+}

--- a/src/main/java/net/glowstone/util/EntityUtils.java
+++ b/src/main/java/net/glowstone/util/EntityUtils.java
@@ -18,8 +18,10 @@ public class EntityUtils {
      */
     public static void heal(LivingEntity target, double amount,
             EntityRegainHealthEvent.RegainReason reason) {
-        EntityRegainHealthEvent event
-                = new EntityRegainHealthEvent(target, amount, reason);
+        if (target.isDead()) {
+            return; // too late!
+        }
+        EntityRegainHealthEvent event = new EntityRegainHealthEvent(target, amount, reason);
         EventFactory.getInstance().callEvent(event);
         if (!event.isCancelled()) {
             target.setHealth(Math.min(

--- a/src/main/java/net/glowstone/util/EntityUtils.java
+++ b/src/main/java/net/glowstone/util/EntityUtils.java
@@ -8,6 +8,9 @@ import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+/**
+ * Utility methods for dealing with entities.
+ */
 public class EntityUtils {
     /**
      * Heals an entity by a specific amount.

--- a/src/main/java/net/glowstone/util/EntityUtils.java
+++ b/src/main/java/net/glowstone/util/EntityUtils.java
@@ -29,7 +29,7 @@ public class EntityUtils {
         if (!event.isCancelled()) {
             target.setHealth(Math.min(
                     target.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue(),
-                    target.getHealth() + amount));
+                    target.getHealth() + event.getAmount()));
         }
     }
 

--- a/src/main/java/net/glowstone/util/EntityUtils.java
+++ b/src/main/java/net/glowstone/util/EntityUtils.java
@@ -24,12 +24,15 @@ public class EntityUtils {
         if (target.isDead()) {
             return; // too late!
         }
+        final double maxHealth = target.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
+        final double currentHealth = target.getHealth();
+        if (currentHealth >= maxHealth) {
+            return;
+        }
         EntityRegainHealthEvent event = new EntityRegainHealthEvent(target, amount, reason);
         EventFactory.getInstance().callEvent(event);
         if (!event.isCancelled()) {
-            target.setHealth(Math.min(
-                    target.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue(),
-                    target.getHealth() + event.getAmount()));
+            target.setHealth(Math.min(maxHealth, currentHealth + event.getAmount()));
         }
     }
 

--- a/src/main/java/net/glowstone/util/EntityUtils.java
+++ b/src/main/java/net/glowstone/util/EntityUtils.java
@@ -51,7 +51,8 @@ public class EntityUtils {
             heal(target, (2 << baseAmplifier) * instantIntensity,
                     EntityRegainHealthEvent.RegainReason.MAGIC);
         } else if (type.equals(PotionEffectType.HARM)) {
-            target.damage(3 << baseAmplifier, EntityDamageEvent.DamageCause.MAGIC);
+            target.damage((3 << baseAmplifier) * instantIntensity,
+                    EntityDamageEvent.DamageCause.MAGIC);
         } else if (type.isInstant()) {
             // Custom instant potion effect: can't partially apply, so scale amplifier down instead
             // (but never reduce it to zero)


### PR DESCRIPTION
Progresses #922 

PotionSplashEvent is now fired whenever a splash potion lands (including a lingering potion, but only for immediate effects). In addition to cancelation, we also recognize changes to the list of targets and the intensity for each target. In the case of a potion of healing, EntityRegainHealthEvent is also fired for each target, using the same logic that `GlowPlayer.pulse()` already uses when regenerating from food; that logic is now `EntityUtils.heal(LivingEntity, double, EntityRegainHealthEvent.RegainReason)`.

Partial-intensity effects for splash potions and lingering potions are now implemented. For custom instant effects at level 2 or higher, partial intensity may mean a lower level.