### PR TITLE
tests/build: add public repos to resolve dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,10 @@ version = glowstoneVersion
 
 repositories {
     mavenLocal()
+    mavenCentral()
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    maven { url 'https://repo.md-5.net/content/repositories/public/' }
+    maven { url 'https://repo.md-5.net/content/repositories/snapshots/' }
 
     maven {
         name = 'Glowstone'


### PR DESCRIPTION
Add Maven Central and md-5/sonatype snapshot repos so test dependencies resolve on a clean machine. This is groundwork for updating tests to 1.13 semantics.\n\nReferences GlowstoneMC/1.13-board#29.