### PR TITLE
Fixes #847

### DIFF
--- a/src/main/java/net/glowstone/block/itemtype/ItemBoat.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemBoat.java
@@ -3,6 +3,7 @@ package net.glowstone.block.itemtype;
 import java.util.Set;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.entity.GlowPlayer;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.TreeSpecies;
@@ -24,7 +25,7 @@ public class ItemBoat extends ItemType {
     @Override
     public void rightClickAir(GlowPlayer player, ItemStack holding) {
         // Executed when the player clicks on water that doesn't have a block beneath
-        placeBoat(player);
+        placeBoat(player, holding);
     }
 
     @Override
@@ -33,10 +34,10 @@ public class ItemBoat extends ItemType {
             Vector clickedLoc, EquipmentSlot hand) {
         // Two cases are handled here: Either the player clicked on a block on the land or beneath
         // water
-        placeBoat(player);
+        placeBoat(player, holding);
     }
 
-    private void placeBoat(GlowPlayer player) {
+    private void placeBoat(GlowPlayer player, ItemStack holding) {
         Block targetBlock = player.getTargetBlock((Set<Material>) null, 5);
 
         if (targetBlock != null && !targetBlock.isEmpty()
@@ -47,6 +48,9 @@ public class ItemBoat extends ItemType {
             location.setYaw(player.getLocation().getYaw());
             Boat boat = targetBlock.getWorld().spawn(location, Boat.class);
             boat.setWoodType(woodType);
+            if (player.getGameMode() != GameMode.CREATIVE) {
+                player.getInventory().removeItem(holding);
+            }
         }
     }
 

--- a/src/main/java/net/glowstone/inventory/GlowInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowInventory.java
@@ -472,6 +472,7 @@ public class GlowInventory implements Inventory {
                     slotItem.setAmount(slotItem.getAmount() - toRemove);
                 } else {
                     toRemove -= slotItem.getAmount();
+                    item.setAmount(0);
                     slot.setItem(new ItemStack(Material.AIR, 0));
                 }
             }

--- a/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
@@ -144,9 +144,7 @@ public final class BlockPlacementHandler implements
         }
 
         if (holding.getAmount() <= 0) {
-            holding = InventoryUtil.createEmptyStack();
+            player.getInventory().setItem(slot, InventoryUtil.createEmptyStack());
         }
-
-        player.getInventory().setItem(slot, holding);
     }
 }

--- a/src/main/java/net/glowstone/net/handler/play/player/UseItemHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/UseItemHandler.java
@@ -95,9 +95,8 @@ public class UseItemHandler implements MessageHandler<GlowSession, UseItemMessag
 
             // Empties the user's inventory when the item is used up
             if (holding.getAmount() <= 0) {
-                holding = InventoryUtil.createEmptyStack();
+                player.getInventory().setItem(slot, InventoryUtil.createEmptyStack());
             }
-            player.getInventory().setItem(slot, holding);
         }
     }
 }

