### PR TITLE
Implement EntityDamageByBlockEvent firing

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockMagma.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockMagma.java
@@ -16,7 +16,7 @@ public class BlockMagma extends BlockDirectDrops {
     @Override
     public void onEntityStep(GlowBlock block, LivingEntity entity) {
         if (entity instanceof GlowEntity) {
-            ((GlowEntity) entity).damageBlock(1, block, EntityDamageEvent.DamageCause.FIRE);
+            ((GlowEntity) entity).damage(1, block, EntityDamageEvent.DamageCause.FIRE);
         } else {
             entity.damage(1.0, EntityDamageEvent.DamageCause.FIRE);
         }

--- a/src/main/java/net/glowstone/block/blocktype/BlockMagma.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockMagma.java
@@ -15,7 +15,7 @@ public class BlockMagma extends BlockDirectDrops {
 
     @Override
     public void onEntityStep(GlowBlock block, LivingEntity entity) {
-        if(entity instanceof GlowEntity) {
+        if (entity instanceof GlowEntity) {
             ((GlowEntity) entity).damageBlock(1, block, EntityDamageEvent.DamageCause.FIRE);
         } else {
             entity.damage(1.0, EntityDamageEvent.DamageCause.FIRE);

--- a/src/main/java/net/glowstone/block/blocktype/BlockMagma.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockMagma.java
@@ -1,6 +1,7 @@
 package net.glowstone.block.blocktype;
 
 import net.glowstone.block.GlowBlock;
+import net.glowstone.entity.GlowEntity;
 import net.glowstone.inventory.ToolType;
 import org.bukkit.Material;
 import org.bukkit.entity.LivingEntity;
@@ -14,6 +15,10 @@ public class BlockMagma extends BlockDirectDrops {
 
     @Override
     public void onEntityStep(GlowBlock block, LivingEntity entity) {
-        entity.damage(1.0, EntityDamageEvent.DamageCause.FIRE);
+        if(entity instanceof GlowEntity) {
+            ((GlowEntity) entity).damageBlock(1, block, EntityDamageEvent.DamageCause.FIRE);
+        } else {
+            entity.damage(1.0, EntityDamageEvent.DamageCause.FIRE);
+        }
     }
 }

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -982,20 +982,40 @@ public abstract class GlowEntity implements Entity {
                 }
             }
         } else {
-            // bounding box-based calculation
-            Vector min = boundingBox.minCorner;
-            Vector max = boundingBox.maxCorner;
-            for (int x = min.getBlockX(); x <= max.getBlockX(); ++x) {
-                for (int y = min.getBlockY(); y <= max.getBlockY(); ++y) {
-                    for (int z = min.getBlockZ(); z <= max.getBlockZ(); ++z) {
-                        if (world.getBlockTypeIdAt(x, y, z) == material.getId()) {
-                            return true;
-                        }
-                    }
+            for (Block touchingBlock : getTouchingBlocks()) {
+                if (touchingBlock.getType().getId() == material.getId()) {
+                    return true;
                 }
             }
         }
         return false;
+    }
+
+    /**
+     * Gets a list containing all the blocks a player is touching
+     *
+     * <p>If the entity has not a defined bounding box, the list will be empty.
+     *
+     * @return the list of blocks a player is touching
+     */
+    public List<Block> getTouchingBlocks() {
+        if(boundingBox == null) {
+            return Collections.emptyList();
+        }
+
+        List<Block> blocks = new ArrayList<>();
+
+        // bounding box-based calculation
+        Vector min = boundingBox.minCorner;
+        Vector max = boundingBox.maxCorner;
+        for (int x = min.getBlockX(); x <= max.getBlockX(); ++x) {
+            for (int y = min.getBlockY(); y <= max.getBlockY(); ++y) {
+                for (int z = min.getBlockZ(); z <= max.getBlockZ(); ++z) {
+                    blocks.add(world.getBlockAt(x, y, z));
+                }
+            }
+        }
+        return blocks;
     }
 
     protected final void setBoundingBox(double xz, double y) {
@@ -1440,6 +1460,9 @@ public abstract class GlowEntity implements Entity {
 
     public void damage(double amount, DamageCause cause) {
         damage(amount, null, cause);
+    }
+
+    public void damageBlock(double amount, Block block, DamageCause cause) {
     }
 
     public void damage(double amount, Entity source, DamageCause cause) {

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -999,7 +999,7 @@ public abstract class GlowEntity implements Entity {
      * @return the list of blocks a player is touching
      */
     public List<Block> getTouchingBlocks() {
-        if(boundingBox == null) {
+        if (boundingBox == null) {
             return Collections.emptyList();
         }
 

--- a/src/main/java/net/glowstone/entity/GlowEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowEntity.java
@@ -1451,7 +1451,7 @@ public abstract class GlowEntity implements Entity {
     }
 
     public void damage(double amount) {
-        damage(amount, null, DamageCause.CUSTOM);
+        damage(amount, (Entity) null, DamageCause.CUSTOM);
     }
 
     public void damage(double amount, Entity source) {
@@ -1459,10 +1459,10 @@ public abstract class GlowEntity implements Entity {
     }
 
     public void damage(double amount, DamageCause cause) {
-        damage(amount, null, cause);
+        damage(amount, (Entity) null, cause);
     }
 
-    public void damageBlock(double amount, Block block, DamageCause cause) {
+    public void damage(double amount, Block block, DamageCause cause) {
     }
 
     public void damage(double amount, Entity source, DamageCause cause) {

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -960,6 +960,25 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         }
     }
 
+    private boolean callDamageEvent(EntityDamageEvent event) {
+        if (event.isCancelled()) {
+            return true;
+        }
+        // apply damage
+        lastDamage = event.getFinalDamage();
+        return false;
+    }
+
+    private double getEffectiveDamage(double amount) {
+        // armor damage protection
+        // formula source: http://minecraft.gamepedia.com/Armor#Damage_Protection
+        double defensePoints = getAttributeManager().getPropertyValue(Key.KEY_ARMOR);
+        double toughness = getAttributeManager().getPropertyValue(Key.KEY_ARMOR_TOUGHNESS);
+        return amount * (1 - Math.min(20.0,
+                Math.max(defensePoints / 5.0,
+                        defensePoints - amount / (2.0 + toughness / 4.0))) / 25);
+    }
+
     @Override
     public void damage(double amount, Block block, DamageCause cause) {
         if (noDamageTicks > 0 || health <= 0 || isInvulnerable() || !canTakeDamage(cause)) {
@@ -993,25 +1012,6 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                 world.playSound(location, hurtSound, getSoundVolume(), getSoundPitch());
             }
         }
-    }
-
-    private boolean callDamageEvent(EntityDamageEvent event) {
-        if (event.isCancelled()) {
-            return true;
-        }
-        // apply damage
-        lastDamage = event.getFinalDamage();
-        return false;
-    }
-
-    private double getEffectiveDamage(double amount) {
-        // armor damage protection
-        // formula source: http://minecraft.gamepedia.com/Armor#Damage_Protection
-        double defensePoints = getAttributeManager().getPropertyValue(Key.KEY_ARMOR);
-        double toughness = getAttributeManager().getPropertyValue(Key.KEY_ARMOR_TOUGHNESS);
-        return amount * (1 - Math.min(20.0,
-                Math.max(defensePoints / 5.0,
-                        defensePoints - amount / (2.0 + toughness / 4.0))) / 25);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -316,7 +316,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         }
 
         if (isTouchingMaterial(Material.CACTUS)) {
-            for(Block block : getTouchingBlocks()) {
+            for (Block block : getTouchingBlocks()) {
                 if(block.getType() == Material.CACTUS) {
                     damage(1, block, DamageCause.CONTACT);
                     break;
@@ -349,7 +349,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         } else if (isTouchingMaterial(Material.FIRE)
                 || isTouchingMaterial(Material.LAVA)
                 || isTouchingMaterial(Material.STATIONARY_LAVA)) {
-            for(Block block : getTouchingBlocks()) {
+            for (Block block : getTouchingBlocks()) {
                 if(block.getType() == Material.FIRE || block.getType() == Material.LAVA || block.getType() == Material.STATIONARY_LAVA) {
                     damage(1, block, DamageCause.CONTACT);
                     break;
@@ -970,11 +970,12 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
         amount = getEffectiveDamage(amount);
 
+
         // fire event
         EntityDamageByBlockEvent event = EventFactory.getInstance().onEntityDamage(
                 new EntityDamageByBlockEvent(block, this, cause, amount));
 
-        if (event.isCancelled()) {
+        if (callDamageEvent(event)) {
             return;
         }
 
@@ -992,6 +993,16 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                 world.playSound(location, hurtSound, getSoundVolume(), getSoundPitch());
             }
         }
+    }
+
+    private boolean callDamageEvent(EntityDamageEvent event) {
+        if (event.isCancelled()) {
+            return true;
+        }
+
+        // apply damage
+        lastDamage = event.getFinalDamage();
+        return false;
     }
 
     private double getEffectiveDamage(double amount) {

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -308,7 +308,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                 --remainingAir;
                 if (remainingAir <= -20) {
                     remainingAir = 0;
-                    damageBlock(1, eyeBlock, DamageCause.DROWNING);
+                    damage(1, eyeBlock, DamageCause.DROWNING);
                 }
             }
         } else {
@@ -318,7 +318,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         if (isTouchingMaterial(Material.CACTUS)) {
             for(Block block : getTouchingBlocks()) {
                 if(block.getType() == Material.CACTUS) {
-                    damageBlock(1, block, DamageCause.CONTACT);
+                    damage(1, block, DamageCause.CONTACT);
                     break;
                 }
             }
@@ -329,17 +329,17 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         }
 
         if (isWithinSolidBlock()) {
-            damageBlock(1, eyeBlock, DamageCause.SUFFOCATION);
+            damage(1, eyeBlock, DamageCause.SUFFOCATION);
         }
 
         // fire and lava damage
         if (getLocation().getBlock().getType() == Material.FIRE) {
-            damageBlock(1, getLocation().getBlock(), DamageCause.FIRE);
+            damage(1, getLocation().getBlock(), DamageCause.FIRE);
             // not applying additional fire ticks after dying in fire
             stoodInFire = !isDead();
         } else if (getLocation().getBlock().getType() == Material.LAVA
                 || getLocation().getBlock().getType() == Material.STATIONARY_LAVA) {
-            damageBlock(4, getLocation().getBlock(), DamageCause.LAVA);
+            damage(4, getLocation().getBlock(), DamageCause.LAVA);
             if (swamInLava) {
                 setFireTicks(getFireTicks() + 2);
             } else {
@@ -351,7 +351,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                 || isTouchingMaterial(Material.STATIONARY_LAVA)) {
             for(Block block : getTouchingBlocks()) {
                 if(block.getType() == Material.FIRE || block.getType() == Material.LAVA || block.getType() == Material.STATIONARY_LAVA) {
-                    damageBlock(1, block, DamageCause.CONTACT);
+                    damage(1, block, DamageCause.CONTACT);
                     break;
                 }
             }
@@ -961,7 +961,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     }
 
     @Override
-    public void damageBlock(double amount, Block block, DamageCause cause) {
+    public void damage(double amount, Block block, DamageCause cause) {
         if (!canTakeDamage() || !canTakeDamage(cause)) {
             return;
         } else {

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -317,7 +317,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
         if (isTouchingMaterial(Material.CACTUS)) {
             for (Block block : getTouchingBlocks()) {
-                if(block.getType() == Material.CACTUS) {
+                if (block.getType() == Material.CACTUS) {
                     damage(1, block, DamageCause.CONTACT);
                     break;
                 }
@@ -350,7 +350,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                 || isTouchingMaterial(Material.LAVA)
                 || isTouchingMaterial(Material.STATIONARY_LAVA)) {
             for (Block block : getTouchingBlocks()) {
-                if(block.getType() == Material.FIRE || block.getType() == Material.LAVA || block.getType() == Material.STATIONARY_LAVA) {
+                if (block.getType() == Material.FIRE || block.getType() == Material.LAVA || block.getType() == Material.STATIONARY_LAVA) {
                     damage(1, block, DamageCause.CONTACT);
                     break;
                 }
@@ -999,7 +999,6 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         if (event.isCancelled()) {
             return true;
         }
-
         // apply damage
         lastDamage = event.getFinalDamage();
         return false;

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -968,13 +968,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             noDamageTicks = maximumNoDamageTicks;
         }
 
-        // armor damage protection
-        // formula source: http://minecraft.gamepedia.com/Armor#Damage_Protection
-        double defensePoints = getAttributeManager().getPropertyValue(Key.KEY_ARMOR);
-        double toughness = getAttributeManager().getPropertyValue(Key.KEY_ARMOR_TOUGHNESS);
-        amount = amount * (1 - Math.min(20.0,
-                Math.max(defensePoints / 5.0,
-                        defensePoints - amount / (2.0 + toughness / 4.0))) / 25);
+        amount = getEffectiveDamage(amount);
 
         // fire event
         EntityDamageByBlockEvent event = EventFactory.getInstance().onEntityDamage(
@@ -998,6 +992,16 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
                 world.playSound(location, hurtSound, getSoundVolume(), getSoundPitch());
             }
         }
+    }
+
+    private double getEffectiveDamage(double amount) {
+        // armor damage protection
+        // formula source: http://minecraft.gamepedia.com/Armor#Damage_Protection
+        double defensePoints = getAttributeManager().getPropertyValue(Key.KEY_ARMOR);
+        double toughness = getAttributeManager().getPropertyValue(Key.KEY_ARMOR_TOUGHNESS);
+        return amount * (1 - Math.min(20.0,
+                Math.max(defensePoints / 5.0,
+                        defensePoints - amount / (2.0 + toughness / 4.0))) / 25);
     }
 
     @Override
@@ -1026,13 +1030,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             }
         }
 
-        // armor damage protection
-        // formula source: http://minecraft.gamepedia.com/Armor#Damage_Protection
-        double defensePoints = getAttributeManager().getPropertyValue(Key.KEY_ARMOR);
-        double toughness = getAttributeManager().getPropertyValue(Key.KEY_ARMOR_TOUGHNESS);
-        amount = amount * (1 - Math.min(20.0,
-                Math.max(defensePoints / 5.0,
-                        defensePoints - amount / (2.0 + toughness / 4.0))) / 25);
+        amount = getEffectiveDamage(amount);
 
         // fire event
         EntityDamageEvent event = EventFactory.getInstance().onEntityDamage(source == null

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -71,8 +71,8 @@ import org.bukkit.entity.Monster;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.entity.EntityAirChangeEvent;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageByBlockEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityDeathEvent;
@@ -962,7 +962,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
 
     @Override
     public void damage(double amount, Block block, DamageCause cause) {
-        if (!canTakeDamage() || !canTakeDamage(cause)) {
+        if (noDamageTicks > 0 || health <= 0 || isInvulnerable() || !canTakeDamage(cause)) {
             return;
         } else {
             noDamageTicks = maximumNoDamageTicks;
@@ -1017,7 +1017,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
     @Override
     public void damage(double amount, Entity source, DamageCause cause) {
         // invincibility timer
-        if (!canTakeDamage() || !canTakeDamage(cause)) {
+        if (noDamageTicks > 0 || health <= 0 || isInvulnerable() || !canTakeDamage(cause)) {
             return;
         } else {
             noDamageTicks = maximumNoDamageTicks;


### PR DESCRIPTION
I created the new method `getTouchingBlocks()` to get every block a player was colliding with to put it on the EntityDamageByBlockEvent.

I created the `canTakeDamage()` method without any parameters to avoid code duplication on the new `damageBlock()` method.

I implemented[ `damageBlock()` method because default damage LivingEntity's method does not allow Blocks as a damage source.

