### PR TITLE
Item amount decrement is now applied on block place (fixes #1012)

### DIFF
--- a/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
+++ b/src/main/java/net/glowstone/net/handler/play/player/BlockPlacementHandler.java
@@ -145,6 +145,9 @@ public final class BlockPlacementHandler implements
 
         if (holding.getAmount() <= 0) {
             player.getInventory().setItem(slot, InventoryUtil.createEmptyStack());
+        } else {
+            // Set the item in `slot` to `holding`, as it was cloned before its amount was decremented.
+            player.getInventory().setItem(slot, holding);
         }
     }
 }


### PR DESCRIPTION
When a block or item (such as sugarcane) is placed, the reference to the item in the player's main hand is cloned before its amount is decremented (after it has been placed successfully). Because of this, the amount of the **cloned** item was being decremented rather the amount of the actual item (in the player's hand). This pull request fixes this issue (#1012) and was tested accordingly.