### PR TITLE
NBT: minor adjustments for 1.13 (ItemFrame Rotation byte)

### DIFF
--- a/src/main/java/net/glowstone/io/entity/ItemFrameStore.java
+++ b/src/main/java/net/glowstone/io/entity/ItemFrameStore.java
@@ -24,7 +24,7 @@ class ItemFrameStore extends HangingStore<GlowItemFrame> {
     public void load(GlowItemFrame entity, CompoundTag tag) {
         super.load(entity, tag);
         tag.readItem("Item", entity::setItem);
-        tag.readInt("Rotation", rotation -> entity.setRotation(Rotation.values()[rotation]));
+        tag.readByte("Rotation", rotation -> entity.setRotation(Rotation.values()[rotation & 0xFF]));
     }
 
     @Override
@@ -32,6 +32,6 @@ class ItemFrameStore extends HangingStore<GlowItemFrame> {
         super.save(entity, tag);
         tag.putByte("Facing", HangingFace.getByBlockFace(entity.getFacing()).ordinal());
         tag.putCompound("Item", NbtSerialization.writeItem(entity.getItem(), -1));
-        tag.putInt("Rotation", entity.getRotation().ordinal());
+        tag.putByte("Rotation", entity.getRotation().ordinal());
     }
 }


### PR DESCRIPTION
Updates NBT types per 1.13 flattening:\n- ItemFrame Rotation is stored as a byte, not an int. Adjust read/write in ItemFrameStore.\n\nIn addition to PR #1149 (Damage semantics), this aligns item/block/entity NBT with 1.13 expectations.\n\nReferences GlowstoneMC/1.13-board#25.