--- a/src/test/java/net/glowstone/net/handler/play/player/UseItemHandlerTest.java
+++ b/src/test/java/net/glowstone/net/handler/play/player/UseItemHandlerTest.java
@@ -1,0 +1,96 @@
+package net.glowstone.net.handler.play.player;
+
+import net.glowstone.EventFactory;
+import net.glowstone.GlowServer;
+import net.glowstone.GlowWorld;
+import net.glowstone.block.GlowBlock;
+import net.glowstone.entity.EntityIdManager;
+import net.glowstone.entity.EntityManager;
+import net.glowstone.entity.GlowPlayer;
+import net.glowstone.entity.objects.GlowBoat;
+import net.glowstone.inventory.GlowPlayerInventory;
+import net.glowstone.net.GlowSession;
+import net.glowstone.net.message.play.player.UseItemMessage;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Boat;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Set;
+
+public class UseItemHandlerTest {
+
+    @Test
+    public void testRightClickAir() throws Exception {
+        EventFactory origEventFactory = EventFactory.getInstance();
+        try {
+            // setup mocks
+            GlowWorld world = Mockito.mock(GlowWorld.class);
+            GlowServer server = Mockito.mock(GlowServer.class);
+            EntityManager entityManager = Mockito.mock(EntityManager.class);
+            EntityIdManager entityIdManager = Mockito.mock(EntityIdManager.class);
+            GlowSession session = Mockito.mock(GlowSession.class);
+            GlowPlayer player = Mockito.mock(GlowPlayer.class);
+            GlowBlock emptyBlock = Mockito.mock(GlowBlock.class);
+            GlowBlock targetBlock = Mockito.mock(GlowBlock.class);
+            EventFactory eventFactory = Mockito.mock(EventFactory.class);
+            EventFactory.setInstance(eventFactory);
+
+            // world and server behaviours
+            Mockito.when(world.getEntityManager()).thenReturn(entityManager);
+            Mockito.when(world.getServer()).thenReturn(server);
+            Mockito.when(server.getEntityIdManager()).thenReturn(entityIdManager);
+
+            // setup items under test
+            Location location = new Location(world, 1.0, 1.0, 1.0);
+            Location playerLocation = new Location(world, 2.0, 2.0, 2.0);
+            GlowPlayerInventory inventory = new GlowPlayerInventory(player);
+            Assert.assertFalse(inventory.contains(Material.BOAT_JUNGLE, 1));
+
+            ItemStack stack = new ItemStack(Material.BOAT_JUNGLE);
+            inventory.setItemInMainHand(stack);
+            Assert.assertTrue(inventory.contains(Material.BOAT_JUNGLE, 1));
+
+            UseItemMessage message = new UseItemMessage(EquipmentSlot.HAND.ordinal());
+            PlayerInteractEvent event = new PlayerInteractEvent(player,
+                    Action.RIGHT_CLICK_AIR, stack, null, null);
+            GlowBoat boat = new GlowBoat(location);
+
+            // prepare mock behaviours
+            Mockito.when(session.getPlayer()).thenReturn(player);
+            Mockito.when(player.getInventory()).thenReturn(inventory);
+            Mockito.when(player.getLocation()).thenReturn(playerLocation);
+            Mockito.when(player.getTargetBlock((Set<Material>) null,
+                    5)).thenReturn(targetBlock);
+            Mockito.when(player.getGameMode()).thenReturn(GameMode.SURVIVAL);
+            Mockito.when(eventFactory.onPlayerInteract(player, Action.RIGHT_CLICK_AIR,
+                    EquipmentSlot.HAND)).thenReturn(event);
+
+            Mockito.when(emptyBlock.isEmpty()).thenReturn(Boolean.TRUE);
+            Mockito.when(emptyBlock.getLocation()).thenReturn(location);
+            Mockito.when(targetBlock.isEmpty()).thenReturn(Boolean.FALSE);
+            Mockito.when(targetBlock.getRelative(BlockFace.UP)).thenReturn(emptyBlock);
+            Mockito.when(targetBlock.getWorld()).thenReturn(world);
+            Mockito.when(world.spawn(location, Boat.class)).thenReturn(boat);
+
+            // run test
+            Assert.assertTrue(inventory.contains(Material.BOAT_JUNGLE, 1));
+            UseItemHandler handler = new UseItemHandler();
+            handler.handle(session, message);
+            Assert.assertFalse(inventory.contains(Material.BOAT_JUNGLE, 1));
+        } finally {
+            EventFactory.setInstance(origEventFactory);
+        }
+    }
+
+
+
+}

--- a/src/test/java/net/glowstone/net/handler/play/player/UseItemHandlerTest.java
+++ b/src/test/java/net/glowstone/net/handler/play/player/UseItemHandlerTest.java
@@ -4,7 +4,6 @@ import net.glowstone.EventFactory;
 import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
-import net.glowstone.block.itemtype.ItemTypeTest;
 import net.glowstone.entity.EntityIdManager;
 import net.glowstone.entity.EntityManager;
 import net.glowstone.entity.GlowPlayer;
@@ -29,7 +28,7 @@ import org.mockito.Mockito;
 
 import java.util.Set;
 
