### PR TITLE
Use 1.13 list formatting

### DIFF
--- a/src/main/java/net/glowstone/command/CommandUtils.java
+++ b/src/main/java/net/glowstone/command/CommandUtils.java
@@ -53,7 +53,10 @@ public class CommandUtils {
      *
      * @param entities one or more entities
      * @return a list of the entities' names, formatted like "Alice, Bob and Creeper"
+     * @deprecated Use one of the {@code joinList} overloads in
+     * {@link net.glowstone.command.minecraft.GlowVanillaCommand.CommandMessages}.
      */
+    @Deprecated
     public static String prettyPrint(Entity[] entities) {
         String[] names = new String[entities.length];
         for (int i = 0; i < entities.length; i++) {
@@ -67,8 +70,10 @@ public class CommandUtils {
      *
      * @param strings one or more strings
      * @return a list of the strings, formatted like "a, b and c"
+     * @deprecated Use one of the {@code joinList} overloads in
+     * {@link net.glowstone.command.minecraft.GlowVanillaCommand.CommandMessages}.
      */
-    // FIXME: Replace with the function from the Unicode CLDR that handles almost any language
+    @Deprecated
     public static String prettyPrint(String[] strings) {
         StringBuilder builder = new StringBuilder();
         for (int i = 0; i < strings.length; i++) {

--- a/src/main/java/net/glowstone/command/minecraft/BanListCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/BanListCommand.java
@@ -8,8 +8,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.Set;
-import java.util.stream.Collectors;
-import net.glowstone.command.CommandUtils;
+import java.util.stream.Stream;
 import net.glowstone.i18n.LocalizedStringImpl;
 import org.bukkit.BanEntry;
 import org.bukkit.BanList;
@@ -62,12 +61,10 @@ public class BanListCommand extends GlowVanillaCommand {
         if (banEntries.isEmpty()) {
             new LocalizedStringImpl("banlist.empty", resourceBundle).send(sender);
         } else {
-            final List<String> targets = banEntries.stream().map(BanEntry::getTarget)
-                .collect(Collectors.toList());
+            final Stream<String> targets = banEntries.stream().map(BanEntry::getTarget);
             new LocalizedStringImpl("banlist.non-empty", resourceBundle).send(sender,
                     banEntries.size());
-            sender
-                .sendMessage(CommandUtils.prettyPrint(targets.toArray(new String[0])));
+            sender.sendMessage(messages.joinList(targets));
         }
 
         return true;

--- a/src/main/java/net/glowstone/command/minecraft/GlowVanillaCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/GlowVanillaCommand.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.Data;
 import net.glowstone.entity.GlowPlayer;
 import net.glowstone.i18n.ConsoleMessages;
@@ -49,6 +51,7 @@ public abstract class GlowVanillaCommand extends VanillaCommand {
             .maximumSize(CACHE_SIZE)
             .build(CacheLoader.from(localeStr ->
                     ResourceBundle.getBundle(BUNDLE_BASE_NAME, Locale.forLanguageTag(localeStr))));
+    public static final String JOINER = "_generic.joiner";
 
     private final LoadingCache<ResourceBundle, CommandMessages> bundleToMessageCache;
 
@@ -60,7 +63,8 @@ public abstract class GlowVanillaCommand extends VanillaCommand {
                 bundle.getString(name + USAGE_SUFFIX),
                 bundle.getString(
                         bundle.containsKey(permissionKey) ? permissionKey : DEFAULT_PERMISSION),
-                new LocalizedStringImpl(NO_SUCH_PLAYER, bundle));
+                new LocalizedStringImpl(NO_SUCH_PLAYER, bundle),
+                new LocalizedStringImpl(JOINER, bundle).get());
     }
 
     /**
@@ -102,7 +106,8 @@ public abstract class GlowVanillaCommand extends VanillaCommand {
                     getDescription(),
                     getUsage(),
                     getPermissionMessage(),
-                    new LocalizedStringImpl("_generic.no-such-player", SERVER_LOCALE_BUNDLE));
+                    new LocalizedStringImpl(NO_SUCH_PLAYER, SERVER_LOCALE_BUNDLE),
+                    new LocalizedStringImpl("_generic.joiner", SERVER_LOCALE_BUNDLE).get());
         }
         return execute(sender, commandLabel, args, bundle, localizedMessages);
     }
@@ -154,5 +159,39 @@ public abstract class GlowVanillaCommand extends VanillaCommand {
         private final String usageMessage;
         private final String permissionMessage;
         private final LocalizedString noSuchPlayer;
+        private final String joiner;
+
+        /**
+         * Returns the given items as a comma-separated list. The comma character and surrounding
+         * spacing are a localized string.
+         *
+         * @param objects the items to format as a list
+         * @return a comma-separated list
+         */
+        public String joinList(Iterable<? extends CharSequence> objects) {
+            return String.join(joiner, objects);
+        }
+
+        /**
+         * Returns the given items as a comma-separated list. The comma character and surrounding
+         * spacing are a localized string.
+         *
+         * @param objects the items to format as a list
+         * @return a comma-separated list
+         */
+        public String joinList(Stream<? extends CharSequence> objects) {
+            return objects.collect(Collectors.joining(joiner));
+        }
+
+        /**
+         * Returns the given items as a comma-separated list. The comma character and surrounding
+         * spacing are a localized string.
+         *
+         * @param objects the items to format as a list
+         * @return a comma-separated list
+         */
+        public String joinList(CharSequence... objects) {
+            return String.join(joiner, objects);
+        }
     }
 }

--- a/src/main/resources/commands.properties
+++ b/src/main/resources/commands.properties
@@ -5,6 +5,7 @@
 # {name}.usage: Example invocations of the command. May be multiline.
 # {name}.no-permission: Error message when the command sender doesn't have permission
 #     ({name}.no-permission is optional as long as _generic.no-permission is defined.)
+_generic.joiner=,\u0020
 _generic.no-permission=\
   I'm sorry, but you do not have permission to perform this command. Please contact the server \
   administrators if you believe that this is in error.

--- a/src/main/resources/commands.properties
+++ b/src/main/resources/commands.properties
@@ -5,7 +5,11 @@
 # {name}.usage: Example invocations of the command. May be multiline.
 # {name}.no-permission: Error message when the command sender doesn't have permission
 #     ({name}.no-permission is optional as long as _generic.no-permission is defined.)
+
+# _generic.joiner is used to join names in a list. Leading and trailing spaces should be escaped,
+#     to make it clear that they're intentional.
 _generic.joiner=,\u0020
+
 _generic.no-permission=\
   I'm sorry, but you do not have permission to perform this command. Please contact the server \
   administrators if you believe that this is in error.


### PR DESCRIPTION
Switches /banlist to output an "and"-less list with a localizable joiner string, matching Vanilla from 1.13 onward and simplifying i18n. Deprecates CommandUtils.prettyPrint(all overloads); they'll be removed as they're converted to extend GlowVanillaCommand in my next few PRs.