### PR TITLE
Update Minecraft wiki references

### DIFF
--- a/src/main/java/net/glowstone/GlowWorld.java
+++ b/src/main/java/net/glowstone/GlowWorld.java
@@ -835,7 +835,7 @@ public class GlowWorld implements World {
     /**
      * Returns the fraction of the moon that is illuminated, ranging from 0.0 at new moon to 1.0 at
      * full moon. Always a multiple of 0.25. See
-     * <a href="https://minecraft.gamepedia.com/Moon#Phases">Moon Phases</a> at Gamepedia.
+     * <a href="https://minecraft.wiki/w/Moon#Phases">Moon Phases</a> at Wiki.
      *
      * @return the fraction of the moon that is illuminated
      */

--- a/src/main/java/net/glowstone/block/itemtype/ItemEndCrystal.java
+++ b/src/main/java/net/glowstone/block/itemtype/ItemEndCrystal.java
@@ -25,7 +25,7 @@ public class ItemEndCrystal extends ItemType {
         location.add(0.5, 0, 0.5);
         EnderCrystal crystal = player.getWorld().spawn(location, EnderCrystal.class);
         // "Defaults to false when placing by hand [..]
-        // http://minecraft.gamepedia.com/End_Crystal#Data_values
+        // http://minecraft.wiki/w/End_Crystal#Data_values
         crystal.setShowingBottom(false);
 
         super.rightClickBlock(player, target, face, holding, clickedLoc, hand);

--- a/src/main/java/net/glowstone/chunk/GlowChunk.java
+++ b/src/main/java/net/glowstone/chunk/GlowChunk.java
@@ -213,8 +213,8 @@ public class GlowChunk implements Chunk {
     }
 
     /**
-     * Formula taken from Minecraft Gamepedia.
-     * https://minecraft.gamepedia.com/Slime#.22Slime_chunks.22
+     * Formula taken from Minecraft Wiki.
+     * https://minecraft.wiki/w/Slime#.22Slime_chunks.22
      */
     @Override
     public boolean isSlimeChunk() {
@@ -965,7 +965,7 @@ public class GlowChunk implements Chunk {
         if (entireChunk && biomes != null) {
             for (int i = 0; i < 256; i++) {
                 // TODO: 1.13 Biome ID (0 = OCEAN)
-                // For biome IDs, see https://minecraft.gamepedia.com/Biome#Biome_IDs
+                // For biome IDs, see https://minecraft.wiki/w/Biome#Biome_IDs
                 buf.writeInt(0);
             }
         }

--- a/src/main/java/net/glowstone/constants/GlowEnchantment.java
+++ b/src/main/java/net/glowstone/constants/GlowEnchantment.java
@@ -346,7 +346,7 @@ public final class GlowEnchantment extends Enchantment implements Choice {
         private final EnchantmentRarity rarity;
         private final boolean treasure;
         private final boolean cursed;
-        private final int minValue; // https://minecraft.gamepedia.com/Enchanting/Levels
+        private final int minValue; // https://minecraft.wiki/w/Enchanting/Levels
         private final int minIncrement;
         private final int maxIncrement;
         private final int maxValue;

--- a/src/main/java/net/glowstone/entity/AttributeManager.java
+++ b/src/main/java/net/glowstone/entity/AttributeManager.java
@@ -21,7 +21,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
- * Manages the attributes described at https://minecraft.gamepedia.com/Attribute
+ * Manages the attributes described at https://minecraft.wiki/w/Attribute
  */
 public class AttributeManager {
 
@@ -151,7 +151,7 @@ public class AttributeManager {
             Attribute.ZOMBIE_SPAWN_REINFORCEMENTS, 0, 1);
 
         /**
-         * Attribute name from https://minecraft.gamepedia.com/Attribute
+         * Attribute name from https://minecraft.wiki/w/Attribute
          */
         private final String name;
         /**
@@ -283,7 +283,7 @@ public class AttributeManager {
          *
          * <p>
          * Attributes with the same uuid will be overridden according to
-         * https://minecraft.gamepedia.com/Attribute#Attributes
+         * https://minecraft.wiki/w/Attribute#Attributes
          * </p>
          *
          * @param attributeModifier to add to this property

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -1099,7 +1099,7 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         }
 
         // armor damage protection
-        // formula source: http://minecraft.gamepedia.com/Armor#Damage_Protection
+        // formula source: http://minecraft.wiki/w/Armor#Damage_protection
         double defensePoints = getAttributeManager().getPropertyValue(Key.KEY_ARMOR);
         double toughness = getAttributeManager().getPropertyValue(Key.KEY_ARMOR_TOUGHNESS);
         amount = amount * (1 - Math.min(20.0,

--- a/src/main/java/net/glowstone/entity/passive/GlowLlama.java
+++ b/src/main/java/net/glowstone/entity/passive/GlowLlama.java
@@ -18,7 +18,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Represents a llama.
- * The data comes from https://minecraft.gamepedia.com/Llama
+ * The data comes from https://minecraft.wiki/w/Llama
  */
 public class GlowLlama extends GlowChestedHorse<GlowLlamaInventory> implements Llama {
 

--- a/src/main/java/net/glowstone/generator/structures/GlowStructurePiece.java
+++ b/src/main/java/net/glowstone/generator/structures/GlowStructurePiece.java
@@ -20,7 +20,7 @@ public abstract class GlowStructurePiece {
     private BlockFace orientation;
     /**
      * The NBT data field "GD" described in
-     * https://minecraft.gamepedia.com/Generated_structures_data_file_format like this:
+     * https://minecraft.wiki/w/Generated_structures_data_file_format like this:
      * "Appears to be some sort of measure of how far this piece is from the start."
      */
     @Getter

--- a/src/main/java/net/glowstone/io/entity/EntityStore.java
+++ b/src/main/java/net/glowstone/io/entity/EntityStore.java
@@ -57,7 +57,7 @@ public abstract class EntityStore<T extends GlowEntity> {
     }
 
     // For information on the NBT tags loaded here and elsewhere:
-    // http://minecraft.gamepedia.com/Chunk_format#Entity_Format
+    // https://minecraft.wiki/w/Entity_format
 
     // todo: the following tags
     // - bool "Invulnerable"

--- a/src/main/java/net/glowstone/io/entity/HumanEntityStore.java
+++ b/src/main/java/net/glowstone/io/entity/HumanEntityStore.java
@@ -19,7 +19,7 @@ abstract class HumanEntityStore<T extends GlowHumanEntity> extends LivingEntityS
         super(clazz, type);
     }
 
-    // documented at http://minecraft.gamepedia.com/Player.dat_Format
+    // documented at http://minecraft.wiki/w/Player.dat_format
     // player data that does not correspond to HumanEntity is in PlayerStore
 
     @Override

--- a/src/main/java/net/glowstone/map/GlowMapRenderer.java
+++ b/src/main/java/net/glowstone/map/GlowMapRenderer.java
@@ -28,7 +28,7 @@ public final class GlowMapRenderer extends MapRenderer {
     }
 
     /**
-     * Based on https://minecraft.gamepedia.com/Slime#.22Slime_chunks.22 but simplified (doesn't
+     * Based on https://minecraft.wiki/w/Slime#.22Slime_chunks.22 but simplified (doesn't
      * instantiate a Random, and doesn't vary with the world seed. Designed to be reproducible, so
      * that updating a map doesn't change the color unless the map contents have changed.
      */


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all Gamepedia, owned now by Fandom, references accordingly.