### PR TITLE
Command localization, step 1

### DIFF
--- a/src/main/java/net/glowstone/command/minecraft/GlowVanillaCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/GlowVanillaCommand.java
@@ -1,0 +1,123 @@
+package net.glowstone.command.minecraft;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import net.glowstone.entity.GlowPlayer;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.defaults.VanillaCommand;
+import org.jetbrains.annotations.NonNls;
+
+/**
+ * A subclass of {@link VanillaCommand} with the additional feature that when the command sender is
+ * a {@link GlowPlayer}, description, usage and permission-error messages are looked up in the
+ * client's locale, temporarily overriding whatever has been or is subsequently set in
+ * {@link #setDescription(String)}, {@link #setUsage(String)} or
+ * {@link #setPermissionMessage(String)}.
+ */
+public abstract class GlowVanillaCommand extends VanillaCommand {
+
+  private static final String BUNDLE_BASE_NAME = "commands";
+  private static final String DESCRIPTION_SUFFIX = ".description";
+  private static final String USAGE_SUFFIX = ".usage";
+  private static final String PERMISSION_SUFFIX = ".no-permission";
+  private static final ResourceBundle SERVER_LOCALE = ResourceBundle.getBundle(BUNDLE_BASE_NAME);
+
+  private final Lock localeChangeLock = new ReentrantLock();
+  private final String resourceKey;
+  private volatile Locale lastLoadedLocale;
+
+  public GlowVanillaCommand(@NonNls String name, @NonNls String resourceKey,
+      @NonNls List<String> aliases) {
+    super(name,
+        SERVER_LOCALE.getString(resourceKey + DESCRIPTION_SUFFIX),
+        SERVER_LOCALE.getString(resourceKey + USAGE_SUFFIX),
+        aliases);
+    setPermissionMessage(SERVER_LOCALE.getString(resourceKey + PERMISSION_SUFFIX));
+    this.resourceKey = resourceKey;
+    lastLoadedLocale = SERVER_LOCALE.getLocale();
+  }
+
+  @Override
+  public Command setDescription(String description) {
+    localeChangeLock.lock();
+    try {
+      lastLoadedLocale = null;
+      return super.setDescription(description);
+    } finally {
+      localeChangeLock.unlock();
+    }
+  }
+
+  @Override
+  public Command setUsage(String usage) {
+    localeChangeLock.lock();
+    try {
+      lastLoadedLocale = null;
+      return super.setUsage(usage);
+    } finally {
+      localeChangeLock.unlock();
+    }
+  }
+
+  @Override
+  public Command setPermissionMessage(String permissionMessage) {
+    localeChangeLock.lock();
+    try {
+      lastLoadedLocale = null;
+      return super.setPermissionMessage(permissionMessage);
+    } finally {
+      localeChangeLock.unlock();
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>This delegates to {@link #innerExecute(CommandSender, String, String[])}, but first ensures
+   * that if the command sender is a player, the description and usage message are for that player's
+   * locale.</p>
+   */
+  @Override
+  public boolean execute(CommandSender sender, String commandLabel, String[] args) {
+    if (!(sender instanceof GlowPlayer)) {
+      return innerExecute(sender, commandLabel, args);
+    }
+    localeChangeLock.lock();
+    try {
+      Locale locale = Locale.forLanguageTag(((GlowPlayer) sender).getLocale());
+      if (locale.equals(lastLoadedLocale)) {
+        return innerExecute(sender, commandLabel, args);
+      }
+      lastLoadedLocale = locale;
+      String oldDescription = getDescription();
+      String oldUsage = getUsage();
+      String oldPermissionMessage = getPermissionMessage();
+      ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_BASE_NAME, locale);
+      description = bundle.getString(resourceKey + DESCRIPTION_SUFFIX);
+      usageMessage = bundle.getString(resourceKey + USAGE_SUFFIX);
+      super.setPermissionMessage(bundle.getString(resourceKey + PERMISSION_SUFFIX));
+      try {
+        return innerExecute(sender, commandLabel, args);
+      } finally {
+        description = oldDescription;
+        usageMessage = oldUsage;
+        super.setPermissionMessage(oldPermissionMessage);
+      }
+    } finally {
+      localeChangeLock.unlock();
+    }
+  }
+
+  /**
+   * Executes the command, returning its success.
+   *
+   * @param sender Source object which is executing this command
+   * @param commandLabel The alias of the command used
+   * @param args All arguments passed to the command, split via ' '
+   * @return true if the command was successful, otherwise false
+   */
+  protected abstract boolean innerExecute(CommandSender sender, String commandLabel, String[] args);
+}

--- a/src/main/java/net/glowstone/command/minecraft/GlowVanillaCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/GlowVanillaCommand.java
@@ -28,21 +28,17 @@ public abstract class GlowVanillaCommand extends VanillaCommand {
     private static final ResourceBundle SERVER_LOCALE = ResourceBundle.getBundle(BUNDLE_BASE_NAME);
 
     private final Lock localeChangeLock = new ReentrantLock();
-    private final String resourceKey;
     private volatile Locale lastLoadedLocale;
 
     /**
-     * {@inheritDoc}
-     * @param resourceKey the base name of this command's localizable strings in commands.properties
+     * Creates an instance, using the command's name to look up the description etc.
      */
-    public GlowVanillaCommand(@NonNls String name, @NonNls String resourceKey,
-            @NonNls List<String> aliases) {
+    public GlowVanillaCommand(@NonNls String name, @NonNls List<String> aliases) {
         super(name,
-                SERVER_LOCALE.getString(resourceKey + DESCRIPTION_SUFFIX),
-                SERVER_LOCALE.getString(resourceKey + USAGE_SUFFIX),
+                SERVER_LOCALE.getString(name + DESCRIPTION_SUFFIX),
+                SERVER_LOCALE.getString(name + USAGE_SUFFIX),
                 aliases);
-        setPermissionMessage(SERVER_LOCALE.getString(resourceKey + PERMISSION_SUFFIX));
-        this.resourceKey = resourceKey;
+        setPermissionMessage(SERVER_LOCALE.getString(name + PERMISSION_SUFFIX));
         lastLoadedLocale = SERVER_LOCALE.getLocale();
     }
 
@@ -102,9 +98,9 @@ public abstract class GlowVanillaCommand extends VanillaCommand {
             String oldUsage = getUsage();
             String oldPermissionMessage = getPermissionMessage();
             ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_BASE_NAME, locale);
-            description = bundle.getString(resourceKey + DESCRIPTION_SUFFIX);
-            usageMessage = bundle.getString(resourceKey + USAGE_SUFFIX);
-            super.setPermissionMessage(bundle.getString(resourceKey + PERMISSION_SUFFIX));
+            description = bundle.getString(getName() + DESCRIPTION_SUFFIX);
+            usageMessage = bundle.getString(getName() + USAGE_SUFFIX);
+            super.setPermissionMessage(bundle.getString(getName() + PERMISSION_SUFFIX));
             try {
                 return innerExecute(sender, commandLabel, args);
             } finally {

--- a/src/main/java/net/glowstone/command/minecraft/GlowVanillaCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/GlowVanillaCommand.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -20,104 +21,110 @@ import org.jetbrains.annotations.NonNls;
  */
 public abstract class GlowVanillaCommand extends VanillaCommand {
 
-  private static final String BUNDLE_BASE_NAME = "commands";
-  private static final String DESCRIPTION_SUFFIX = ".description";
-  private static final String USAGE_SUFFIX = ".usage";
-  private static final String PERMISSION_SUFFIX = ".no-permission";
-  private static final ResourceBundle SERVER_LOCALE = ResourceBundle.getBundle(BUNDLE_BASE_NAME);
+    private static final String BUNDLE_BASE_NAME = "commands";
+    private static final String DESCRIPTION_SUFFIX = ".description";
+    private static final String USAGE_SUFFIX = ".usage";
+    private static final String PERMISSION_SUFFIX = ".no-permission";
+    private static final ResourceBundle SERVER_LOCALE = ResourceBundle.getBundle(BUNDLE_BASE_NAME);
 
-  private final Lock localeChangeLock = new ReentrantLock();
-  private final String resourceKey;
-  private volatile Locale lastLoadedLocale;
+    private final Lock localeChangeLock = new ReentrantLock();
+    private final String resourceKey;
+    private volatile Locale lastLoadedLocale;
 
-  public GlowVanillaCommand(@NonNls String name, @NonNls String resourceKey,
-      @NonNls List<String> aliases) {
-    super(name,
-        SERVER_LOCALE.getString(resourceKey + DESCRIPTION_SUFFIX),
-        SERVER_LOCALE.getString(resourceKey + USAGE_SUFFIX),
-        aliases);
-    setPermissionMessage(SERVER_LOCALE.getString(resourceKey + PERMISSION_SUFFIX));
-    this.resourceKey = resourceKey;
-    lastLoadedLocale = SERVER_LOCALE.getLocale();
-  }
-
-  @Override
-  public Command setDescription(String description) {
-    localeChangeLock.lock();
-    try {
-      lastLoadedLocale = null;
-      return super.setDescription(description);
-    } finally {
-      localeChangeLock.unlock();
+    /**
+     * {@inheritDoc}
+     * @param resourceKey the base name of this command's localizable strings in commands.properties
+     */
+    public GlowVanillaCommand(@NonNls String name, @NonNls String resourceKey,
+            @NonNls List<String> aliases) {
+        super(name,
+                SERVER_LOCALE.getString(resourceKey + DESCRIPTION_SUFFIX),
+                SERVER_LOCALE.getString(resourceKey + USAGE_SUFFIX),
+                aliases);
+        setPermissionMessage(SERVER_LOCALE.getString(resourceKey + PERMISSION_SUFFIX));
+        this.resourceKey = resourceKey;
+        lastLoadedLocale = SERVER_LOCALE.getLocale();
     }
-  }
 
-  @Override
-  public Command setUsage(String usage) {
-    localeChangeLock.lock();
-    try {
-      lastLoadedLocale = null;
-      return super.setUsage(usage);
-    } finally {
-      localeChangeLock.unlock();
+    @Override
+    public Command setDescription(String description) {
+        localeChangeLock.lock();
+        try {
+            lastLoadedLocale = null;
+            return super.setDescription(description);
+        } finally {
+            localeChangeLock.unlock();
+        }
     }
-  }
 
-  @Override
-  public Command setPermissionMessage(String permissionMessage) {
-    localeChangeLock.lock();
-    try {
-      lastLoadedLocale = null;
-      return super.setPermissionMessage(permissionMessage);
-    } finally {
-      localeChangeLock.unlock();
+    @Override
+    public Command setUsage(String usage) {
+        localeChangeLock.lock();
+        try {
+            lastLoadedLocale = null;
+            return super.setUsage(usage);
+        } finally {
+            localeChangeLock.unlock();
+        }
     }
-  }
 
-  /**
-   * {@inheritDoc}
-   * <p>This delegates to {@link #innerExecute(CommandSender, String, String[])}, but first ensures
-   * that if the command sender is a player, the description and usage message are for that player's
-   * locale.</p>
-   */
-  @Override
-  public boolean execute(CommandSender sender, String commandLabel, String[] args) {
-    if (!(sender instanceof GlowPlayer)) {
-      return innerExecute(sender, commandLabel, args);
+    @Override
+    public Command setPermissionMessage(String permissionMessage) {
+        localeChangeLock.lock();
+        try {
+            lastLoadedLocale = null;
+            return super.setPermissionMessage(permissionMessage);
+        } finally {
+            localeChangeLock.unlock();
+        }
     }
-    localeChangeLock.lock();
-    try {
-      Locale locale = Locale.forLanguageTag(((GlowPlayer) sender).getLocale());
-      if (locale.equals(lastLoadedLocale)) {
-        return innerExecute(sender, commandLabel, args);
-      }
-      lastLoadedLocale = locale;
-      String oldDescription = getDescription();
-      String oldUsage = getUsage();
-      String oldPermissionMessage = getPermissionMessage();
-      ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_BASE_NAME, locale);
-      description = bundle.getString(resourceKey + DESCRIPTION_SUFFIX);
-      usageMessage = bundle.getString(resourceKey + USAGE_SUFFIX);
-      super.setPermissionMessage(bundle.getString(resourceKey + PERMISSION_SUFFIX));
-      try {
-        return innerExecute(sender, commandLabel, args);
-      } finally {
-        description = oldDescription;
-        usageMessage = oldUsage;
-        super.setPermissionMessage(oldPermissionMessage);
-      }
-    } finally {
-      localeChangeLock.unlock();
-    }
-  }
 
-  /**
-   * Executes the command, returning its success.
-   *
-   * @param sender Source object which is executing this command
-   * @param commandLabel The alias of the command used
-   * @param args All arguments passed to the command, split via ' '
-   * @return true if the command was successful, otherwise false
-   */
-  protected abstract boolean innerExecute(CommandSender sender, String commandLabel, String[] args);
+    /**
+     * {@inheritDoc}
+     * <p>This delegates to {@link #innerExecute(CommandSender, String, String[])}, but first
+     * ensures that if the command sender is a player, then the description and usage message are
+     * for that player's locale. (If the command sender <em>isn't</em> a player, the server locale
+     * is used.)</p>
+     */
+    @Override
+    public boolean execute(CommandSender sender, String commandLabel, String[] args) {
+        if (!(sender instanceof GlowPlayer)) {
+            return innerExecute(sender, commandLabel, args);
+        }
+        localeChangeLock.lock();
+        try {
+            Locale locale = Locale.forLanguageTag(((GlowPlayer) sender).getLocale());
+            if (locale.equals(lastLoadedLocale)) {
+                return innerExecute(sender, commandLabel, args);
+            }
+            lastLoadedLocale = locale;
+            String oldDescription = getDescription();
+            String oldUsage = getUsage();
+            String oldPermissionMessage = getPermissionMessage();
+            ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE_BASE_NAME, locale);
+            description = bundle.getString(resourceKey + DESCRIPTION_SUFFIX);
+            usageMessage = bundle.getString(resourceKey + USAGE_SUFFIX);
+            super.setPermissionMessage(bundle.getString(resourceKey + PERMISSION_SUFFIX));
+            try {
+                return innerExecute(sender, commandLabel, args);
+            } finally {
+                description = oldDescription;
+                usageMessage = oldUsage;
+                super.setPermissionMessage(oldPermissionMessage);
+            }
+        } finally {
+            localeChangeLock.unlock();
+        }
+    }
+
+    /**
+     * Executes the command, returning its success.
+     *
+     * @param sender       Source object which is executing this command
+     * @param commandLabel The alias of the command used
+     * @param args         All arguments passed to the command, split via ' '
+     * @return true if the command was successful, otherwise false
+     */
+    protected abstract boolean innerExecute(CommandSender sender, String commandLabel,
+            String[] args);
 }

--- a/src/main/java/net/glowstone/command/minecraft/GlowVanillaCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/GlowVanillaCommand.java
@@ -50,7 +50,7 @@ public abstract class GlowVanillaCommand extends VanillaCommand {
      */
     public GlowVanillaCommand(@NonNls String name, @NonNls List<String> aliases) {
         super(name, "", "", aliases);
-        bundleToMessageCache = CacheBuilder.newBuilder().build(
+        bundleToMessageCache = CacheBuilder.newBuilder().maximumSize(CACHE_SIZE).build(
                 CacheLoader.from(this::readResourceBundle));
         CommandMessages defaultMessages = readResourceBundle(DEFAULT_RESOURCE_BUNDLE);
         super.setDescription(defaultMessages.getDescription());

--- a/src/main/java/net/glowstone/i18n/ConsoleMessages.java
+++ b/src/main/java/net/glowstone/i18n/ConsoleMessages.java
@@ -381,6 +381,11 @@ public interface ConsoleMessages {
                     "console.chunk.unload-failed", Level.WARNING);
         }
 
+        interface Command {
+            LoggableLocalizedString L10N_FAILED = new LoggableLocalizedStringImpl(
+                    "console.command.l10n-failed", Level.WARNING);
+        }
+
         interface Crypt {
             LoggableLocalizedString AUTH_FAILED = new LoggableLocalizedStringImpl(
                     "console.net.crypt.user-auth", Level.WARNING);

--- a/src/main/resources/commands.properties
+++ b/src/main/resources/commands.properties
@@ -1,0 +1,5 @@
+# Localized strings related to commands will be placed here.
+# The naming scheme is:
+# {basename}.description: Description of the command's function.
+# {basename}.usage: Example invocations of the command. May be multiline.
+# {basename}.no-permission: Error message when the command sender doesn't have permission.

--- a/src/main/resources/commands.properties
+++ b/src/main/resources/commands.properties
@@ -1,5 +1,5 @@
 # Localized strings related to commands will be placed here.
 # The naming scheme is:
-# {basename}.description: Description of the command's function.
-# {basename}.usage: Example invocations of the command. May be multiline.
-# {basename}.no-permission: Error message when the command sender doesn't have permission.
+# {name}.description: Description of the command's function.
+# {name}.usage: Example invocations of the command. May be multiline.
+# {name}.no-permission: Error message when the command sender doesn't have permission.

--- a/src/main/resources/strings.properties
+++ b/src/main/resources/strings.properties
@@ -27,6 +27,7 @@ console.chunk.section-oob=Out of bounds chunk section at y {0} in {1}!
 console.chunk.unknown-block-to-tick=Unknown block ''{0}'' when loading chunk block ticks.
 console.chunk.unload-failed=Failed to unload chunk {0}:{1}
 console.classpath.load-failed=Error loading classpath!
+console.command.l10n-failed=Error retrieving messages for command {0} in {1}'s locale.
 console.config-only-done=Configuration files have been loaded, exiting...
 console.enchant.bad-slot=Malicious client, cannot enchant slot {0}
 console.enchant.missing-resources=Malicious client, player has not enough levels / enough resources to enchant item!


### PR DESCRIPTION
This creates an abstract base class for commands which extend VanillaCommand and need i18n, so they will speak to players in their own locale if available. (To non-player CommandSender instances, they'll speak the server locale.)

Subsequent PRs will do the same for BukkitCommand, make all the concrete command classes extend these two, and add tests to ensure no missing or unused entries in `commands.properties`.