### PR TITLE
Changed port validator to allow all valid ports

### DIFF
--- a/src/main/java/net/glowstone/util/config/ServerConfig.java
+++ b/src/main/java/net/glowstone/util/config/ServerConfig.java
@@ -660,7 +660,7 @@ public class ServerConfig implements DynamicallyTypedMap<ServerConfig.Key> {
          * Checks if the value is a valid port number.
          */
         static final Predicate<Integer> PORT = typeCheck(Integer.class)
-                .and(POSITIVE).and((number) -> number < 49152);
+                .and(POSITIVE).and((number) -> number <= 65535);
         /**
          * Checks if the value is a valid {@link WorldType} name.
          */


### PR DESCRIPTION
(Same as #1126 but for the 1.12 branch)

Currently, only ports below 49152 are accepted, otherwise, Glowstone falls back to 25565. This produces this warning:

`20:08:46 [WARNING] Invalid config value for 'server.port' (54224), resetting to default (25565)`

While the ports 49152 to 65535 are considered private/dynamic ports and probably aren't ideal to use under many circumstances, they are still valid ports and should be accepted by Glowstone.

At Aternos, we use a large port range including that private range to reduce the chance of conflicting ports while trying to keep the server port consistent for the user.