-public class UseItemHandlerTest extends ItemTypeTest {
+public class UseItemHandlerTest {
 
     private EventFactory actualEventFactory;
 

--- a/src/test/java/net/glowstone/net/handler/play/player/UseItemHandlerTest.java
+++ b/src/test/java/net/glowstone/net/handler/play/player/UseItemHandlerTest.java
@@ -4,6 +4,7 @@ import net.glowstone.EventFactory;
 import net.glowstone.GlowServer;
 import net.glowstone.GlowWorld;
 import net.glowstone.block.GlowBlock;
+import net.glowstone.block.itemtype.ItemTypeTest;
 import net.glowstone.entity.EntityIdManager;
 import net.glowstone.entity.EntityManager;
 import net.glowstone.entity.GlowPlayer;
@@ -20,77 +21,96 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.Set;
 
-public class UseItemHandlerTest {
+public class UseItemHandlerTest extends ItemTypeTest {
+
+    private EventFactory actualEventFactory;
+
+    private GlowWorld world;
+    private GlowServer server;
+    private EntityManager entityManager;
+    private EntityIdManager entityIdManager;
+    private GlowSession session;
+    private GlowPlayer player;
+    private GlowBlock emptyBlock;
+    private GlowBlock targetBlock;
+    private EventFactory eventFactory;
+
+    @Before
+    public void setupMocks() {
+        // cache the event factory
+        actualEventFactory = EventFactory.getInstance();
+        // install the mock event factory
+        eventFactory = Mockito.mock(EventFactory.class);
+        EventFactory.setInstance(eventFactory);
+
+        // create mocks
+        world = Mockito.mock(GlowWorld.class);
+        server = Mockito.mock(GlowServer.class);
+        entityManager = Mockito.mock(EntityManager.class);
+        entityIdManager = Mockito.mock(EntityIdManager.class);
+        session = Mockito.mock(GlowSession.class);
+        player = Mockito.mock(GlowPlayer.class);
+        emptyBlock = Mockito.mock(GlowBlock.class);
+        targetBlock = Mockito.mock(GlowBlock.class);
+
+        // world and server behaviours
+        Mockito.when(world.getEntityManager()).thenReturn(entityManager);
+        Mockito.when(world.getServer()).thenReturn(server);
+        Mockito.when(server.getEntityIdManager()).thenReturn(entityIdManager);
+    }
 
     @Test
     public void testRightClickAir() throws Exception {
-        EventFactory origEventFactory = EventFactory.getInstance();
-        try {
-            // setup mocks
-            GlowWorld world = Mockito.mock(GlowWorld.class);
-            GlowServer server = Mockito.mock(GlowServer.class);
-            EntityManager entityManager = Mockito.mock(EntityManager.class);
-            EntityIdManager entityIdManager = Mockito.mock(EntityIdManager.class);
-            GlowSession session = Mockito.mock(GlowSession.class);
-            GlowPlayer player = Mockito.mock(GlowPlayer.class);
-            GlowBlock emptyBlock = Mockito.mock(GlowBlock.class);
-            GlowBlock targetBlock = Mockito.mock(GlowBlock.class);
-            EventFactory eventFactory = Mockito.mock(EventFactory.class);
-            EventFactory.setInstance(eventFactory);
+        // prepare objects under test
+        Location location = new Location(world, 1.0, 1.0, 1.0);
+        Location playerLocation = new Location(world, 2.0, 2.0, 2.0);
+        GlowPlayerInventory inventory = new GlowPlayerInventory(player);
+        ItemStack stack = new ItemStack(Material.BOAT_JUNGLE);
+        GlowBoat boat = new GlowBoat(location);
+        inventory.setItemInMainHand(stack);
+        UseItemMessage message = new UseItemMessage(EquipmentSlot.HAND.ordinal());
+        PlayerInteractEvent event = new PlayerInteractEvent(player,
+                Action.RIGHT_CLICK_AIR, stack, null, null);
 
-            // world and server behaviours
-            Mockito.when(world.getEntityManager()).thenReturn(entityManager);
-            Mockito.when(world.getServer()).thenReturn(server);
-            Mockito.when(server.getEntityIdManager()).thenReturn(entityIdManager);
+        // prepare mock behaviours
+        Mockito.when(session.getPlayer()).thenReturn(player);
+        Mockito.when(player.getInventory()).thenReturn(inventory);
+        Mockito.when(player.getLocation()).thenReturn(playerLocation);
+        Mockito.when(player.getTargetBlock((Set<Material>) null,
+                5)).thenReturn(targetBlock);
+        Mockito.when(player.getGameMode()).thenReturn(GameMode.SURVIVAL);
+        Mockito.when(eventFactory.onPlayerInteract(player, Action.RIGHT_CLICK_AIR,
+                EquipmentSlot.HAND)).thenReturn(event);
 
-            // setup items under test
-            Location location = new Location(world, 1.0, 1.0, 1.0);
-            Location playerLocation = new Location(world, 2.0, 2.0, 2.0);
-            GlowPlayerInventory inventory = new GlowPlayerInventory(player);
-            Assert.assertFalse(inventory.contains(Material.BOAT_JUNGLE, 1));
+        Mockito.when(emptyBlock.isEmpty()).thenReturn(Boolean.TRUE);
+        Mockito.when(emptyBlock.getLocation()).thenReturn(location);
+        Mockito.when(targetBlock.isEmpty()).thenReturn(Boolean.FALSE);
+        Mockito.when(targetBlock.getRelative(BlockFace.UP)).thenReturn(emptyBlock);
+        Mockito.when(targetBlock.getWorld()).thenReturn(world);
+        Mockito.when(world.spawn(location, Boat.class)).thenReturn(boat);
 
-            ItemStack stack = new ItemStack(Material.BOAT_JUNGLE);
-            inventory.setItemInMainHand(stack);
-            Assert.assertTrue(inventory.contains(Material.BOAT_JUNGLE, 1));
-
-            UseItemMessage message = new UseItemMessage(EquipmentSlot.HAND.ordinal());
-            PlayerInteractEvent event = new PlayerInteractEvent(player,
-                    Action.RIGHT_CLICK_AIR, stack, null, null);
-            GlowBoat boat = new GlowBoat(location);
-
-            // prepare mock behaviours
-            Mockito.when(session.getPlayer()).thenReturn(player);
-            Mockito.when(player.getInventory()).thenReturn(inventory);
-            Mockito.when(player.getLocation()).thenReturn(playerLocation);
-            Mockito.when(player.getTargetBlock((Set<Material>) null,
-                    5)).thenReturn(targetBlock);
-            Mockito.when(player.getGameMode()).thenReturn(GameMode.SURVIVAL);
-            Mockito.when(eventFactory.onPlayerInteract(player, Action.RIGHT_CLICK_AIR,
-                    EquipmentSlot.HAND)).thenReturn(event);
-
-            Mockito.when(emptyBlock.isEmpty()).thenReturn(Boolean.TRUE);
-            Mockito.when(emptyBlock.getLocation()).thenReturn(location);
-            Mockito.when(targetBlock.isEmpty()).thenReturn(Boolean.FALSE);
-            Mockito.when(targetBlock.getRelative(BlockFace.UP)).thenReturn(emptyBlock);
-            Mockito.when(targetBlock.getWorld()).thenReturn(world);
-            Mockito.when(world.spawn(location, Boat.class)).thenReturn(boat);
-
-            // run test
-            Assert.assertTrue(inventory.contains(Material.BOAT_JUNGLE, 1));
-            UseItemHandler handler = new UseItemHandler();
-            handler.handle(session, message);
-            Assert.assertFalse(inventory.contains(Material.BOAT_JUNGLE, 1));
-        } finally {
-            EventFactory.setInstance(origEventFactory);
-        }
+        // run test
+        Assert.assertTrue(inventory.contains(Material.BOAT_JUNGLE, 1));
+        UseItemHandler handler = new UseItemHandler();
+        handler.handle(session, message);
+        // after calling use item and creating a boat, the inventory no longer contains a boat
+        Assert.assertFalse(inventory.contains(Material.BOAT_JUNGLE, 1));
     }
 
+
+    @After
+    public void tearDown() {
+        // restore the original event factory
+        EventFactory.setInstance(actualEventFactory);
+    }
 
 
 }


### PR DESCRIPTION
This fix builds on the earlier work by Pr0methean [fb5cc7b].  The issue was that `UseItemHandler` restored the original item into the inventory.  I guess this was done in order to delete items when they are consumed.

I made a similar fix to `BlockPlacementHandler`.
