### PR TITLE
Use resolved UUID instead of illegal string.

### DIFF
--- a/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
@@ -195,7 +195,7 @@ public class GlowPlayerProfile implements PlayerProfile {
         CompoundTag profileTag = new CompoundTag();
         UUID uuid = getId();
         if (uuid != null) {
-            profileTag.putString("Id", uniqueId.toString());
+            profileTag.putString("Id", uuid.toString());
         }
         if (name != null) {
             profileTag.putString("Name", name);


### PR DESCRIPTION
Reference #977 #978

PR #978 attempted to fix Issue #977 (Completablefuture typename was being used as the UUID string in NBT data), however after the null check, the uuid variable that was resolved is discarded instead of used in the NBT.

This change uses the resolved UUID in the NBT instead of the CompletableFuture type-string as the uuid.

In #977 I list some exceptions that occur when this string is read before adding this PR. After adding this PR, these don't seem to appear.

EDIT: double word