### PR TITLE
[WIP] implement getters/setter in GlowPlayerProfile

### DIFF
--- a/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
@@ -245,7 +245,7 @@ public class GlowPlayerProfile implements PlayerProfile {
             synchronized (this) {
                 if (uniqueId == null) {
                     uniqueId = CompletableFuture.completedFuture(uuid);
-                    return;
+                    return null;
                 }
                 oldUuid = uniqueId.getNow(null);
             }

--- a/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
+++ b/src/main/java/net/glowstone/entity/meta/profile/GlowPlayerProfile.java
@@ -32,7 +32,7 @@ public class GlowPlayerProfile implements PlayerProfile {
     public static final int MAX_USERNAME_LENGTH = 16;
     @Getter
     @Nullable
-    private final String name;
+    private String name;
     @Nullable
     private volatile CompletableFuture<UUID> uniqueId;
     private final Map<String, ProfileProperty> properties;
@@ -217,10 +217,19 @@ public class GlowPlayerProfile implements PlayerProfile {
         }
         return profileTag;
     }
+    
+    private void checkOwnerCriteria(String name, UUID id) {
+        if (id == null && (name == null || name.isEmpty())) {
+            throw new IllegalArgumentException("Either name or uuid must be present in profile");
+        }
+    }
 
     @Override
     public String setName(@Nullable String name) {
-        throw new UnsupportedOperationException("Not implemented yet.");
+        checkOwnerCriteria(name,getId());
+        String oldname = this.name;
+        this.name = name;
+        return oldname;
     }
 
     @Override
@@ -230,7 +239,11 @@ public class GlowPlayerProfile implements PlayerProfile {
 
     @Override
     public UUID setId(@Nullable UUID uuid) {
-        throw new UnsupportedOperationException("Not implemented yet.");
+        checkOwnerCriteria(name,uuid);
+        UUID olduuid = getId();
+        uniqueId = new CompletableFuture<UUID>();
+        uniqueId.complete(uuid);
+        return olduuid;
     }
 
     /**
@@ -250,7 +263,7 @@ public class GlowPlayerProfile implements PlayerProfile {
 
     @Override
     public boolean hasProperty(String property) {
-        throw new UnsupportedOperationException("Not implemented yet.");
+        return properties.containsKey(property);
     }
 
     @Override


### PR DESCRIPTION
This is my relatively primitive attempt to implement the remaining getters/setters in GlowPlayerProfile that are currently unsupported.

While this seems pretty basic I think it *should* have a similar enough behavior to other implementations, since I don't think others resolve input id's during set/construction either.

Since there's not an internal object used to hold the owner here, I had to remove the `final` from the name.  You may also may want to decide if it should be `volatile` now that it can be changed by different threads.

This is not ready for merging without changes after review.
Let me know.