### PR TITLE
Blocks: flatten FlowerPot and Note Block (no block entities)

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockFlowerPot.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockFlowerPot.java
@@ -40,7 +40,8 @@ public class BlockFlowerPot extends BlockType {
 
     @Override
     public BlockEntity createBlockEntity(GlowChunk chunk, int cx, int cy, int cz) {
-        return new FlowerPotEntity(chunk.getBlock(cx, cy, cz));
+        // In 1.13+, flower pot variants are flattened into individual blocks; no block entity needed.
+        return null;
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/blocktype/BlockNote.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockNote.java
@@ -17,7 +17,8 @@ public class BlockNote extends BlockType {
 
     @Override
     public BlockEntity createBlockEntity(GlowChunk chunk, int cx, int cy, int cz) {
-        return new NoteblockEntity(chunk.getBlock(cx, cy, cz));
+        // In 1.13+, note value is represented via block state; no block entity needed.
+        return null;
     }
 
     @Override

--- a/src/main/java/net/glowstone/block/entity/state/GlowNoteBlock.java
+++ b/src/main/java/net/glowstone/block/entity/state/GlowNoteBlock.java
@@ -34,7 +34,13 @@ public class GlowNoteBlock extends GlowBlockState implements NoteBlock {
                 "GlowNoteBlock: expected NOTE_BLOCK, got " + block.getType());
         }
 
-        note = getBlockEntity().getNote();
+        NoteblockEntity entity = getBlockEntity();
+        if (entity != null) {
+            note = entity.getNote();
+        } else {
+            // Fallback: store note in block metadata/data when no block entity is present
+            note = new Note(getBlock().getData());
+        }
     }
 
     private static Instrument instrumentOf(Material mat) {
@@ -222,7 +228,13 @@ public class GlowNoteBlock extends GlowBlockState implements NoteBlock {
     public boolean update(boolean force, boolean applyPhysics) {
         boolean result = super.update(force, applyPhysics);
         if (result) {
-            getBlockEntity().setNote(note);
+            NoteblockEntity entity = getBlockEntity();
+            if (entity != null) {
+                entity.setNote(note);
+            } else {
+                // Persist via block metadata/data in absence of a block entity
+                getBlock().setData(note.getId());
+            }
         }
         return result;
     }


### PR DESCRIPTION
Extends #26: \n- Flower Pot: stop creating block entity.\n- Note Block: stop creating block entity; store note value using block data (block metadata fallback) and play/update continue to work.\n\nThis is compatible with current block data implementation (metadata used as interim).\n\nReferences GlowstoneMC/1.13-board#26.