### PR TITLE
Use cloudflare DNS for session server IP lookup

### DIFF
--- a/src/main/java/net/glowstone/net/http/HttpClient.java
+++ b/src/main/java/net/glowstone/net/http/HttpClient.java
@@ -22,8 +22,9 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import io.netty.handler.timeout.ReadTimeoutHandler;
-import io.netty.resolver.dns.DefaultDnsServerAddressStreamProvider;
 import io.netty.resolver.dns.DnsAddressResolverGroup;
+import io.netty.resolver.dns.SingletonDnsServerAddressStreamProvider;
+import io.netty.util.internal.SocketUtils;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
@@ -36,7 +37,7 @@ public class HttpClient {
     private static DnsAddressResolverGroup resolverGroup = new DnsAddressResolverGroup(
         GlowServer.EPOLL ? EpollDatagramChannel.class : GlowServer.KQUEUE
             ? KQueueDatagramChannel.class : NioDatagramChannel.class,
-        DefaultDnsServerAddressStreamProvider.INSTANCE);
+        new SingletonDnsServerAddressStreamProvider(SocketUtils.socketAddress("1.1.1.1", 53)));
 
     /**
      * Opens a URL.


### PR DESCRIPTION
This PR fixes an issue where the client would be kicked with the message: internal error during login. The server complains about not being able to reach the mojang session server, failing with a timeout exception. This is because netty's ```DefaultDnsServerAddressStreamProvider``` which uses Googles DNS servers (8.8.8.8 and 8.8.4.4) for IP lookup. This PR changes the DNS servers tou cloudflare's (1.1.1.1) thus resolving the issue.

This has been tested many times (it was frustrating to not be able to play on my server for 2 months now) and is proven to solve my issue (Thanks for your fast support on Discord, that really helped :D)
