### PR TITLE
Fix: Add placeholder for missing API event triggers (WIP)

### DIFF
--- a/src/main/java/net/glowstone/TODOEventHooks.java
+++ b/src/main/java/net/glowstone/TODOEventHooks.java
@@ -1,0 +1,13 @@
+package net.glowstone;
+
+/**
+ * Temporary class to track missing Bukkit event hook points.
+ * 
+ * TODO: Hook PlayerInteractEvent in entity.PlayerInteractionManager
+ * TODO: Add InventoryClickEvent trigger inside inventory.InventoryMonitor
+ * 
+ * This class is for internal planning use only and will be removed after integration.
+ */
+public class TODOEventHooks {
+    // Placeholder for event audit tracking.
+}


### PR DESCRIPTION
## Overview

This PR introduces a placeholder file (`TODOEventHooks.java`) to begin documenting and organizing missing event trigger logic within Glowstone’s Bukkit-compatible API. Based on issue [#922](https://github.com/GlowstoneMC/Glowstone/issues/922), several gameplay interactions currently do not fire the expected events (e.g., PlayerMoveEvent, InventoryClickEvent), causing incompatibility with plugins that rely on these hooks.

## Motivation

The goal of this commit is to establish a central point to track these gaps and gradually improve coverage and consistency with Bukkit behavior. This file will act as a staging ground for identifying missing hooks and associating them with relevant gameplay flows before full implementations are made.

## Next Steps

- Map in-game actions to expected Bukkit events
- Locate appropriate injection points in the event pipeline
- Gradually implement and test new hooks
