### PR TITLE
Fix bed drop color

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockBed.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockBed.java
@@ -92,9 +92,8 @@ public class BlockBed extends BlockType {
 
     @Override
     public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {
-        GlowBed bed = (GlowBed) block.getState();
-        byte data = bed.getColor().getWoolData();
-        return Collections.singletonList(new ItemStack(Material.BED, 1, data));
+        return Collections.singletonList(new ItemStack(Material.BED, 1,
+                (((GlowBed) block.getState()).getColor().getWoolData()));
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/blocktype/BlockBed.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockBed.java
@@ -1,5 +1,7 @@
 package net.glowstone.block.blocktype;
 
+import java.util.Collection;
+import java.util.Collections;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
@@ -25,10 +27,6 @@ import org.bukkit.material.MaterialData;
 import org.bukkit.util.Vector;
 
 public class BlockBed extends BlockType {
-
-    public BlockBed() {
-        setDrops(new ItemStack(Material.BED));
-    }
 
     /**
      * Helper method for set whether the specified bed blocks are occupied.
@@ -90,6 +88,13 @@ public class BlockBed extends BlockType {
         } else {
             return block;
         }
+    }
+
+    @Override
+    public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {
+        GlowBed bed = (GlowBed)block.getState();
+        byte data = bed.getColor().getWoolData();
+        return Collections.singletonList(new ItemStack(Material.BED, 1, data));
     }
 
     /**

--- a/src/main/java/net/glowstone/block/blocktype/BlockBed.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockBed.java
@@ -93,7 +93,7 @@ public class BlockBed extends BlockType {
     @Override
     public Collection<ItemStack> getDrops(GlowBlock block, ItemStack tool) {
         return Collections.singletonList(new ItemStack(Material.BED, 1,
-                (((GlowBed) block.getState()).getColor().getWoolData()));
+                (((GlowBed) block.getState()).getColor().getWoolData())));
     }
 
     @Override


### PR DESCRIPTION
Destroyed Beds (no matter what color they had) did always drop in white.
They will now drop in the correct color.