### PR TITLE
Animal feeding improvements

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowAgeable.java
+++ b/src/main/java/net/glowstone/entity/GlowAgeable.java
@@ -77,7 +77,9 @@ public class GlowAgeable extends GlowCreature implements Ageable {
         if (love > 0) {
             setInLove(love - 1);
             if (love % 20 == 0) {
-                world.showParticle(location, Effect.HEART, 0, 0, 0, 1, 1);
+                world.showParticle(location, Effect.HEART, 0,
+                        /* float above head */ (float) (getHeight() + 0.5),
+                        0, 1, 1);
             }
             // TODO: Search for a mate if in MobState.IDLE
         }

--- a/src/main/java/net/glowstone/entity/GlowAgeable.java
+++ b/src/main/java/net/glowstone/entity/GlowAgeable.java
@@ -12,6 +12,7 @@ import net.glowstone.net.message.play.player.InteractEntityMessage;
 import net.glowstone.util.InventoryUtil;
 import net.glowstone.util.SoundUtil;
 import net.glowstone.util.TickUtil;
+import org.bukkit.Effect;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -71,6 +72,14 @@ public class GlowAgeable extends GlowCreature implements Ageable {
                 currentAge--;
                 setAge(currentAge);
             }
+        }
+        int love = getInLove();
+        if (love > 0) {
+            setInLove(love - 1);
+            if (love % 20 == 0) {
+                world.showParticle(location, Effect.HEART, 0, 0, 0, 1, 1);
+            }
+            // TODO: Search for a mate if in MobState.IDLE
         }
     }
 

