### PR TITLE
Update EntityEffectMessage. Optimize PotionEffect's pulsing

### DIFF
--- a/src/main/java/net/glowstone/command/minecraft/EffectCommand.java
+++ b/src/main/java/net/glowstone/command/minecraft/EffectCommand.java
@@ -90,7 +90,7 @@ public class EffectCommand extends GlowVanillaCommand {
                 }
             }
 
-            int amplifier = 1;
+            int amplifier = 0;
             if (args.length >= 4 && args[3] != null) {
                 try {
                     amplifier = Integer.parseInt(args[3]);
@@ -109,9 +109,9 @@ public class EffectCommand extends GlowVanillaCommand {
                     commandMessages.getResourceBundle());
             for (GlowPlayer player : players) {
                 player.addPotionEffect(
-                    new PotionEffect(effectType, duration, amplifier, false, hideParticles));
+                    new PotionEffect(effectType, duration, amplifier, false, !hideParticles));
                 doneMessage.send(sender, effectType.getName(),
-                        effectType.getId(), amplifier, player.getName(), duration / 20);
+                        effectType.getId(), amplifier + 1, player.getName(), duration / 20);
             }
             return true;
         }

--- a/src/main/java/net/glowstone/constants/GlowPotionEffect.java
+++ b/src/main/java/net/glowstone/constants/GlowPotionEffect.java
@@ -136,7 +136,7 @@ public final class GlowPotionEffect extends PotionEffectType {
 
     @Override
     public Color getColor() {
-        return null;
+        return impl.color;
     }
 
     @Override
@@ -163,37 +163,38 @@ public final class GlowPotionEffect extends PotionEffectType {
 
     @RequiredArgsConstructor
     private enum Impl {
-        SPEED(1, false, 1.0, "minecraft:speed"),
-        SLOW(2, false, 0.5, "minecraft:slowness"),
-        FAST_DIGGING(3, false, 1.5, "minecraft:haste"),
-        SLOW_DIGGING(4, false, 0.5, "minecraft:mining_fatigue"),
-        INCREASE_DAMAGE(5, false, 1.0, "minecraft:strength"),
-        HEAL(6, true, 1.0, "minecraft:instant_heal"),
-        HARM(7, true, 0.5, "minecraft:instant_damage"),
-        JUMP(8, false, 1.0, "minecraft:jump_boost"),
-        CONFUSION(9, false, 0.25, "minecraft:nausea"),
-        REGENERATION(10, false, 0.25, "minecraft:regeneration"),
-        DAMAGE_RESISTANCE(11, false, 1.0, "minecraft:resistance"),
-        FIRE_RESISTANCE(12, false, 1.0, "minecraft:fire_resistance"),
-        WATER_BREATHING(13, false, 1.0, "minecraft:water_breathing"),
-        INVISIBILITY(14, false, 1.0, "minecraft:invisibility"),
-        BLINDNESS(15, false, 0.25, "minecraft:blindness"),
-        NIGHT_VISION(16, false, 1.0, "minecraft:night_vision"),
-        HUNGER(17, false, 0.5, "minecraft:hunger"),
-        WEAKNESS(18, false, 0.5, "minecraft:weakness"),
-        POISON(19, false, 0.25, "minecraft:poison"),
-        WITHER(20, false, 0.25, "minecraft:wither"),
-        HEALTH_BOOST(21, false, 1.0, "minecraft:health_boost"),
-        ABSORPTION(22, false, 1.0, "minecraft:absorption"),
-        SATURATION(23, true, 1.0, "minecraft:saturation"),
-        GLOWING(24, false, 1.0, "minecraft:glowing"),
-        LEVITATION(25, false, 1.0, "minecraft:levitation"),
-        LUCK(26, false, 1.0, "minecraft:luck"),
-        UNLUCK(27, false, 1.0, "minecraft:unluck");
+        SPEED(1, false, 1.0, Color.fromBGR(8171462), "minecraft:speed"),
+        SLOW(2, false, 0.5, Color.fromBGR(5926017), "minecraft:slowness"),
+        FAST_DIGGING(3, false, 1.5, Color.fromBGR(14270531), "minecraft:haste"),
+        SLOW_DIGGING(4, false, 0.5, Color.fromBGR(4866583), "minecraft:mining_fatigue"),
+        INCREASE_DAMAGE(5, false, 1.0, Color.fromBGR(9643043), "minecraft:strength"),
+        HEAL(6, true, 1.0, Color.fromBGR(16262179), "minecraft:instant_heal"),
+        HARM(7, true, 0.5, Color.fromBGR(4393481), "minecraft:instant_damage"),
+        JUMP(8, false, 1.0, Color.fromBGR(2293580), "minecraft:jump_boost"),
+        CONFUSION(9, false, 0.25, Color.fromBGR(5578058), "minecraft:nausea"),
+        REGENERATION(10, false, 0.25, Color.fromBGR(13458603), "minecraft:regeneration"),
+        DAMAGE_RESISTANCE(11, false, 1.0, Color.fromBGR(10044730), "minecraft:resistance"),
+        FIRE_RESISTANCE(12, false, 1.0, Color.fromBGR(14981690), "minecraft:fire_resistance"),
+        WATER_BREATHING(13, false, 1.0, Color.fromBGR(3035801), "minecraft:water_breathing"),
+        INVISIBILITY(14, false, 1.0, Color.fromBGR(8356754), "minecraft:invisibility"),
+        BLINDNESS(15, false, 0.25, Color.fromBGR(2039587), "minecraft:blindness"),
+        NIGHT_VISION(16, false, 1.0, Color.fromBGR(2039713), "minecraft:night_vision"),
+        HUNGER(17, false, 0.5, Color.fromBGR(5797459), "minecraft:hunger"),
+        WEAKNESS(18, false, 0.5, Color.fromBGR(4738376), "minecraft:weakness"),
+        POISON(19, false, 0.25, Color.fromBGR(5149489), "minecraft:poison"),
+        WITHER(20, false, 0.25, Color.fromBGR(3484199), "minecraft:wither"),
+        HEALTH_BOOST(21, false, 1.0, Color.fromBGR(16284963), "minecraft:health_boost"),
+        ABSORPTION(22, false, 1.0, Color.fromBGR(2445989), "minecraft:absorption"),
+        SATURATION(23, true, 1.0, Color.fromBGR(16262179), "minecraft:saturation"),
+        GLOWING(24, false, 1.0, Color.fromBGR(9740385), "minecraft:glowing"),
+        LEVITATION(25, false, 1.0, Color.fromBGR(13565951), "minecraft:levitation"),
+        LUCK(26, false, 1.0, Color.fromBGR(3381504), "minecraft:luck"),
+        UNLUCK(27, false, 1.0, Color.fromBGR(12624973), "minecraft:unluck");
 
         private final int id;
         private final boolean instant;
         private final double modifier;
+        private final Color color;
         @Getter
         private final String vanillaId;
 

--- a/src/main/java/net/glowstone/net/codec/play/entity/EntityEffectCodec.java
+++ b/src/main/java/net/glowstone/net/codec/play/entity/EntityEffectCodec.java
@@ -14,8 +14,10 @@ public final class EntityEffectCodec implements Codec<EntityEffectMessage> {
         byte effect = buf.readByte();
         byte amplifier = buf.readByte();
         int duration = ByteBufUtils.readVarInt(buf);
-        boolean hideParticles = buf.readBoolean();
-        return new EntityEffectMessage(id, effect, amplifier, duration, hideParticles);
+        byte flags = buf.readByte();
+        boolean ambient = (flags & 1) == 1;
+        boolean showParticles = (flags & 2) == 2;
+        return new EntityEffectMessage(id, effect, amplifier, duration, showParticles, ambient);
     }
 
     @Override
@@ -24,7 +26,16 @@ public final class EntityEffectCodec implements Codec<EntityEffectMessage> {
         buf.writeByte(message.getEffect());
         buf.writeByte(message.getAmplifier());
         ByteBufUtils.writeVarInt(buf, message.getDuration());
-        buf.writeBoolean(message.isHideParticles());
+
+        byte flags = 0;
+        if (message.isAmbient()) {
+            flags |= 1;
+        }
+        if (message.isShowParticles()) {
+            flags |= 2;
+        }
+
+        buf.writeByte(flags);
         return buf;
     }
 }

--- a/src/main/java/net/glowstone/net/message/play/entity/EntityEffectMessage.java
+++ b/src/main/java/net/glowstone/net/message/play/entity/EntityEffectMessage.java
@@ -10,6 +10,7 @@ public final class EntityEffectMessage implements Message {
     private final int effect;
     private final int amplifier;
     private final int duration;
-    private final boolean hideParticles;
+    private final boolean showParticles;
+    private final boolean ambient;
 
 }

--- a/src/test/java/net/glowstone/net/PlayProtocolTest.java
+++ b/src/test/java/net/glowstone/net/PlayProtocolTest.java
@@ -151,7 +151,7 @@ public class PlayProtocolTest extends BaseProtocolTest {
         new RelativeEntityPositionMessage(1, (short) 2, (short) 3, (short) 4, true),
         new KickMessage(ProtocolTestUtils.getTextMessage()),
         new AttachEntityMessage(1, 2),
-        new EntityEffectMessage(1, (byte) 2, (byte) 3, 4, false),
+        new EntityEffectMessage(1, (byte) 2, (byte) 3, 4, false, false),
         new EntityHeadRotationMessage(1, 2),
         new EntityMetadataMessage(1, ProtocolTestUtils.getMetadataEntry()),
         new EntityRemoveEffectMessage(1, (byte) 2),


### PR DESCRIPTION
Changes in this PR:
- Updated `EntityEffectMessage` according to 1.12.2 protocol specification from [wiki.vg](https://wiki.vg/index.php?title=Protocol&oldid=14204#Entity_Effect)
- Removed updating of potion effects to clients every pulse. Duration of potion effect autimatically decreases on client. Server need to only remove it when duration time is out
- Added updating of `MetadataIndex.POTION_COLOR` and `MetadataIndex.POTION_AMBIENT` metadata values on potion effect added/removed
- Improvements to `EffectCommand`