### PR TITLE
Fix wrong coordinates in isSnowy

### DIFF
--- a/src/main/java/net/glowstone/generator/populators/overworld/SnowPopulator.java
+++ b/src/main/java/net/glowstone/generator/populators/overworld/SnowPopulator.java
@@ -18,7 +18,7 @@ public class SnowPopulator extends BlockPopulator {
         for (int x = sourceX; x < sourceX + 16; x++) {
             for (int z = sourceZ; z < sourceZ + 16; z++) {
                 int y = world.getHighestBlockYAt(x, z) - 1;
-                if (GlowBiomeClimate.isSnowy(world.getBiome(x, z), sourceX + x, y, sourceZ + z)) {
+                if (GlowBiomeClimate.isSnowy(world.getBiome(x, z), x, y, z)) {
                     Block block = world.getBlockAt(x, y, z);
                     Block blockAbove = block.getRelative(BlockFace.UP);
                     switch (block.getType()) {


### PR DESCRIPTION
The values of x and z variables over here are absolute world coordinates (the coordinates aren't relative to the chunk). Adding sourceX and sourceZ (the absolute coordinates of the chunk's beginning) sets the value far too high.

Possibly, the author was trying to do something like this: https://github.com/GlowstoneMC/Glowstone/blob/dev/src/main/java/net/glowstone/generator/objects/Lake.java#L95

But in Lake.java, x and z are coordinates relative to the chunk so it makes sense in Lake.