--- a/src/main/java/net/glowstone/entity/GlowAnimal.java
+++ b/src/main/java/net/glowstone/entity/GlowAnimal.java
@@ -59,6 +59,7 @@ public class GlowAnimal extends GlowAgeable implements Animals {
             boolean successfullyUsed = false;
             if (getBreedingFoods().contains(type)) {
                 if (canBreed()) {
+                    setInLove(1000); // TODO get the correct duration
                     // TODO set love mode if possible and spawn particles
                     // and don't set successfullyUsed if love mode is not possible
                     player.incrementStatistic(Statistic.ANIMALS_BRED);

--- a/src/main/java/net/glowstone/entity/GlowAnimal.java
+++ b/src/main/java/net/glowstone/entity/GlowAnimal.java
@@ -53,10 +53,8 @@ public class GlowAnimal extends GlowAgeable implements Animals {
      */
     protected boolean tryFeed(Material type, GlowPlayer player) {
         if (getBreedingFoods().contains(type)) {
-            if (canBreed()) {
+            if (canBreed() && (getInLove() <= 0)) {
                 setInLove(1000); // TODO get the correct duration
-                // TODO set love mode if possible and spawn particles
-                // and don't set successfullyUsed if love mode is not possible
                 player.incrementStatistic(Statistic.ANIMALS_BRED);
                 return true;
             } else {

--- a/src/main/java/net/glowstone/entity/GlowAnimal.java
+++ b/src/main/java/net/glowstone/entity/GlowAnimal.java
@@ -44,6 +44,32 @@ public class GlowAnimal extends GlowAgeable implements Animals {
         return 120;
     }
 
+    /**
+     * Determines whether this entity can eat an item, if so, applies the effects of eating it.
+     *
+     * @param player the player feeding the entity, for statistical purposes
+     * @param type an item that may be food
+     * @return true if the item should be consumed; false otherwise
+     */
+    protected boolean tryFeed(Material type, GlowPlayer player) {
+        if (getBreedingFoods().contains(type)) {
+            if (canBreed()) {
+                setInLove(1000); // TODO get the correct duration
+                // TODO set love mode if possible and spawn particles
+                // and don't set successfullyUsed if love mode is not possible
+                player.incrementStatistic(Statistic.ANIMALS_BRED);
+                return true;
+            } else {
+                int growth = computeGrowthAmount(type);
+                if (growth > 0) {
+                    grow(growth);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     @Override
     public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
         if (!super.entityInteract(player, message)
@@ -55,23 +81,7 @@ public class GlowAnimal extends GlowAgeable implements Animals {
                     || InventoryUtil.isEmpty(item)) {
                 return false;
             }
-            Material type = item.getType();
-            boolean successfullyUsed = false;
-            if (getBreedingFoods().contains(type)) {
-                if (canBreed()) {
-                    setInLove(1000); // TODO get the correct duration
-                    // TODO set love mode if possible and spawn particles
-                    // and don't set successfullyUsed if love mode is not possible
-                    player.incrementStatistic(Statistic.ANIMALS_BRED);
-                    successfullyUsed = true;
-                } else {
-                    int growth = computeGrowthAmount(type);
-                    if (growth > 0) {
-                        grow(growth);
-                        successfullyUsed = true;
-                    }
-                }
-            }
+            boolean successfullyUsed = tryFeed(item.getType(), player);
             if (successfullyUsed && GameMode.CREATIVE != player.getGameMode()) {
                 player.getInventory().consumeItem(message.getHand());
             }

--- a/src/main/java/net/glowstone/entity/GlowAnimal.java
+++ b/src/main/java/net/glowstone/entity/GlowAnimal.java
@@ -55,16 +55,26 @@ public class GlowAnimal extends GlowAgeable implements Animals {
                     || InventoryUtil.isEmpty(item)) {
                 return false;
             }
-
-            if (GameMode.CREATIVE != player.getGameMode()
-                    && getBreedingFoods().contains(item.getType())) {
-                // TODO set love mode if possible and spawn particles
-                // TODO heal
-                // TODO only consume the item if the animal is healed or something else
-                player.getInventory().consumeItem(message.getHand());
-                player.incrementStatistic(Statistic.ANIMALS_BRED);
-                return true;
+            Material type = item.getType();
+            boolean successfullyUsed = false;
+            if (getBreedingFoods().contains(type)) {
+                if (canBreed()) {
+                    // TODO set love mode if possible and spawn particles
+                    // and don't set successfullyUsed if love mode is not possible
+                    player.incrementStatistic(Statistic.ANIMALS_BRED);
+                    successfullyUsed = true;
+                } else {
+                    int growth = computeGrowthAmount(type);
+                    if (growth > 0) {
+                        grow(growth);
+                        successfullyUsed = true;
+                    }
+                }
             }
+            if (successfullyUsed && GameMode.CREATIVE != player.getGameMode()) {
+                player.getInventory().consumeItem(message.getHand());
+            }
+            return successfullyUsed;
         }
 
         return false;

--- a/src/main/java/net/glowstone/entity/passive/GlowAbstractHorse.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowAbstractHorse.java
@@ -3,6 +3,7 @@ package net.glowstone.entity.passive;
 import com.flowpowered.network.Message;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -73,6 +74,11 @@ public abstract class GlowAbstractHorse extends GlowTameable implements Abstract
         // Field has been removed in 1.11
     }
 
+    @Override
+    public boolean canBreed() {
+        return super.canBreed() && isTamed();
+    }
+
     private int getHorseFlags() {
         int value = 0;
         if (isTamed()) {
@@ -101,7 +107,7 @@ public abstract class GlowAbstractHorse extends GlowTameable implements Abstract
 
     @Override
     public Set<Material> getBreedingFoods() {
-        return BREEDING_FOODS;
+        return isTamed() ? BREEDING_FOODS : Collections.emptySet();
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/passive/GlowAbstractHorse.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowAbstractHorse.java
@@ -36,19 +36,6 @@ public abstract class GlowAbstractHorse extends GlowTameable implements Abstract
             .put(Material.HAY_BLOCK, TickUtil.minutesToTicks(3))
             .build();
 
-    @Override
-    protected boolean tryFeed(Material food, GlowPlayer player) {
-        if (isAdult() && !isTamed()) {
-            int taming = computeTamingAmount(food);
-            if (taming > 0) {
-                domestication = Math.max(domestication + taming, maxDomestication);
-                super.tryFeed(food, player);
-                return true;
-            }
-        }
-        return super.tryFeed(food, player);
-    }
-
     @Getter
     @Setter
     private int domestication;
@@ -65,6 +52,20 @@ public abstract class GlowAbstractHorse extends GlowTameable implements Abstract
     public GlowAbstractHorse(Location location, EntityType type, double maxHealth) {
         super(location, type, maxHealth);
         setSize(1.3964f, 1.6f);
+    }
+
+    @Override
+    protected boolean tryFeed(Material food, GlowPlayer player) {
+        if (!isAdult() || isTamed()) {
+            return super.tryFeed(food, player);
+        }
+        int taming = computeDomestication(food);
+        if (taming > 0) {
+            domestication = Math.max(domestication + taming, maxDomestication);
+            super.tryFeed(food, player); // can have another effect in addition to taming
+            return true;
+        }
+        return super.tryFeed(food, player);
     }
 
     @Override
@@ -123,9 +124,18 @@ public abstract class GlowAbstractHorse extends GlowTameable implements Abstract
         return BREEDING_FOODS;
     }
 
-    protected int computeTamingAmount(Material material) {
+    /**
+     * Returns the amount to increment the {@linkplain #setDomestication(int) domestication}
+     * (progress toward taming) when the given food is consumed by an untamed adult mob, before
+     * applying the {@linkplain #getMaxDomestication() maximum domestication}. Zero is returned for
+     * any item this mob cannot eat.
+     *
+     * @param food the food to consume
+     * @return the amount of domestication to gain
+     */
+    protected int computeDomestication(Material food) {
         // TODO
-        return BREEDING_FOODS.contains(material) ? 10 : 0;
+        return BREEDING_FOODS.contains(food) ? 10 : 0;
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/passive/GlowAbstractHorse.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowAbstractHorse.java
@@ -3,7 +3,6 @@ package net.glowstone.entity.passive;
 import com.flowpowered.network.Message;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -107,7 +106,7 @@ public abstract class GlowAbstractHorse extends GlowTameable implements Abstract
 
     @Override
     public Set<Material> getBreedingFoods() {
-        return isTamed() ? BREEDING_FOODS : Collections.emptySet();
+        return BREEDING_FOODS;
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/passive/GlowAbstractHorse.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowAbstractHorse.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
+import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
@@ -34,6 +35,19 @@ public abstract class GlowAbstractHorse extends GlowTameable implements Abstract
             .put(Material.GOLDEN_APPLE, TickUtil.minutesToTicks(4))
             .put(Material.HAY_BLOCK, TickUtil.minutesToTicks(3))
             .build();
+
+    @Override
+    protected boolean tryFeed(Material food, GlowPlayer player) {
+        if (isAdult() && !isTamed()) {
+            int taming = computeTamingAmount(food);
+            if (taming > 0) {
+                domestication = Math.max(domestication + taming, maxDomestication);
+                super.tryFeed(food, player);
+                return true;
+            }
+        }
+        return super.tryFeed(food, player);
+    }
 
     @Getter
     @Setter
@@ -107,6 +121,11 @@ public abstract class GlowAbstractHorse extends GlowTameable implements Abstract
     @Override
     public Set<Material> getBreedingFoods() {
         return BREEDING_FOODS;
+    }
+
+    protected int computeTamingAmount(Material material) {
+        // TODO
+        return BREEDING_FOODS.contains(material) ? 10 : 0;
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/passive/GlowHorse.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowHorse.java
@@ -65,9 +65,9 @@ public class GlowHorse extends GlowAbstractHorse implements Horse {
     protected boolean tryFeed(Material food, GlowPlayer player) {
         Double healingAmount = HEALING_FOODS.get(food);
         if (healingAmount != null) {
-            EntityUtils.heal(this, healingAmount, EntityRegainHealthEvent.RegainReason.EATING);
-            super.tryFeed(food, player);
-            return true;
+            boolean healed = EntityUtils.heal(this, healingAmount,
+                    EntityRegainHealthEvent.RegainReason.EATING);
+            return super.tryFeed(food, player) || healed;
         }
         return super.tryFeed(food, player);
     }

--- a/src/main/java/net/glowstone/entity/passive/GlowHorse.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowHorse.java
@@ -1,31 +1,53 @@
 package net.glowstone.entity.passive;
 
 import com.flowpowered.network.Message;
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
-import java.util.Random;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 import lombok.Getter;
 import lombok.Setter;
+import net.glowstone.entity.GlowPlayer;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.inventory.GlowHorseInventory;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
+import net.glowstone.net.message.play.player.InteractEntityMessage;
+import net.glowstone.util.EntityUtils;
+import net.glowstone.util.InventoryUtil;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Ageable;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Horse;
+import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.inventory.HorseInventory;
+import org.bukkit.inventory.ItemStack;
 
 public class GlowHorse extends GlowAbstractHorse implements Horse {
 
+    private static final Map<Material, Double> HEALING_FOODS = ImmutableMap
+            .<Material, Double>builder()
+            .put(Material.SUGAR, 1.0)
+            .put(Material.WHEAT, 2.0)
+            .put(Material.APPLE, 3.0)
+            .put(Material.GOLDEN_CARROT, 4.0)
+            .put(Material.GOLDEN_APPLE, 10.0)
+            .put(Material.HAY_BLOCK, 20.0)
+            .build();
+    private static final Variant[] VARIANTS = Variant.values();
+    private static final Color[] COLORS = Color.values();
+    private static final Style[] STYLES = Style.values();
+
     @Getter
     @Setter
-    private Variant variant = Variant.values()[new Random().nextInt(2)];
+    private Variant variant = VARIANTS[ThreadLocalRandom.current().nextInt(2)];
     @Getter
-    private Color color = Color.values()[new Random().nextInt(6)];
+    private Color color = COLORS[ThreadLocalRandom.current().nextInt(6)];
     @Getter
-    private Style style = Style.values()[new Random().nextInt(3)];
+    private Style style = STYLES[ThreadLocalRandom.current().nextInt(3)];
     @Getter
     @Setter
     private boolean eatingHay;
@@ -41,6 +63,24 @@ public class GlowHorse extends GlowAbstractHorse implements Horse {
     public GlowHorse(Location location) {
         super(location, EntityType.HORSE, 15);
         setSize(1.4F, 1.6F);
+    }
+
+    @Override
+    public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
+        if (getHealth() < getMaxHealth()) {
+            ItemStack item = InventoryUtil
+                    .itemOrEmpty(player.getInventory().getItem(message.getHandSlot()));
+            Double healingAmount = HEALING_FOODS.get(item.getType());
+            if (healingAmount != null) {
+                if (GameMode.CREATIVE != player.getGameMode()) {
+                    player.getInventory().consumeItem(message.getHand());
+                }
+                EntityUtils.heal(this, healingAmount, EntityRegainHealthEvent.RegainReason.EATING);
+                super.entityInteract(player, message); // or else damaged horses wouldn't breed
+                return true;
+            }
+        }
+        return super.entityInteract(player, message);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/passive/GlowHorse.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowHorse.java
@@ -12,10 +12,7 @@ import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.entity.meta.MetadataMap;
 import net.glowstone.inventory.GlowHorseInventory;
 import net.glowstone.net.message.play.entity.EntityMetadataMessage;
-import net.glowstone.net.message.play.player.InteractEntityMessage;
 import net.glowstone.util.EntityUtils;
-import net.glowstone.util.InventoryUtil;
-import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -24,7 +21,6 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Horse;
 import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.inventory.HorseInventory;
-import org.bukkit.inventory.ItemStack;
 
 public class GlowHorse extends GlowAbstractHorse implements Horse {
 
@@ -66,21 +62,14 @@ public class GlowHorse extends GlowAbstractHorse implements Horse {
     }
 
     @Override
-    public boolean entityInteract(GlowPlayer player, InteractEntityMessage message) {
-        if (getHealth() < getMaxHealth()) {
-            ItemStack item = InventoryUtil
-                    .itemOrEmpty(player.getInventory().getItem(message.getHandSlot()));
-            Double healingAmount = HEALING_FOODS.get(item.getType());
-            if (healingAmount != null) {
-                if (GameMode.CREATIVE != player.getGameMode()) {
-                    player.getInventory().consumeItem(message.getHand());
-                }
-                EntityUtils.heal(this, healingAmount, EntityRegainHealthEvent.RegainReason.EATING);
-                super.entityInteract(player, message); // or else damaged horses wouldn't breed
-                return true;
-            }
+    protected boolean tryFeed(Material food, GlowPlayer player) {
+        Double healingAmount = HEALING_FOODS.get(food);
+        if (healingAmount != null) {
+            EntityUtils.heal(this, healingAmount, EntityRegainHealthEvent.RegainReason.EATING);
+            super.tryFeed(food, player);
+            return true;
         }
-        return super.entityInteract(player, message);
+        return super.tryFeed(food, player);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/passive/GlowLlama.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowLlama.java
@@ -98,15 +98,11 @@ public class GlowLlama extends GlowChestedHorse<GlowLlamaInventory> implements L
 
     @Override
     protected int computeGrowthAmount(Material material) {
-        if (canGrow()) {
-            Integer mapResult = GROWING_FOODS.get(material);
-
-            if (mapResult != null) {
-                return Math.min(mapResult, Math.abs(getAge()));
-            }
+        if (!canGrow()) {
+            return 0;
         }
-
-        return 0;
+        int mapResult = GROWING_FOODS.getOrDefault(material, 0);
+        return Math.min(mapResult, Math.abs(getAge()));
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/passive/GlowLlama.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowLlama.java
@@ -102,7 +102,7 @@ public class GlowLlama extends GlowChestedHorse<GlowLlamaInventory> implements L
             return 0;
         }
         int mapResult = GROWING_FOODS.getOrDefault(material, 0);
-        return Math.min(mapResult, Math.abs(getAge()));
+        return Math.min(mapResult, -getAge());
     }
 
     @Override

--- a/src/main/java/net/glowstone/util/EntityUtils.java
+++ b/src/main/java/net/glowstone/util/EntityUtils.java
@@ -18,22 +18,25 @@ public class EntityUtils {
      * @param target the entity to heal
      * @param amount the amount of health to regain
      * @param reason the reason supplied to the {@link EntityRegainHealthEvent}
+     * @return whether any health was regained this way
      */
-    public static void heal(LivingEntity target, double amount,
+    public static boolean heal(LivingEntity target, double amount,
             EntityRegainHealthEvent.RegainReason reason) {
-        if (target.isDead()) {
-            return; // too late!
+        if (target.isDead() || amount <= 0) {
+            return false;
         }
         final double maxHealth = target.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
         final double currentHealth = target.getHealth();
         if (currentHealth >= maxHealth) {
-            return;
+            return false;
         }
         EntityRegainHealthEvent event = new EntityRegainHealthEvent(target, amount, reason);
         EventFactory.getInstance().callEvent(event);
-        if (!event.isCancelled()) {
-            target.setHealth(Math.min(maxHealth, currentHealth + event.getAmount()));
+        if (event.isCancelled() || event.getAmount() <= 0) {
+            return false;
         }
+        target.setHealth(Math.min(maxHealth, currentHealth + event.getAmount()));
+        return true;
     }
 
     /**

--- a/src/main/java/net/glowstone/util/InventoryUtil.java
+++ b/src/main/java/net/glowstone/util/InventoryUtil.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
-
+import javax.annotation.Nullable;
 import net.glowstone.EventFactory;
 import net.glowstone.entity.GlowPlayer;
 import org.bukkit.GameMode;
@@ -30,7 +30,7 @@ public class InventoryUtil {
      * @param stack the ItemStack to check
      * @return whether the given ItemStack is empty
      */
-    public static boolean isEmpty(ItemStack stack) {
+    public static boolean isEmpty(@Nullable ItemStack stack) {
         return stack == null || stack.getType() == Material.AIR || stack.getAmount() == 0;
     }
 

--- a/src/test/java/net/glowstone/entity/GlowAnimalTest.java
+++ b/src/test/java/net/glowstone/entity/GlowAnimalTest.java
@@ -1,13 +1,16 @@
 package net.glowstone.entity;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.EnumSet;
 import java.util.function.Function;
+import net.glowstone.net.message.play.player.InteractEntityMessage;
+import net.glowstone.util.TickUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
 
 public abstract class GlowAnimalTest<T extends GlowAnimal> extends GlowAgeableTest<T> {
     protected GlowAnimalTest(
@@ -20,6 +23,32 @@ public abstract class GlowAnimalTest<T extends GlowAnimal> extends GlowAgeableTe
         assertEquals(EnumSet.noneOf(Material.class), entity.getBreedingFoods());
     }
 
+    @Test
+    public void testFoodSetsLoveMode() {
+        InteractEntityMessage interact = new InteractEntityMessage(1,
+                InteractEntityMessage.Action.INTERACT.ordinal());
+        for (Material foodType : entity.getBreedingFoods()) {
+            try {
+                entity.setAge(TickUtil.minutesToTicks(5));
+                ItemStack food = new ItemStack(foodType, 2);
+                inventory.setItemInMainHand(food);
+                entity.entityInteract(player, interact);
+
+                // Should consume food
+                assertEquals(1, inventory.getItemInMainHand().getAmount());
+
+                // Should set love mode
+                assertTrue(entity.getInLove() > 0);
+
+                // Using food a 2nd time should not consume it
+                entity.entityInteract(player, interact);
+                assertEquals(1, inventory.getItemInMainHand().getAmount());
+            } finally {
+                entity.setInLove(0);
+            }
+        }
+    }
+
     @Test(expected = UnsupportedOperationException.class)
     public void testGetBreedingFoodsReturnsImmutableSet() {
         entity.getBreedingFoods().add(Material.SANDSTONE);
@@ -29,22 +58,22 @@ public abstract class GlowAnimalTest<T extends GlowAnimal> extends GlowAgeableTe
     @Override
     public void testComputeGrowthAmount() {
         entity.setAge(-21000);
-        Assertions.assertEquals(0, entity.computeGrowthAmount(null));
-        Assertions.assertEquals(0, entity.computeGrowthAmount(Material.SAND));
+        assertEquals(0, entity.computeGrowthAmount(null));
+        assertEquals(0, entity.computeGrowthAmount(Material.SAND));
 
         for (Material food : entity.getBreedingFoods()) {
-            Assertions.assertEquals(2100, entity.computeGrowthAmount(food), food.name());
+            assertEquals(2100, entity.computeGrowthAmount(food), food.name());
         }
     }
 
     @Test
     public void testComputeGrowthAmountAdult() {
         entity.setAge(0);
-        Assertions.assertEquals(0, entity.computeGrowthAmount(null));
-        Assertions.assertEquals(0, entity.computeGrowthAmount(Material.SAND));
+        assertEquals(0, entity.computeGrowthAmount(null));
+        assertEquals(0, entity.computeGrowthAmount(Material.SAND));
 
         for (Material food : entity.getBreedingFoods()) {
-            Assertions.assertEquals(0, entity.computeGrowthAmount(food), food.name());
+            assertEquals(0, entity.computeGrowthAmount(food), food.name());
         }
     }
 }

--- a/src/test/java/net/glowstone/entity/GlowAnimalTest.java
+++ b/src/test/java/net/glowstone/entity/GlowAnimalTest.java
@@ -25,7 +25,7 @@ public abstract class GlowAnimalTest<T extends GlowAnimal> extends GlowAgeableTe
     @Test
     public void testFoodSetsLoveMode() {
         InteractEntityMessage interact = new InteractEntityMessage(1,
-                InteractEntityMessage.Action.INTERACT.ordinal());
+                InteractEntityMessage.Action.INTERACT.ordinal(), /* main hand */ 0);
         for (Material foodType : entity.getBreedingFoods()) {
             try {
                 entity.setBreed(true);
@@ -51,7 +51,7 @@ public abstract class GlowAnimalTest<T extends GlowAnimal> extends GlowAgeableTe
     @Test
     public void testFoodDoesNotSetLoveModeAfterBreeding() {
         InteractEntityMessage interact = new InteractEntityMessage(1,
-                InteractEntityMessage.Action.INTERACT.ordinal());
+                InteractEntityMessage.Action.INTERACT.ordinal(), /* main hand */ 0);
         entity.setAge(1);
         for (Material foodType : entity.getBreedingFoods()) {
             ItemStack food = new ItemStack(foodType, 1);

--- a/src/test/java/net/glowstone/entity/GlowAnimalTest.java
+++ b/src/test/java/net/glowstone/entity/GlowAnimalTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.EnumSet;
 import java.util.function.Function;
 import net.glowstone.net.message.play.player.InteractEntityMessage;
-import net.glowstone.util.TickUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -29,7 +28,7 @@ public abstract class GlowAnimalTest<T extends GlowAnimal> extends GlowAgeableTe
                 InteractEntityMessage.Action.INTERACT.ordinal());
         for (Material foodType : entity.getBreedingFoods()) {
             try {
-                entity.setAge(TickUtil.minutesToTicks(5));
+                entity.setBreed(true);
                 ItemStack food = new ItemStack(foodType, 2);
                 inventory.setItemInMainHand(food);
                 entity.entityInteract(player, interact);

--- a/src/test/java/net/glowstone/entity/GlowAnimalTest.java
+++ b/src/test/java/net/glowstone/entity/GlowAnimalTest.java
@@ -48,6 +48,24 @@ public abstract class GlowAnimalTest<T extends GlowAnimal> extends GlowAgeableTe
         }
     }
 
+    @Test
+    public void testFoodDoesNotSetLoveModeAfterBreeding() {
+        InteractEntityMessage interact = new InteractEntityMessage(1,
+                InteractEntityMessage.Action.INTERACT.ordinal());
+        entity.setAge(1);
+        for (Material foodType : entity.getBreedingFoods()) {
+            ItemStack food = new ItemStack(foodType, 1);
+            inventory.setItemInMainHand(food);
+            entity.entityInteract(player, interact);
+
+            // Should not consume food
+            assertEquals(1, inventory.getItemInMainHand().getAmount());
+
+            // Should not set love mode
+            assertEquals(0, entity.getInLove());
+        }
+    }
+
     @Test(expected = UnsupportedOperationException.class)
     public void testGetBreedingFoodsReturnsImmutableSet() {
         entity.getBreedingFoods().add(Material.SANDSTONE);

--- a/src/test/java/net/glowstone/entity/passive/GlowAbstractHorseTest.java
+++ b/src/test/java/net/glowstone/entity/passive/GlowAbstractHorseTest.java
@@ -38,6 +38,13 @@ public abstract class GlowAbstractHorseTest<T extends GlowAbstractHorse> extends
     }
 
     @Test
+    @Override
+    public void testSetBreedTrueBaby() {
+        entity.setTamed(true);
+        super.testSetBreedTrueBaby();
+    }
+
+    @Test
     public void testSetBreedTrueAdultUntamed() {
         entity.setTamed(false);
         entity.setBreed(true);

--- a/src/test/java/net/glowstone/entity/passive/GlowAbstractHorseTest.java
+++ b/src/test/java/net/glowstone/entity/passive/GlowAbstractHorseTest.java
@@ -1,6 +1,7 @@
 package net.glowstone.entity.passive;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.EnumSet;
 import java.util.function.Function;
@@ -13,6 +14,26 @@ public abstract class GlowAbstractHorseTest<T extends GlowAbstractHorse> extends
     protected GlowAbstractHorseTest(
             Function<Location, ? extends T> entityCreator) {
         super(entityCreator);
+    }
+
+    @Test
+    @Override
+    public void testSetAgeAdult() {
+        entity.setTamed(true);
+        super.testSetAgeAdult();
+    }
+
+    @Test
+    public void testCannotBreedIfUntamed() {
+        entity.setAge(0);
+        entity.setTamed(false);
+        assertFalse(entity.canBreed());
+    }
+
+    @Test
+    public void testSetAgeAdultCannotBreedTamed() {
+        entity.setTamed(true);
+        testSetAgeAdultCannotBreed();
     }
 
     @Test

--- a/src/test/java/net/glowstone/entity/passive/GlowAbstractHorseTest.java
+++ b/src/test/java/net/glowstone/entity/passive/GlowAbstractHorseTest.java
@@ -31,6 +31,21 @@ public abstract class GlowAbstractHorseTest<T extends GlowAbstractHorse> extends
     }
 
     @Test
+    @Override
+    public void testSetBreedTrueAdult() {
+        entity.setTamed(true);
+        super.testSetBreedTrueAdult();
+    }
+
+    @Test
+    public void testSetBreedTrueAdultUntamed() {
+        entity.setTamed(false);
+        entity.setBreed(true);
+        assertAdult(entity);
+        assertFalse(entity.canBreed());
+    }
+
+    @Test
     public void testSetAgeAdultCannotBreedTamed() {
         entity.setTamed(true);
         testSetAgeAdultCannotBreed();

--- a/src/test/java/net/glowstone/entity/passive/GlowAbstractHorseTest.java
+++ b/src/test/java/net/glowstone/entity/passive/GlowAbstractHorseTest.java
@@ -65,10 +65,18 @@ public abstract class GlowAbstractHorseTest<T extends GlowAbstractHorse> extends
                 entity.getBreedingFoods());
     }
 
+    @Test
     @Override
     public void testFoodSetsLoveMode() {
         entity.setTamed(true);
         super.testFoodSetsLoveMode();
+    }
+
+    @Test
+    @Override
+    public void testFoodDoesNotSetLoveModeAfterBreeding() {
+        entity.setTamed(true);
+        super.testFoodDoesNotSetLoveModeAfterBreeding();
     }
 
     @Test

--- a/src/test/java/net/glowstone/entity/passive/GlowAbstractHorseTest.java
+++ b/src/test/java/net/glowstone/entity/passive/GlowAbstractHorseTest.java
@@ -65,6 +65,12 @@ public abstract class GlowAbstractHorseTest<T extends GlowAbstractHorse> extends
                 entity.getBreedingFoods());
     }
 
+    @Override
+    public void testFoodSetsLoveMode() {
+        entity.setTamed(true);
+        super.testFoodSetsLoveMode();
+    }
+
     @Test
     @Override
     public void testComputeGrowthAmount() {

--- a/src/test/java/net/glowstone/entity/passive/GlowMuleTest.java
+++ b/src/test/java/net/glowstone/entity/passive/GlowMuleTest.java
@@ -3,6 +3,9 @@ package net.glowstone.entity.passive;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import net.glowstone.net.message.play.player.InteractEntityMessage;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 import org.junit.Test;
 
 public class GlowMuleTest extends GlowChestedHorseTest<GlowMule> {
@@ -38,4 +41,22 @@ public class GlowMuleTest extends GlowChestedHorseTest<GlowMule> {
         assertFalse(entity.canBreed());
     }
 
+    @Test
+    @Override
+    public void testFoodSetsLoveMode() {
+        entity.setTamed(true);
+        InteractEntityMessage interact = new InteractEntityMessage(1,
+                InteractEntityMessage.Action.INTERACT.ordinal(), /* main hand */ 0);
+        for (Material foodType : entity.getBreedingFoods()) {
+            ItemStack food = new ItemStack(foodType, 1);
+            inventory.setItemInMainHand(food);
+            entity.entityInteract(player, interact);
+
+            // Should not consume food
+            assertEquals(1, inventory.getItemInMainHand().getAmount());
+
+            // Should not set love mode
+            assertEquals(0, entity.getInLove());
+        }
+    }
 }

--- a/src/test/java/net/glowstone/entity/passive/GlowMuleTest.java
+++ b/src/test/java/net/glowstone/entity/passive/GlowMuleTest.java
@@ -41,6 +41,10 @@ public class GlowMuleTest extends GlowChestedHorseTest<GlowMule> {
         assertFalse(entity.canBreed());
     }
 
+    /**
+     * This override instead tests that the "breeding foods" do <em>not</em> set love mode, since
+     * mules can't breed (but still have their healing and growth foods listed as "breeding foods").
+     */
     @Test
     @Override
     public void testFoodSetsLoveMode() {


### PR DESCRIPTION
- Implements use of food for taming, horse healing, growth, or to set Love Mode.
- Animals won't consume food when it has none of these effects.
- `GlowAbstractHorse.canBreed()` can no longer return true if untamed.
- Implements the duration limit and the particle effect for Love Mode.