### PR TITLE
Inefficient Usages of Java Collections

### DIFF
--- a/src/main/java/net/glowstone/GlowPluginTypeDetector.java
+++ b/src/main/java/net/glowstone/GlowPluginTypeDetector.java
@@ -11,7 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.zip.ZipEntry;
@@ -19,12 +19,12 @@ import java.util.zip.ZipFile;
 
 public class GlowPluginTypeDetector {
 
-    public List<File> bukkitPlugins = new ArrayList<>();
-    public List<File> spongePlugins = new ArrayList<>();
-    public List<File> canaryPlugins = new ArrayList<>();
-    public List<File> forgefPlugins = new ArrayList<>();
-    public List<File> forgenPlugins = new ArrayList<>();
-    public List<File> unrecognizedPlugins = new ArrayList<>();
+    public List<File> bukkitPlugins = new LinkedList<>();
+    public List<File> spongePlugins = new LinkedList<>();
+    public List<File> canaryPlugins = new LinkedList<>();
+    public List<File> forgefPlugins = new LinkedList<>();
+    public List<File> forgenPlugins = new LinkedList<>();
+    public List<File> unrecognizedPlugins = new LinkedList<>();
 
     private File directory;
 

--- a/src/main/java/net/glowstone/generator/objects/IceSpike.java
+++ b/src/main/java/net/glowstone/generator/objects/IceSpike.java
@@ -4,6 +4,8 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 
+import java.util.Set;
+import java.util.HashSet;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -25,6 +27,8 @@ public class IceSpike implements TerrainObject {
         }
         boolean succeeded = false;
         int stemRadius = Math.max(0, Math.min(MAX_STEM_RADIUS, tipRadius - 1));
+        Set<Material> materialSet = new HashSet<>(Arrays.asList(MATERIALS));
+        
         for (int x = -stemRadius; x <= stemRadius; x++) {
             for (int z = -stemRadius; z <= stemRadius; z++) {
                 int stackHeight = MAX_STEM_HEIGHT;
@@ -33,7 +37,7 @@ public class IceSpike implements TerrainObject {
                 }
                 for (int y = tipOffset - 1; y >= -3; y--) {
                     Block block = world.getBlockAt(sourceX + x, sourceY + y, sourceZ + z);
-                    if (Arrays.asList(MATERIALS).contains(block.getType())
+                    if (materialSet.contains(block.getType())
                         || block.getType() == Material.PACKED_ICE) {
                         block.setType(Material.PACKED_ICE);
                         stackHeight--;
@@ -63,14 +67,14 @@ public class IceSpike implements TerrainObject {
                     // tip shape in top direction
                     Block block = world
                         .getBlockAt(sourceX + x, sourceY + tipOffset + y, sourceZ + z);
-                    if (Arrays.asList(MATERIALS).contains(block.getType())) {
+                    if (materialSet.contains(block.getType())) {
                         block.setType(Material.PACKED_ICE);
                         succeeded = true;
                     }
                     if (radius > 1 && y != 0) { // same shape in bottom direction
                         block = world
                             .getBlockAt(sourceX + x, sourceY + tipOffset - y, sourceZ + z);
-                        if (Arrays.asList(MATERIALS).contains(block.getType())) {
+                        if (materialSet.contains(block.getType())) {
                             block.setType(Material.PACKED_ICE);
                             succeeded = true;
                         }

--- a/src/main/java/net/glowstone/generator/objects/trees/RedwoodTree.java
+++ b/src/main/java/net/glowstone/generator/objects/trees/RedwoodTree.java
@@ -5,6 +5,8 @@ import org.bukkit.Material;
 import org.bukkit.World;
 
 import java.util.Random;
+import java.util.HashSet;
+import java.util.Set;
 
 public class RedwoodTree extends GenericTree {
 
@@ -45,6 +47,7 @@ public class RedwoodTree extends GenericTree {
 
     @Override
     public boolean canPlace(int baseX, int baseY, int baseZ, World world) {
+        Set<Material> overridableSet = new HashSet<>(overridables);
         for (int y = baseY; y <= baseY + 1 + height; y++) {
             // Space requirement
             int radius; // default radius if above first block
@@ -59,7 +62,7 @@ public class RedwoodTree extends GenericTree {
                     if (y >= 0 && y < 256) {
                         // we can overlap some blocks around
                         Material type = blockTypeAt(x, y, z, world);
-                        if (!overridables.contains(type)) {
+                        if (!overridableSet.contains(type)) {
                             return false;
                         }
                     } else { // height out of range
@@ -81,6 +84,8 @@ public class RedwoodTree extends GenericTree {
         int radius = random.nextInt(2);
         int peakRadius = 1;
         int minRadius = 0;
+        Set<Material> overridableSet = new HashSet<>(overridables);
+        
         for (int y = blockY + height; y >= blockY + leavesHeight; y--) {
             // leaves are built from top to bottom
             for (int x = blockX - radius; x <= blockX + radius; x++) {
@@ -107,7 +112,7 @@ public class RedwoodTree extends GenericTree {
         // generate the trunk
         for (int y = 0; y < height - random.nextInt(3); y++) {
             Material type = blockTypeAt(blockX, blockY + y, blockZ, world);
-            if (overridables.contains(type)) {
+            if (overridableSet.contains(type)) {
                 delegate.setType(world, blockX, blockY + y,
                         blockZ, logType);
             }

--- a/src/main/java/net/glowstone/util/GlowHelpMap.java
+++ b/src/main/java/net/glowstone/util/GlowHelpMap.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.TreeSet;
 
 /**
  * An implementation of {@link HelpMap}.
@@ -48,7 +47,7 @@ public final class GlowHelpMap implements HelpMap {
     private final Map<Class, HelpTopicFactory<Command>> topicFactoryMap = new HashMap<>();
     private final Set<String> ignoredPlugins = new HashSet<>();
 
-    private final Set<HelpTopic> indexTopics = new TreeSet<>(TOPIC_COMPARE);
+    private final Set<HelpTopic> indexTopics = new HashSet<>();
     private HelpTopic defaultTopic;
     private boolean commandsInIndex = true;
 

--- a/src/main/java/net/glowstone/util/GlowHelpMap.java
+++ b/src/main/java/net/glowstone/util/GlowHelpMap.java
@@ -47,7 +47,7 @@ public final class GlowHelpMap implements HelpMap {
     private final Map<Class, HelpTopicFactory<Command>> topicFactoryMap = new HashMap<>();
     private final Set<String> ignoredPlugins = new HashSet<>();
 
-    private final Set<HelpTopic> indexTopics = new HashSet<>();
+    private final Set<HelpTopic> indexTopics = new TreeSet<>(TOPIC_COMPARE);
     private HelpTopic defaultTopic;
     private boolean commandsInIndex = true;
 
@@ -58,7 +58,7 @@ public final class GlowHelpMap implements HelpMap {
      */
     public GlowHelpMap(GlowServer server) {
         this.server = server;
-        helpTopics = new TreeMap<>(NAME_COMPARE);
+        helpTopics = new HashMap<>();
         defaultTopic
             = new IndexHelpTopic("Index", null, null, indexTopics, "Use /help [n] to get page"
             + " n of help.");

--- a/src/main/java/net/glowstone/util/GlowHelpMap.java
+++ b/src/main/java/net/glowstone/util/GlowHelpMap.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.TreeMap;
+import java.util.TreeSet;
 
 /**
  * An implementation of {@link HelpMap}.

--- a/src/main/java/net/glowstone/util/library/Library.java
+++ b/src/main/java/net/glowstone/util/library/Library.java
@@ -7,7 +7,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.jetbrains.annotations.NonNls;
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -157,8 +157,7 @@ public class Library implements Comparable<Library> {
      * @return A map that is able to be serialized into a config.
      */
     public Map<?, ?> toConfigMap() {
-        // Using LinkedHashMap to keep the props in order when written into the config file.
-        Map<String, Object> configMap = new LinkedHashMap<>();
+        Map<String, Object> configMap = new HashMap<>();
         configMap.put(GROUP_ID_KEY, libraryKey.getGroupId());
         configMap.put(ARTIFACT_ID_KEY, libraryKey.getArtifactId());
         configMap.put(VERSION_KEY, version);
@@ -168,7 +167,7 @@ public class Library implements Comparable<Library> {
         }
 
         if (checksumType != null && checksumValue != null) {
-            Map<String, Object> checksumMap = new LinkedHashMap<>();
+            Map<String, Object> checksumMap = new HashMap<>();
             checksumMap.put(CHECKSUM_TYPE_KEY, checksumType.getName());
             checksumMap.put(CHECKSUM_VALUE_KEY, checksumValue);
             configMap.put(CHECKSUM_KEY, checksumMap);


### PR DESCRIPTION
Hi,

We find that there are several inefficient usages of Java Collections:

1. The contains method is invoked upon a list object. We recommend replacing it with a HashSet.
2. There is no iteration occurring upon a TreeMap and LinkedHashMap, thus the insertion order does not matter. We recommend replacing it with a HashMap.
3. ArrayList is inserted before an iteration, while multiple memory reallocation might occur when the size of the list exceeds its capacity. We recommend replacing it with a LinkedList.

We discovered the above inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

Bests

Ditto