### PR TITLE
[i18n] Replace CommandUtils.prettyPrint with ListFormatter from ICU4J

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,11 @@
       <artifactId>fast-uuid</artifactId>
       <version>0.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.ibm.icu</groupId>
+      <artifactId>icu4j</artifactId>
+      <version>63.1</version>
+    </dependency>
     <!-- NonNls annotation: https://mvnrepository.com/artifact/org.jetbrains/annotations -->
     <dependency>
       <groupId>org.jetbrains</groupId>

--- a/src/main/java/net/glowstone/command/CommandUtils.java
+++ b/src/main/java/net/glowstone/command/CommandUtils.java
@@ -1,7 +1,9 @@
 package net.glowstone.command;
 
+import com.ibm.icu.text.ListFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import net.glowstone.GlowWorld;
 import net.glowstone.ServerProvider;
 import net.glowstone.block.state.BlockStateData;
@@ -77,24 +79,16 @@ public class CommandUtils {
     }
 
     /**
-     * Converts an array of strings describing list items to a single string listing them.
+     * Converts an array of strings describing list items to a single string listing them, in the
+     * server locale.
      *
      * @param strings one or more strings
      * @return a list of the strings, formatted like "a, b and c"
+     * @deprecated Use a {@link ListFormatter} when the desired locale is known.
      */
-    // FIXME: Replace with the function from the Unicode CLDR that handles almost any language
+    @Deprecated
     public static String prettyPrint(String[] strings) {
-        StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < strings.length; i++) {
-            String string = strings[i];
-            if (i == strings.length - 1 && strings.length > 1) {
-                builder.append(" and ");
-            } else if (i > 0) {
-                builder.append(", ");
-            }
-            builder.append(string);
-        }
-        return builder.toString();
+        return ListFormatter.getInstance(Locale.getDefault()).format(strings);
     }
 
     // TODO: Move this into the Server class within Glowkit, and implement it with GlowServer.

--- a/src/main/java/net/glowstone/command/CommandUtils.java
+++ b/src/main/java/net/glowstone/command/CommandUtils.java
@@ -3,7 +3,6 @@ package net.glowstone.command;
 import com.ibm.icu.text.ListFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import net.glowstone.GlowWorld;
 import net.glowstone.ServerProvider;
 import net.glowstone.block.state.BlockStateData;

--- a/src/main/java/net/glowstone/command/CommandUtils.java
+++ b/src/main/java/net/glowstone/command/CommandUtils.java
@@ -62,11 +62,13 @@ public class CommandUtils {
     }
 
     /**
-     * Converts an array of entities to a readable string.
+     * Converts an array of entities to a readable string, in the server locale.
      *
      * @param entities one or more entities
      * @return a list of the entities' names, formatted like "Alice, Bob and Creeper"
+     * @deprecated Use a {@link ListFormatter} when the desired locale is known.
      */
+    @Deprecated
     public static String prettyPrint(Entity[] entities) {
         List<String> names = new ArrayList<>();
         for (int i = 0; i < entities.length; i++) {

--- a/src/main/java/net/glowstone/command/CommandUtils.java
+++ b/src/main/java/net/glowstone/command/CommandUtils.java
@@ -88,7 +88,7 @@ public class CommandUtils {
      */
     @Deprecated
     public static String prettyPrint(String[] strings) {
-        return ListFormatter.getInstance(Locale.getDefault()).format(strings);
+        return ListFormatter.getInstance().format(strings);
     }
 
     // TODO: Move this into the Server class within Glowkit, and implement it with GlowServer.

--- a/src/main/java/net/glowstone/command/minecraft/BanListCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/BanListCommand.java
@@ -1,5 +1,6 @@
 package net.glowstone.command.minecraft;
 
+import com.ibm.icu.text.ListFormatter;
 import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -9,7 +10,6 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.stream.Collectors;
-import net.glowstone.command.CommandUtils;
 import net.glowstone.i18n.LocalizedStringImpl;
 import org.bukkit.BanEntry;
 import org.bukkit.BanList;
@@ -66,8 +66,9 @@ public class BanListCommand extends GlowVanillaCommand {
                 .collect(Collectors.toList());
             new LocalizedStringImpl("banlist.non-empty", resourceBundle).send(sender,
                     banEntries.size());
-            sender
-                .sendMessage(CommandUtils.prettyPrint(targets.toArray(new String[0])));
+            String[] strings = targets.toArray(new String[0]);
+            sender.sendMessage(
+                    ListFormatter.getInstance(resourceBundle.getLocale()).format(strings));
         }
 
         return true;

--- a/src/main/resources/LICENSE.txt
+++ b/src/main/resources/LICENSE.txt
@@ -25,7 +25,12 @@ THE SOFTWARE.
 ------------------------------------------------------------------------------
 
 This distribution includes a derivative of Bukkit, which is GPL-licensed, and
-is therefore the derivative, Glowkit, is licensed under the terms of the GNU GPLv3, which follows.
+therefore the derivative, Glowkit, is licensed under the terms of the GNU GPLv3,
+which follows.
+
+It also includes functionality from ICU4J, which is licensed under the
+Unicode, Inc. License Agreement for Data Files and Software, which follows below
+the GPL.
 
 For more information, visit:
 - Glowstone: https://github.com/GlowstoneMC/Glowstone
@@ -707,3 +712,60 @@ may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
 <http://www.gnu.org/philosophy/why-not-lgpl.html>.
+
+------------------------------------------------------------------------------
+Unicode Data Files include all data files under the directories
+http://www.unicode.org/Public/, http://www.unicode.org/reports/,
+http://www.unicode.org/cldr/data/, http://source.icu-project.org/repos/icu/, and
+http://www.unicode.org/utility/trac/browser/.
+
+Unicode Data Files do not include PDF online code charts under the
+directory http://www.unicode.org/Public/.
+
+Software includes any source code published in the Unicode Standard
+or under the directories
+http://www.unicode.org/Public/, http://www.unicode.org/reports/,
+http://www.unicode.org/cldr/data/, http://source.icu-project.org/repos/icu/, and
+http://www.unicode.org/utility/trac/browser/.
+
+NOTICE TO USER: Carefully read the following legal agreement.
+BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
+DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
+YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT.
+IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
+THE DATA FILES OR SOFTWARE.
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2018 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in http://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.


### PR DESCRIPTION
Only applies to `/banlist` right now, but will apply to all commands that use `CommandUtils.prettyPrint` once the rest are converted to extend `GlowVanillaCommand`.