### PR TITLE
Leaves: update decay range to 6 and dynamic map sizing (1.13 change)

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockLeaves.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockLeaves.java
@@ -20,7 +20,12 @@ import org.jetbrains.annotations.NotNull;
 
 public class BlockLeaves extends BlockType {
 
-    private final byte[] blockMap = new byte[11 * 11 * 11];
+    private static final int LEAVE_BLOCK_DECAY_RANGE = 6;
+    private static final int LEAVE_BLOCK_MAP_RANGE = (LEAVE_BLOCK_DECAY_RANGE * 2) + 1;
+
+    // map of neighbouring blocks within decay range, center is the current leaves block,
+    // includes a 1-block border for indexing convenience
+    private final byte[] blockMap = new byte[(int) Math.pow(LEAVE_BLOCK_MAP_RANGE + 2, 3)];
 
     @Override
     public void placeBlock(GlowPlayer player, GlowBlockState state, BlockFace face,
@@ -97,12 +102,15 @@ public class BlockLeaves extends BlockType {
         }
         GlowWorld world = block.getWorld();
 
-        // build a 9x9x9 box to map neighboring blocks
-        for (int x = 0; x < 9; x++) {
-            for (int z = 0; z < 9; z++) {
-                for (int y = 0; y < 9; y++) {
+        // build a box around the current block to map neighboring blocks within decay range
+        for (int x = 0; x < LEAVE_BLOCK_MAP_RANGE; x++) {
+            for (int z = 0; z < LEAVE_BLOCK_MAP_RANGE; z++) {
+                for (int y = 0; y < LEAVE_BLOCK_MAP_RANGE; y++) {
                     GlowBlock b = world
-                        .getBlockAt(block.getLocation().add(x - 4, y - 4, z - 4));
+                        .getBlockAt(block.getLocation().add(
+                            x - LEAVE_BLOCK_DECAY_RANGE,
+                            y - LEAVE_BLOCK_DECAY_RANGE,
+                            z - LEAVE_BLOCK_DECAY_RANGE));
                     byte val = 127;
                     // TODO: 1.13 leaves and log types
                     if (b.getType() == Material.LEGACY_LOG || b.getType() == Material.LEGACY_LOG_2) {
@@ -116,13 +124,13 @@ public class BlockLeaves extends BlockType {
             }
         }
 
-        // browse the map in several pass to detect connected leaves:
-        // leaf block that is 5 blocks away from log or without connection
+        // browse the map in several passes to detect connected leaves:
+        // leaf blocks that are more than 6 blocks away from a log or without a path
         // to another connected leaves block will decay
-        for (int i = 0; i < 4; i++) {
-            for (int x = 0; x < 9; x++) {
-                for (int z = 0; z < 9; z++) {
-                    for (int y = 0; y < 9; y++) {
+        for (int i = 0; i < LEAVE_BLOCK_DECAY_RANGE; i++) {
+            for (int x = 0; x < LEAVE_BLOCK_MAP_RANGE; x++) {
+                for (int z = 0; z < LEAVE_BLOCK_MAP_RANGE; z++) {
+                    for (int y = 0; y < LEAVE_BLOCK_MAP_RANGE; y++) {
                         if (getBlockInMap(x, y, z) != i) {
                             continue;
                         }
@@ -149,7 +157,7 @@ public class BlockLeaves extends BlockType {
             }
         }
 
-        if (getBlockInMap(4, 4, 4) < 0) { // leaf decay
+        if (getBlockInMap(LEAVE_BLOCK_DECAY_RANGE, LEAVE_BLOCK_DECAY_RANGE, LEAVE_BLOCK_DECAY_RANGE) < 0) { // leaf decay
             LeavesDecayEvent decayEvent = new LeavesDecayEvent(block);
             EventFactory.getInstance().callEvent(decayEvent);
             if (!decayEvent.isCancelled()) {
@@ -162,10 +170,10 @@ public class BlockLeaves extends BlockType {
     }
 
     private byte getBlockInMap(int x, int y, int z) {
-        return blockMap[((x + 1) * 11 + z + 1) * 11 + y + 1];
+        return blockMap[((x + 1) * (LEAVE_BLOCK_MAP_RANGE + 2) + z + 1) * (LEAVE_BLOCK_MAP_RANGE + 2) + y + 1];
     }
 
     private void setBlockInMap(byte val, int x, int y, int z) {
-        blockMap[((x + 1) * 11 + z + 1) * 11 + y + 1] = val;
+        blockMap[((x + 1) * (LEAVE_BLOCK_MAP_RANGE + 2) + z + 1) * (LEAVE_BLOCK_MAP_RANGE + 2) + y + 1] = val;
     }
 }


### PR DESCRIPTION
Implements the 1.13 leaves behavior: leaves survive up to a distance of 6 from logs. Replaces hardcoded 9x9x9/4-step search with constants and a 13x13x13 map and 6-step BFS; keeps player-placed leaves persistent.\n\nReferences GlowstoneMC/1.13-board#22.