### PR TITLE
Use synchronizedSet

### DIFF
--- a/src/main/java/net/glowstone/inventory/GlowInventory.java
+++ b/src/main/java/net/glowstone/inventory/GlowInventory.java
@@ -126,7 +126,7 @@ public class GlowInventory implements Inventory {
      * @return Viewers set.
      */
     public Set<HumanEntity> getViewersSet() {
-        return Collections.unmodifiableSet(viewers);
+        return Collections.synchronizedSet(viewers);
     }
 
     ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
For issue #1071

GlowDoubleChest extends GlowSuperInventory and its field, parents' GlowInventory viewers are unmodifiable.
```
protected void initialize(List<GlowInventory> parents, InventoryHolder owner,
        InventoryType type, String title) {
        SuperList<GlowInventorySlot> slots = new SuperList<>();
        SuperSet<HumanEntity> viewers = new SuperSet<>();

        for (GlowInventory parent : parents) {
            slots.getParents().add(parent.getSlots());
            viewers.getParents().add(parent.getViewersSet());
        }

        initialize(slots, viewers, owner, type, title);
        this.parents = parents;
    }
```
However, viewers should be modifiable because openInventory logic modifies its viewers.
UnmodifiableSet could occur UnsupportedOperationException.
We can use synchronizedSet instead of unmodifiableSet.