### PR TITLE
Allow blocks to fall when placed directly on a non solid block

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockFalling.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockFalling.java
@@ -56,17 +56,11 @@ public class BlockFalling extends BlockType {
         }
     }
 
+    /**
+     * @param material A Material
+     * @return true if material will support this block and prevent it from falling or breaking
+     */
     private boolean supportingBlock(Material material) {
-        switch (material) {
-            case AIR:
-            case FIRE:
-            case WATER:
-            case STATIONARY_WATER:
-            case LAVA:
-            case STATIONARY_LAVA:
-                return false;
-            default:
-                return true;
-        }
+        return material.isSolid();
     }
 }


### PR DESCRIPTION
Previously placing a piece of sand on a torch for example would result in the sand not falling.
This change fixes that by considering all non solid blocks as not supporting the block, not just empty blocks.