### PR TITLE
Add background option to GlowAdvancementDisplay. Fix client crash

### DIFF
--- a/src/main/java/net/glowstone/GlowServer.java
+++ b/src/main/java/net/glowstone/GlowServer.java
@@ -455,6 +455,7 @@ public class GlowServer implements Server {
                 new TextMessage("=)"),
                 new ItemStack(Material.GLOWSTONE),
                 GlowAdvancementDisplay.FrameType.GOAL,
+                NamespacedKey.minecraft("textures/gui/advancements/backgrounds/adventure.png"),
                 -10F, 0));
         addAdvancement(advancement);
 

--- a/src/main/java/net/glowstone/advancement/GlowAdvancementDisplay.java
+++ b/src/main/java/net/glowstone/advancement/GlowAdvancementDisplay.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import lombok.Data;
 import net.glowstone.net.GlowBufUtils;
 import net.glowstone.util.TextMessage;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 
 
@@ -16,6 +17,7 @@ public class GlowAdvancementDisplay {
     private final TextMessage description;
     private final ItemStack icon;
     private final FrameType type;
+    private final NamespacedKey background;
     private final float x;
     private final float y;
 
@@ -31,7 +33,8 @@ public class GlowAdvancementDisplay {
         GlowBufUtils.writeChat(buf, description);
         GlowBufUtils.writeSlot(buf, icon);
         ByteBufUtils.writeVarInt(buf, type.ordinal());
-        buf.writeInt((1 << 0x4)); // todo: flags
+        buf.writeInt(0x1 | 0x2); // todo: flags
+        ByteBufUtils.writeUTF8(buf, background.toString());
         buf.writeFloat(x);
         buf.writeFloat(y);
         return buf;


### PR DESCRIPTION
If using 1.12.2 (without forge) client will crash on advancements gui open when on glowstone server. It's related to test advancement and the fact that it doesn't have background set in AdvacementsDisplay.
Here the stacktrace of client crash:
```
java.lang.NullPointerException: Registering texture
    at cdt.a(SourceFile:215)
    at cdm.a(SourceFile:46)
    at cdr.a(SourceFile:60)
    at cdr.a(SourceFile:42)
    at blx.f(SourceFile:96)
    at bmb.c(SourceFile:138)
    at bmb.a(SourceFile:118)
    at buq.a(SourceFile:1079)
    at bib.az(SourceFile:1023)
    at bib.a(SourceFile:419)
    at net.minecraft.client.main.Main.main(SourceFile:123)
```