### PR TITLE
Beds Break On Loss Of Support

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockBed.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockBed.java
@@ -118,7 +118,7 @@ public class BlockBed extends BlockType {
                 block.setType(Material.AIR);
             }
         }
-        if (changedBlock.equals(getHead(block).getRelative(BlockFace.DOWN)) || (changedBlock.equals(getFoot(block).getRelative(BlockFace.DOWN))) {
+        if (changedBlock.equals(getHead(block).getRelative(BlockFace.DOWN)) || changedBlock.equals(getFoot(block).getRelative(BlockFace.DOWN))) {
             if (newType == Material.AIR) {
                 block.setType(Material.AIR);
             }

--- a/src/main/java/net/glowstone/block/blocktype/BlockBed.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockBed.java
@@ -118,7 +118,6 @@ public class BlockBed extends BlockType {
                 block.setType(Material.AIR);
             }
         }
-		//check if blocks below the bed have been changed to air, change bed blocks to air
 		if (changedBlock.equals(getHead(block).getRelative(BlockFace.DOWN)) 
                     || (changedBlock.equals(getFoot(block).getRelative(BlockFace.DOWN))) {
 			if (newType == Material.AIR) {

--- a/src/main/java/net/glowstone/block/blocktype/BlockBed.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockBed.java
@@ -118,12 +118,11 @@ public class BlockBed extends BlockType {
                 block.setType(Material.AIR);
             }
         }
-		if (changedBlock.equals(getHead(block).getRelative(BlockFace.DOWN)) 
-                    || (changedBlock.equals(getFoot(block).getRelative(BlockFace.DOWN))) {
-			if (newType == Material.AIR) {
+        if (changedBlock.equals(getHead(block).getRelative(BlockFace.DOWN)) || (changedBlock.equals(getFoot(block).getRelative(BlockFace.DOWN))) {
+            if (newType == Material.AIR) {
                 block.setType(Material.AIR);
             }
-		}
+        }
     }
 
     /**

--- a/src/main/java/net/glowstone/block/blocktype/BlockBed.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockBed.java
@@ -118,6 +118,13 @@ public class BlockBed extends BlockType {
                 block.setType(Material.AIR);
             }
         }
+		//check if blocks below the bed have been changed to air, change bed blocks to air
+		if (changedBlock.equals(getHead(block).getRelative(BlockFace.DOWN)) 
+                    || (changedBlock.equals(getFoot(block).getRelative(BlockFace.DOWN))) {
+			if (newType == Material.AIR) {
+                block.setType(Material.AIR);
+            }
+		}
     }
 
     /**


### PR DESCRIPTION
Modified BlockBed.java to have beds break when the blocks directly below the head or foot bed blocks are broken.