### PR TITLE
Send real player entity id, implement EntityResurrectEvent, fix #1049

### DIFF
--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -2014,11 +2014,11 @@ public class GlowWorld implements World {
             getRawPlayers().forEach(GlowPlayer::sendTime);
         } else if (rule.equals(GameRules.REDUCED_DEBUG_INFO)) {
             // inform clients about the debug info change
-            EntityStatusMessage message = new EntityStatusMessage(0,
-                gameRuleMap.getBoolean(GameRules.REDUCED_DEBUG_INFO)
-                    ? EntityStatusMessage.ENABLE_REDUCED_DEBUG_INFO
-                    : EntityStatusMessage.DISABLE_REDUCED_DEBUG_INFO);
             for (GlowPlayer player : getRawPlayers()) {
+                EntityStatusMessage message = new EntityStatusMessage(player.getEntityId(),
+                        gameRuleMap.getBoolean(GameRules.REDUCED_DEBUG_INFO)
+                                ? EntityStatusMessage.ENABLE_REDUCED_DEBUG_INFO
+                                : EntityStatusMessage.DISABLE_REDUCED_DEBUG_INFO);
                 player.getSession().send(message);
             }
         }

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -1166,6 +1166,17 @@ public abstract class GlowEntity implements Entity {
         }
     }
 
+    public void playEffectKnownAndSelf(EntityEffect type) {
+        if (type.getApplicable().isInstance(this)) {
+            EntityStatusMessage message = new EntityStatusMessage(entityId, type);
+            if (this instanceof GlowPlayer) {
+                ((GlowPlayer) this).getSession().send(message);
+            }
+            world.getRawPlayers().stream().filter(player -> player.canSeeEntity(this))
+                    .forEach(player -> player.getSession().send(message));
+        }
+    }
+
     @Override
     public EntityType getType() {
         return EntityType.UNKNOWN;

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -850,13 +850,7 @@ public abstract class GlowEntity implements Entity {
             // In case the current session belongs to this player passenger
             // We need to send the self_id
             List<Integer> passengerIds = new ArrayList<>();
-            getPassengers().forEach(e -> {
-                if (session.getPlayer().equals(e)) {
-                    passengerIds.add(GlowPlayer.SELF_ID);
-                } else {
-                    passengerIds.add(e.getEntityId());
-                }
-            });
+            getPassengers().forEach(e -> passengerIds.add(e.getEntityId()));
             result.add(new SetPassengerMessage(getEntityId(), passengerIds.stream()
                 .mapToInt(Integer::intValue).toArray()));
             passengerChanged = false;
@@ -1165,9 +1159,11 @@ public abstract class GlowEntity implements Entity {
 
     @Override
     public void playEffect(EntityEffect type) {
-        EntityStatusMessage message = new EntityStatusMessage(entityId, type);
-        world.getRawPlayers().stream().filter(player -> player.canSeeEntity(this))
-            .forEach(player -> player.getSession().send(message));
+        if (type.getApplicable().isInstance(this)) {
+            EntityStatusMessage message = new EntityStatusMessage(entityId, type);
+            world.getRawPlayers().stream().filter(player -> player.canSeeEntity(this))
+                    .forEach(player -> player.getSession().send(message));
+        }
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -8,13 +8,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -132,7 +132,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     /**
      * Potion effects on the entity.
      */
-    private final Map<PotionEffectType, PotionEffect> potionEffects = new HashMap<>();
+    private final Map<PotionEffectType, PotionEffect> potionEffects = new ConcurrentHashMap<>();
     /**
      * The LivingEntity's AttributeManager.
      */

--- a/src/main/java/net/glowstone/entity/passive/GlowFishingHook.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowFishingHook.java
@@ -61,13 +61,11 @@ public class GlowFishingHook extends GlowProjectile implements FishHook {
                     .filter(player -> player.canSeeEntity(this))
                     .forEach(player -> player.getSession().sendAll(
                             respawnMessages.toArray(EMPTY_MESSAGE_ARRAY)));
-            // Each player believes her own entity ID is 0, so the update is sent separately to the
-            // shooter
             if (shooter instanceof GlowPlayer) {
                 GlowSession session = ((GlowPlayer) shooter).getSession();
                 session.send(destroyOldCopy);
                 session.sendAll(
-                        createSpawnMessage(GlowPlayer.SELF_ID).toArray(EMPTY_MESSAGE_ARRAY));
+                        createSpawnMessage(getEntityId()).toArray(EMPTY_MESSAGE_ARRAY));
             }
         }
     }


### PR DESCRIPTION
This pull request do such changes:
- Now server will send real entity id to player that join server instead 0, like it is works in official mojang server.
- For storing living entity potion effects now uses ConcurrentHashMap instead HashMap. Fixes #1049.
- Implemented firing of EntityResurrectEvent and reworked "Totem of Undying" logic to work more like in vanilla.

_P.S: my english is not best :D. Feel free to say in comments if i spell something wrong._