### PR TITLE
Fix multi-sector region file writing

### DIFF
--- a/src/main/java/net/glowstone/io/anvil/RegionFile.java
+++ b/src/main/java/net/glowstone/io/anvil/RegionFile.java
@@ -332,10 +332,6 @@ public class RegionFile {
             int runLength = 0;
             int currentSector = 2;
             while (runLength < sectorsNeeded) {
-                if (sectorsUsed.length() >= currentSector) {
-                    // We reached the end, and we will need to allocate a new sector.
-                    break;
-                }
                 int nextSector = sectorsUsed.nextClearBit(currentSector + 1);
                 if (currentSector + 1 == nextSector) {
                     runLength++;


### PR DESCRIPTION
I contributed this code almost two years ago (under @minecrafter) and nobody had noticed this bug.

Today, as part of an unrelated project, I used this code to write code that manipulated Anvil region files. Unfortunately, this code had a bug: multi-sector chunk writing would trigger broken code that would result in sector 2 always being overwritten. This fixes that issue.

I believe this was the cause of #465.