### PR TITLE
Switch to ForkJoinPool

### DIFF
--- a/src/main/java/net/glowstone/scheduler/GlowScheduler.java
+++ b/src/main/java/net/glowstone/scheduler/GlowScheduler.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import net.glowstone.GlowServer;
 import net.glowstone.net.SessionRegistry;
-import org.bukkit.Server;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitScheduler;
@@ -41,10 +40,6 @@ public final class GlowScheduler implements BukkitScheduler {
      */
     static final int PULSE_EVERY = 50;
     private static final int PARALLELISM = Runtime.getRuntime().availableProcessors();
-    /**
-     * The server this scheduler is managing for.
-     */
-    private final Server server;
     /**
      * The scheduled executor service which backs this worlds.
      */
@@ -95,19 +90,16 @@ public final class GlowScheduler implements BukkitScheduler {
      *         worlds.
      */
     public GlowScheduler(GlowServer server, WorldScheduler worlds) {
-        this(server, worlds, server.getSessionRegistry());
+        this(worlds, server.getSessionRegistry());
     }
 
     /**
      * Creates a new task scheduler.
-     * @param server The server that will use this scheduler.
      * @param worlds The {@link WorldScheduler} this scheduler will use for ticking the server's
      *         worlds.
      * @param sessionRegistry The {@link SessionRegistry} this scheduler will use to tick players
      */
-    public GlowScheduler(Server server, WorldScheduler worlds,
-            SessionRegistry sessionRegistry) {
-        this.server = server;
+    public GlowScheduler(WorldScheduler worlds, SessionRegistry sessionRegistry) {
         this.worlds = worlds;
         this.sessionRegistry = sessionRegistry;
         inTickTaskCondition = worlds.getAdvanceCondition();

--- a/src/test/java/net/glowstone/testutils/ServerShim.java
+++ b/src/test/java/net/glowstone/testutils/ServerShim.java
@@ -84,7 +84,7 @@ public class ServerShim implements Server {
 
     @Getter
     private final GlowScheduler scheduler
-            = new GlowScheduler(this, worldScheduler, sessionRegistry);
+            = new GlowScheduler(worldScheduler, sessionRegistry);
 
     @Override
     public String getName() {


### PR DESCRIPTION
Scales the number of threads before letting tasks queue up. Should improve performance when there's a BlockPhysicsEvent handler (#994).