### PR TITLE
Implement entity AI system with pathfinding integration

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowAnimal.java
+++ b/src/main/java/net/glowstone/entity/GlowAnimal.java
@@ -42,8 +42,14 @@ public class GlowAnimal extends GlowAgeable implements Animals {
     public GlowAnimal(Location location, EntityType type, double maxHealth) {
         super(location, type, maxHealth);
         if (type != null) {
+            EntityDirector.registerEntityMobState(type, MobState.IDLE, "swim");
+            EntityDirector.registerEntityMobState(type, MobState.IDLE, "avoid_entity");
+            EntityDirector.registerEntityMobState(type, MobState.IDLE, "panic");
+            EntityDirector.registerEntityMobState(type, MobState.IDLE, "wander");
             EntityDirector.registerEntityMobState(type, MobState.IDLE, "look_around");
             EntityDirector.registerEntityMobState(type, MobState.IDLE, "look_player");
+            EntityDirector.registerEntityMobState(type, MobState.ATTACKED, "swim");
+            EntityDirector.registerEntityMobState(type, MobState.ATTACKED, "panic");
         }
         setState(MobState.IDLE);
 

--- a/src/main/java/net/glowstone/entity/ai/AvoidEntityTask.java
+++ b/src/main/java/net/glowstone/entity/ai/AvoidEntityTask.java
@@ -1,0 +1,228 @@
+package net.glowstone.entity.ai;
+
+import net.glowstone.block.GlowBlock;
+import net.glowstone.entity.GlowLivingEntity;
+import net.glowstone.util.TickUtil;
+import net.glowstone.util.pathfinding.Pathfinder;
+import net.glowstone.util.pathfinding.algorithms.AStarAlgorithm;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Monster;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+
+import java.util.List;
+
+/**
+ * A task that makes passive entities flee from threats like monsters or players.
+ * Uses pathfinding to navigate away from danger.
+ */
+public class AvoidEntityTask extends EntityTask {
+
+    private static final double DETECTION_RANGE = 8.0;
+    private static final double SAFE_DISTANCE_SQ = 100.0;
+    private static final double FLEE_SPEED = 0.4;
+    private static final int PATH_RECALC_TICKS = 10;
+    private static final AStarAlgorithm ALGORITHM = new AStarAlgorithm();
+
+    private LivingEntity threat;
+    private List<Vector> currentPath;
+    private int pathIndex;
+    private int ticksSincePathCalc;
+
+    public AvoidEntityTask() {
+        super("avoid_entity", 2);
+    }
+
+    @Override
+    public boolean isInstant() {
+        return false;
+    }
+
+    @Override
+    public int getDurationMin() {
+        return TickUtil.secondsToTicks(2);
+    }
+
+    @Override
+    public int getDurationMax() {
+        return TickUtil.secondsToTicks(5);
+    }
+
+    @Override
+    public boolean shouldStart(GlowLivingEntity entity) {
+        if (entity instanceof Monster) {
+            return false;
+        }
+        return findThreat(entity) != null;
+    }
+
+    @Override
+    public void start(GlowLivingEntity entity) {
+        threat = findThreat(entity);
+        if (threat != null) {
+            calculateFleePath(entity);
+        }
+    }
+
+    @Override
+    public void end(GlowLivingEntity entity) {
+        currentPath = null;
+        pathIndex = 0;
+        ticksSincePathCalc = 0;
+        threat = null;
+        entity.setMovement(new Vector(0, 0, 0));
+    }
+
+    @Override
+    public void execute(GlowLivingEntity entity) {
+        if (threat == null || threat.isDead()) {
+            threat = findThreat(entity);
+            if (threat == null) {
+                reset(entity);
+                return;
+            }
+            calculateFleePath(entity);
+        }
+
+        Location entityLoc = entity.getLocation();
+        Location threatLoc = threat.getLocation();
+        double distSq = entityLoc.distanceSquared(threatLoc);
+
+        if (distSq >= SAFE_DISTANCE_SQ) {
+            reset(entity);
+            return;
+        }
+
+        ticksSincePathCalc++;
+        if (ticksSincePathCalc >= PATH_RECALC_TICKS) {
+            calculateFleePath(entity);
+            ticksSincePathCalc = 0;
+        }
+
+        if (currentPath != null && !currentPath.isEmpty() && pathIndex < currentPath.size()) {
+            Vector nextPoint = currentPath.get(pathIndex);
+            double pointDistSq = entityLoc.toVector().distanceSquared(nextPoint);
+
+            if (pointDistSq < 1.0) {
+                pathIndex++;
+            }
+
+            if (pathIndex < currentPath.size()) {
+                moveToward(entity, currentPath.get(pathIndex));
+            }
+        } else {
+            fleeDirectlyFrom(entity, threatLoc);
+        }
+    }
+
+    private LivingEntity findThreat(GlowLivingEntity entity) {
+        for (Entity nearby : entity.getNearbyEntities(DETECTION_RANGE, DETECTION_RANGE / 2, DETECTION_RANGE)) {
+            if (nearby instanceof Monster) {
+                return (LivingEntity) nearby;
+            }
+            if (nearby instanceof Player) {
+                Player player = (Player) nearby;
+                if (player.isOnline() && !player.isDead()) {
+                    if (player.isSprinting()) {
+                        return player;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private void calculateFleePath(GlowLivingEntity entity) {
+        if (threat == null) {
+            return;
+        }
+
+        Location entityLoc = entity.getLocation();
+        Location threatLoc = threat.getLocation();
+
+        double dx = entityLoc.getX() - threatLoc.getX();
+        double dz = entityLoc.getZ() - threatLoc.getZ();
+        double distance = Math.sqrt(dx * dx + dz * dz);
+
+        if (distance > 0) {
+            dx = dx / distance * 10;
+            dz = dz / distance * 10;
+        }
+
+        Location fleeTarget = entityLoc.clone().add(dx, 0, dz);
+        fleeTarget = findValidLocation(fleeTarget);
+
+        if (fleeTarget != null) {
+            GlowBlock startBlock = (GlowBlock) entityLoc.getBlock();
+            GlowBlock endBlock = (GlowBlock) fleeTarget.getBlock();
+
+            Pathfinder pathfinder = new Pathfinder(startBlock, endBlock,
+                Material.LAVA, Material.FIRE, Material.CACTUS);
+            currentPath = pathfinder.getPath(ALGORITHM);
+            pathIndex = 0;
+        }
+    }
+
+    private Location findValidLocation(Location target) {
+        if (target.getWorld() == null) {
+            return null;
+        }
+
+        for (int dy = 0; dy <= 3; dy++) {
+            Location check = target.clone().add(0, -dy, 0);
+            if (isValidLocation(check)) {
+                return check;
+            }
+            if (dy > 0) {
+                check = target.clone().add(0, dy, 0);
+                if (isValidLocation(check)) {
+                    return check;
+                }
+            }
+        }
+        return null;
+    }
+
+    private boolean isValidLocation(Location loc) {
+        Material blockType = loc.getBlock().getType();
+        Material belowType = loc.clone().subtract(0, 1, 0).getBlock().getType();
+        return !blockType.isSolid() && belowType.isSolid();
+    }
+
+    private void fleeDirectlyFrom(GlowLivingEntity entity, Location threatLoc) {
+        Location entityLoc = entity.getLocation();
+        double dx = entityLoc.getX() - threatLoc.getX();
+        double dz = entityLoc.getZ() - threatLoc.getZ();
+
+        double distance = Math.sqrt(dx * dx + dz * dz);
+        if (distance > 0) {
+            dx /= distance;
+            dz /= distance;
+        }
+
+        float yaw = (float) (Math.atan2(dz, dx) * (180 / Math.PI)) - 90;
+        entity.setHeadYaw(yaw);
+        entity.setSpeed(FLEE_SPEED);
+        entity.setMovement(new Vector(dx, 0, dz));
+    }
+
+    private void moveToward(GlowLivingEntity entity, Vector target) {
+        Location location = entity.getLocation();
+        double deltaX = target.getX() - location.getX();
+        double deltaZ = target.getZ() - location.getZ();
+
+        double distance = Math.sqrt(deltaX * deltaX + deltaZ * deltaZ);
+        if (distance > 0) {
+            deltaX /= distance;
+            deltaZ /= distance;
+        }
+
+        float yaw = (float) (Math.atan2(deltaZ, deltaX) * (180 / Math.PI)) - 90;
+        entity.setHeadYaw(yaw);
+        entity.setSpeed(FLEE_SPEED);
+        entity.setMovement(new Vector(deltaX, 0, deltaZ));
+    }
+}

--- a/src/main/java/net/glowstone/entity/ai/EntityDirector.java
+++ b/src/main/java/net/glowstone/entity/ai/EntityDirector.java
@@ -20,6 +20,12 @@ public class EntityDirector {
         registerEntityTask("look_around", LookAroundTask.class);
         registerEntityTask("look_player", LookAtPlayerTask.class);
         registerEntityTask("follow_player", FollowPlayerTask.class);
+        registerEntityTask("wander", WanderTask.class);
+        registerEntityTask("swim", SwimTask.class);
+        registerEntityTask("panic", PanicTask.class);
+        registerEntityTask("melee_attack", MeleeAttackTask.class);
+        registerEntityTask("avoid_entity", AvoidEntityTask.class);
+        registerEntityTask("find_target", FindTargetTask.class);
     }
 
     /**

--- a/src/main/java/net/glowstone/entity/ai/EntityTask.java
+++ b/src/main/java/net/glowstone/entity/ai/EntityTask.java
@@ -16,6 +16,21 @@ public abstract class EntityTask implements Comparable<EntityTask> {
     @Getter
     @NonNls
     private final String name;
+
+    /**
+     * The priority of this task. Lower values execute first.
+     * Typical ranges:
+     * - 0-2: Critical survival tasks (swim, breathe)
+     * - 3-4: Combat/panic tasks
+     * - 5-6: Target selection
+     * - 7-8: Movement tasks (wander, follow)
+     * - 9-10: Idle behaviors (look around)
+     *
+     * @return the priority of this EntityTask.
+     */
+    @Getter
+    private final int priority;
+
     /**
      * Whether this task is currently being executed.
      *
@@ -33,12 +48,17 @@ public abstract class EntityTask implements Comparable<EntityTask> {
     private boolean paused = false;
 
     public EntityTask(@NonNls String name) {
+        this(name, 5);
+    }
+
+    public EntityTask(@NonNls String name, int priority) {
         this.name = name;
+        this.priority = priority;
     }
 
     @Override
     public int compareTo(EntityTask other) {
-        return 0; // TODO: AI task priority
+        return Integer.compare(this.priority, other.priority);
     }
 
     /**

--- a/src/main/java/net/glowstone/entity/ai/FindTargetTask.java
+++ b/src/main/java/net/glowstone/entity/ai/FindTargetTask.java
@@ -1,0 +1,91 @@
+package net.glowstone.entity.ai;
+
+import net.glowstone.entity.GlowLivingEntity;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Monster;
+import org.bukkit.entity.Player;
+
+/**
+ * A task that searches for and acquires targets for hostile mobs.
+ * When a target is found, switches the entity to the TARGETING state.
+ */
+public class FindTargetTask extends EntityTask {
+
+    private static final double DETECTION_RANGE = 16.0;
+    private static final double VERTICAL_RANGE = 4.0;
+
+    public FindTargetTask() {
+        super("find_target", 5);
+    }
+
+    @Override
+    public boolean isInstant() {
+        return true;
+    }
+
+    @Override
+    public int getDurationMin() {
+        return 1;
+    }
+
+    @Override
+    public int getDurationMax() {
+        return 1;
+    }
+
+    @Override
+    public boolean shouldStart(GlowLivingEntity entity) {
+        return entity instanceof Monster;
+    }
+
+    @Override
+    public void start(GlowLivingEntity entity) {
+    }
+
+    @Override
+    public void end(GlowLivingEntity entity) {
+    }
+
+    @Override
+    public void execute(GlowLivingEntity entity) {
+        if (entity.getState() == HostileMobState.TARGETING) {
+            return;
+        }
+
+        Player target = findNearestPlayer(entity);
+        if (target != null) {
+            entity.setState(HostileMobState.TARGETING);
+        }
+    }
+
+    private Player findNearestPlayer(GlowLivingEntity entity) {
+        Player nearest = null;
+        double nearestDistSq = Double.MAX_VALUE;
+
+        for (Entity nearby : entity.getNearbyEntities(DETECTION_RANGE, VERTICAL_RANGE, DETECTION_RANGE)) {
+            if (!(nearby instanceof Player)) {
+                continue;
+            }
+            Player player = (Player) nearby;
+            if (!player.isOnline() || player.isDead()) {
+                continue;
+            }
+
+            if (!canSee(entity, player)) {
+                continue;
+            }
+
+            double distSq = entity.getLocation().distanceSquared(player.getLocation());
+            if (distSq < nearestDistSq) {
+                nearest = player;
+                nearestDistSq = distSq;
+            }
+        }
+
+        return nearest;
+    }
+
+    private boolean canSee(GlowLivingEntity entity, Player target) {
+        return entity.hasLineOfSight(target);
+    }
+}

--- a/src/main/java/net/glowstone/entity/ai/FollowPlayerTask.java
+++ b/src/main/java/net/glowstone/entity/ai/FollowPlayerTask.java
@@ -16,7 +16,7 @@ public class FollowPlayerTask extends EntityTask {
     private int delay = 1;
 
     public FollowPlayerTask() {
-        super("follow_player");
+        super("follow_player", 7);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/ai/LookAroundTask.java
+++ b/src/main/java/net/glowstone/entity/ai/LookAroundTask.java
@@ -10,7 +10,7 @@ public class LookAroundTask extends EntityTask {
     private int delay = ThreadLocalRandom.current().nextInt(10) + 15;
 
     public LookAroundTask() {
-        super("look_around");
+        super("look_around", 10);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/ai/LookAtPlayerTask.java
+++ b/src/main/java/net/glowstone/entity/ai/LookAtPlayerTask.java
@@ -17,7 +17,7 @@ public class LookAtPlayerTask extends EntityTask {
     private int delay = 1;
 
     public LookAtPlayerTask() {
-        super("look_player");
+        super("look_player", 9);
     }
 
     @Override

--- a/src/main/java/net/glowstone/entity/ai/MeleeAttackTask.java
+++ b/src/main/java/net/glowstone/entity/ai/MeleeAttackTask.java
@@ -1,0 +1,217 @@
+package net.glowstone.entity.ai;
+
+import net.glowstone.block.GlowBlock;
+import net.glowstone.entity.GlowLivingEntity;
+import net.glowstone.util.TickUtil;
+import net.glowstone.util.pathfinding.Pathfinder;
+import net.glowstone.util.pathfinding.algorithms.AStarAlgorithm;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.util.Vector;
+
+import java.util.List;
+
+/**
+ * A melee attack task that moves toward a target and attacks when in range.
+ * Uses pathfinding to navigate to the target.
+ */
+public class MeleeAttackTask extends EntityTask {
+
+    private static final double ATTACK_RANGE_SQ = 4.0;
+    private static final int ATTACK_COOLDOWN_TICKS = 20;
+    private static final double APPROACH_SPEED = 0.35;
+    private static final int PATH_RECALC_TICKS = 10;
+    private static final AStarAlgorithm ALGORITHM = new AStarAlgorithm();
+
+    private LivingEntity target;
+    private List<Vector> currentPath;
+    private int pathIndex;
+    private int ticksSincePathCalc;
+    private int attackCooldown;
+
+    public MeleeAttackTask() {
+        super("melee_attack", 3);
+    }
+
+    @Override
+    public boolean isInstant() {
+        return false;
+    }
+
+    @Override
+    public int getDurationMin() {
+        return TickUtil.secondsToTicks(5);
+    }
+
+    @Override
+    public int getDurationMax() {
+        return TickUtil.secondsToTicks(10);
+    }
+
+    @Override
+    public boolean shouldStart(GlowLivingEntity entity) {
+        return entity.getState() == HostileMobState.TARGETING && findTarget(entity) != null;
+    }
+
+    @Override
+    public void start(GlowLivingEntity entity) {
+        target = findTarget(entity);
+        if (target != null) {
+            calculatePath(entity);
+        }
+    }
+
+    @Override
+    public void end(GlowLivingEntity entity) {
+        currentPath = null;
+        pathIndex = 0;
+        ticksSincePathCalc = 0;
+        attackCooldown = 0;
+        target = null;
+        entity.setMovement(new Vector(0, 0, 0));
+    }
+
+    @Override
+    public void execute(GlowLivingEntity entity) {
+        if (attackCooldown > 0) {
+            attackCooldown--;
+        }
+
+        if (target == null || target.isDead()) {
+            target = findTarget(entity);
+            if (target == null) {
+                reset(entity);
+                return;
+            }
+        }
+
+        if (target instanceof Player && !((Player) target).isOnline()) {
+            reset(entity);
+            return;
+        }
+
+        Location entityLoc = entity.getLocation();
+        Location targetLoc = target.getLocation();
+        double distSq = entityLoc.distanceSquared(targetLoc);
+
+        if (distSq <= ATTACK_RANGE_SQ) {
+            if (attackCooldown <= 0) {
+                performAttack(entity, target);
+                attackCooldown = ATTACK_COOLDOWN_TICKS;
+            }
+            lookAt(entity, targetLoc);
+            return;
+        }
+
+        ticksSincePathCalc++;
+        if (currentPath == null || ticksSincePathCalc >= PATH_RECALC_TICKS) {
+            calculatePath(entity);
+            ticksSincePathCalc = 0;
+        }
+
+        if (currentPath != null && !currentPath.isEmpty() && pathIndex < currentPath.size()) {
+            Vector nextPoint = currentPath.get(pathIndex);
+            double pointDistSq = entityLoc.toVector().distanceSquared(nextPoint);
+
+            if (pointDistSq < 1.0) {
+                pathIndex++;
+            }
+
+            if (pathIndex < currentPath.size()) {
+                moveToward(entity, currentPath.get(pathIndex));
+            }
+        } else {
+            moveToward(entity, targetLoc.toVector());
+        }
+    }
+
+    private LivingEntity findTarget(GlowLivingEntity entity) {
+        double range = 16.0;
+        LivingEntity nearest = null;
+        double nearestDistSq = Double.MAX_VALUE;
+
+        for (Entity nearby : entity.getNearbyEntities(range, range / 2, range)) {
+            if (!(nearby instanceof LivingEntity)) {
+                continue;
+            }
+            if (nearby instanceof Player) {
+                Player player = (Player) nearby;
+                if (!player.isOnline() || player.isDead()) {
+                    continue;
+                }
+            }
+            if (nearby.equals(entity)) {
+                continue;
+            }
+
+            double distSq = entity.getLocation().distanceSquared(nearby.getLocation());
+            if (distSq < nearestDistSq) {
+                nearest = (LivingEntity) nearby;
+                nearestDistSq = distSq;
+            }
+        }
+
+        return nearest;
+    }
+
+    private void performAttack(GlowLivingEntity attacker, LivingEntity target) {
+        double damage = 2.0;
+        AttributeInstance attackDamage = attacker.getAttribute(Attribute.GENERIC_ATTACK_DAMAGE);
+        if (attackDamage != null) {
+            damage = attackDamage.getValue();
+        }
+
+        EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(
+            attacker, target, DamageCause.ENTITY_ATTACK, damage);
+        target.getServer().getPluginManager().callEvent(event);
+
+        if (!event.isCancelled()) {
+            target.damage(event.getFinalDamage(), attacker);
+        }
+    }
+
+    private void calculatePath(GlowLivingEntity entity) {
+        if (target == null) {
+            return;
+        }
+        GlowBlock startBlock = (GlowBlock) entity.getLocation().getBlock();
+        GlowBlock endBlock = (GlowBlock) target.getLocation().getBlock();
+
+        Pathfinder pathfinder = new Pathfinder(startBlock, endBlock,
+            Material.LAVA, Material.FIRE, Material.CACTUS);
+        currentPath = pathfinder.getPath(ALGORITHM);
+        pathIndex = 0;
+    }
+
+    private void lookAt(GlowLivingEntity entity, Location target) {
+        Location location = entity.getLocation();
+        double deltaX = target.getX() - location.getX();
+        double deltaZ = target.getZ() - location.getZ();
+        float yaw = (float) (Math.atan2(deltaZ, deltaX) * (180 / Math.PI)) - 90;
+        entity.setHeadYaw(yaw);
+    }
+
+    private void moveToward(GlowLivingEntity entity, Vector target) {
+        Location location = entity.getLocation();
+        double deltaX = target.getX() - location.getX();
+        double deltaZ = target.getZ() - location.getZ();
+
+        double distance = Math.sqrt(deltaX * deltaX + deltaZ * deltaZ);
+        if (distance > 0) {
+            deltaX /= distance;
+            deltaZ /= distance;
+        }
+
+        float yaw = (float) (Math.atan2(deltaZ, deltaX) * (180 / Math.PI)) - 90;
+        entity.setHeadYaw(yaw);
+        entity.setSpeed(APPROACH_SPEED);
+        entity.setMovement(new Vector(deltaX, 0, deltaZ));
+    }
+}

--- a/src/main/java/net/glowstone/entity/ai/PanicTask.java
+++ b/src/main/java/net/glowstone/entity/ai/PanicTask.java
@@ -1,0 +1,162 @@
+package net.glowstone.entity.ai;
+
+import net.glowstone.block.GlowBlock;
+import net.glowstone.entity.GlowLivingEntity;
+import net.glowstone.util.TickUtil;
+import net.glowstone.util.pathfinding.Pathfinder;
+import net.glowstone.util.pathfinding.algorithms.AStarAlgorithm;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.util.Vector;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A panic task that causes entities to flee rapidly when in the ATTACKED state.
+ * Uses pathfinding to find an escape route away from danger.
+ */
+public class PanicTask extends EntityTask {
+
+    private static final int PANIC_RADIUS = 16;
+    private static final double PANIC_SPEED = 0.5;
+    private static final AStarAlgorithm ALGORITHM = new AStarAlgorithm();
+
+    private List<Vector> currentPath;
+    private int pathIndex;
+    private Location fleeTarget;
+
+    public PanicTask() {
+        super("panic", 1);
+    }
+
+    @Override
+    public boolean isInstant() {
+        return false;
+    }
+
+    @Override
+    public int getDurationMin() {
+        return TickUtil.secondsToTicks(2);
+    }
+
+    @Override
+    public int getDurationMax() {
+        return TickUtil.secondsToTicks(4);
+    }
+
+    @Override
+    public boolean shouldStart(GlowLivingEntity entity) {
+        return entity.getState() == MobState.ATTACKED;
+    }
+
+    @Override
+    public void start(GlowLivingEntity entity) {
+        fleeTarget = findFleeLocation(entity);
+        if (fleeTarget != null) {
+            calculatePath(entity);
+        }
+    }
+
+    @Override
+    public void end(GlowLivingEntity entity) {
+        currentPath = null;
+        pathIndex = 0;
+        fleeTarget = null;
+        entity.setMovement(new Vector(0, 0, 0));
+        if (entity.getState() == MobState.ATTACKED) {
+            entity.setState(MobState.IDLE);
+        }
+    }
+
+    @Override
+    public void execute(GlowLivingEntity entity) {
+        if (fleeTarget == null || currentPath == null || currentPath.isEmpty()) {
+            reset(entity);
+            return;
+        }
+
+        if (pathIndex >= currentPath.size()) {
+            reset(entity);
+            return;
+        }
+
+        Vector nextPoint = currentPath.get(pathIndex);
+        Location entityLoc = entity.getLocation();
+        double distSq = entityLoc.toVector().distanceSquared(nextPoint);
+
+        if (distSq < 1.0) {
+            pathIndex++;
+            if (pathIndex >= currentPath.size()) {
+                reset(entity);
+                return;
+            }
+            nextPoint = currentPath.get(pathIndex);
+        }
+
+        moveToward(entity, nextPoint);
+    }
+
+    private Location findFleeLocation(GlowLivingEntity entity) {
+        Location origin = entity.getLocation();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        for (int attempts = 0; attempts < 10; attempts++) {
+            double angle = random.nextDouble() * 2 * Math.PI;
+            int distance = random.nextInt(PANIC_RADIUS / 2, PANIC_RADIUS);
+            int dx = (int) (Math.cos(angle) * distance);
+            int dz = (int) (Math.sin(angle) * distance);
+            int dy = random.nextInt(-3, 4);
+
+            Location target = origin.clone().add(dx, dy, dz);
+            if (isValidFleeTarget(target)) {
+                return target;
+            }
+        }
+        return null;
+    }
+
+    private boolean isValidFleeTarget(Location loc) {
+        if (loc.getWorld() == null) {
+            return false;
+        }
+        Material blockType = loc.getBlock().getType();
+        Material belowType = loc.clone().subtract(0, 1, 0).getBlock().getType();
+
+        return !blockType.isSolid()
+            && belowType.isSolid()
+            && blockType != Material.WATER
+            && blockType != Material.LAVA
+            && blockType != Material.FIRE;
+    }
+
+    private void calculatePath(GlowLivingEntity entity) {
+        if (fleeTarget == null) {
+            return;
+        }
+        GlowBlock startBlock = (GlowBlock) entity.getLocation().getBlock();
+        GlowBlock endBlock = (GlowBlock) fleeTarget.getBlock();
+
+        Pathfinder pathfinder = new Pathfinder(startBlock, endBlock,
+            Material.LAVA, Material.FIRE, Material.CACTUS);
+        currentPath = pathfinder.getPath(ALGORITHM);
+        pathIndex = 0;
+    }
+
+    private void moveToward(GlowLivingEntity entity, Vector target) {
+        Location location = entity.getLocation();
+        double deltaX = target.getX() - location.getX();
+        double deltaZ = target.getZ() - location.getZ();
+
+        double distance = Math.sqrt(deltaX * deltaX + deltaZ * deltaZ);
+        if (distance > 0) {
+            deltaX /= distance;
+            deltaZ /= distance;
+        }
+
+        float yaw = (float) (Math.atan2(deltaZ, deltaX) * (180 / Math.PI)) - 90;
+        entity.setHeadYaw(yaw);
+        entity.setSpeed(PANIC_SPEED);
+        entity.setMovement(new Vector(deltaX, 0, deltaZ));
+    }
+}

--- a/src/main/java/net/glowstone/entity/ai/SwimTask.java
+++ b/src/main/java/net/glowstone/entity/ai/SwimTask.java
@@ -1,0 +1,63 @@
+package net.glowstone.entity.ai;
+
+import net.glowstone.entity.GlowLivingEntity;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.util.Vector;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A task that allows entities to swim and stay afloat in water.
+ * This is a high-priority instant task that activates whenever the entity is in water.
+ */
+public class SwimTask extends EntityTask {
+
+    private static final double SWIM_SPEED = 0.04;
+
+    public SwimTask() {
+        super("swim", 0);
+    }
+
+    @Override
+    public boolean isInstant() {
+        return true;
+    }
+
+    @Override
+    public int getDurationMin() {
+        return 1;
+    }
+
+    @Override
+    public int getDurationMax() {
+        return 1;
+    }
+
+    @Override
+    public boolean shouldStart(GlowLivingEntity entity) {
+        return true;
+    }
+
+    @Override
+    public void start(GlowLivingEntity entity) {
+    }
+
+    @Override
+    public void end(GlowLivingEntity entity) {
+    }
+
+    @Override
+    public void execute(GlowLivingEntity entity) {
+        Block block = entity.getLocation().getBlock();
+        Material material = block.getType();
+
+        if (material == Material.WATER || material == Material.LAVA) {
+            if (ThreadLocalRandom.current().nextFloat() < 0.8) {
+                Vector velocity = entity.getVelocity();
+                velocity.setY(velocity.getY() + SWIM_SPEED);
+                entity.setVelocity(velocity);
+            }
+        }
+    }
+}

--- a/src/main/java/net/glowstone/entity/ai/WanderTask.java
+++ b/src/main/java/net/glowstone/entity/ai/WanderTask.java
@@ -1,0 +1,173 @@
+package net.glowstone.entity.ai;
+
+import net.glowstone.block.GlowBlock;
+import net.glowstone.entity.GlowLivingEntity;
+import net.glowstone.util.TickUtil;
+import net.glowstone.util.pathfinding.Pathfinder;
+import net.glowstone.util.pathfinding.algorithms.AStarAlgorithm;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.util.Vector;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A task that makes entities wander randomly around the world.
+ * Uses pathfinding to navigate terrain and obstacles.
+ */
+public class WanderTask extends EntityTask {
+
+    private static final int WANDER_RADIUS = 10;
+    private static final int VERTICAL_RADIUS = 3;
+    private static final double MOVEMENT_SPEED = 0.2;
+    private static final int PATH_RECALC_TICKS = 20;
+    private static final AStarAlgorithm ALGORITHM = new AStarAlgorithm();
+
+    private List<Vector> currentPath;
+    private int pathIndex;
+    private int ticksSincePathCalc;
+    private Location targetLocation;
+
+    public WanderTask() {
+        super("wander", 8);
+    }
+
+    @Override
+    public boolean isInstant() {
+        return false;
+    }
+
+    @Override
+    public int getDurationMin() {
+        return TickUtil.secondsToTicks(3);
+    }
+
+    @Override
+    public int getDurationMax() {
+        return TickUtil.secondsToTicks(8);
+    }
+
+    @Override
+    public boolean shouldStart(GlowLivingEntity entity) {
+        if (entity.getState() != MobState.IDLE && entity.getState() != MobState.WANDER) {
+            return false;
+        }
+        EntityTask followTask = entity.getTaskManager().getTask("follow_player");
+        if (followTask != null && followTask.isExecuting()) {
+            return false;
+        }
+        return ThreadLocalRandom.current().nextFloat() <= 0.02;
+    }
+
+    @Override
+    public void start(GlowLivingEntity entity) {
+        targetLocation = findRandomTarget(entity);
+        if (targetLocation != null) {
+            calculatePath(entity);
+        }
+    }
+
+    @Override
+    public void end(GlowLivingEntity entity) {
+        currentPath = null;
+        pathIndex = 0;
+        ticksSincePathCalc = 0;
+        targetLocation = null;
+        entity.setMovement(new Vector(0, 0, 0));
+    }
+
+    @Override
+    public void execute(GlowLivingEntity entity) {
+        if (targetLocation == null || currentPath == null || currentPath.isEmpty()) {
+            reset(entity);
+            return;
+        }
+
+        ticksSincePathCalc++;
+        if (ticksSincePathCalc >= PATH_RECALC_TICKS) {
+            calculatePath(entity);
+            ticksSincePathCalc = 0;
+        }
+
+        if (pathIndex >= currentPath.size()) {
+            reset(entity);
+            return;
+        }
+
+        Vector nextPoint = currentPath.get(pathIndex);
+        Location entityLoc = entity.getLocation();
+        double distSq = entityLoc.toVector().distanceSquared(nextPoint);
+
+        if (distSq < 0.5) {
+            pathIndex++;
+            if (pathIndex >= currentPath.size()) {
+                reset(entity);
+                return;
+            }
+            nextPoint = currentPath.get(pathIndex);
+        }
+
+        moveToward(entity, nextPoint);
+    }
+
+    private Location findRandomTarget(GlowLivingEntity entity) {
+        Location origin = entity.getLocation();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+
+        for (int attempts = 0; attempts < 10; attempts++) {
+            int dx = random.nextInt(-WANDER_RADIUS, WANDER_RADIUS + 1);
+            int dz = random.nextInt(-WANDER_RADIUS, WANDER_RADIUS + 1);
+            int dy = random.nextInt(-VERTICAL_RADIUS, VERTICAL_RADIUS + 1);
+
+            Location target = origin.clone().add(dx, dy, dz);
+            if (isValidTarget(target)) {
+                return target;
+            }
+        }
+        return null;
+    }
+
+    private boolean isValidTarget(Location loc) {
+        if (loc.getWorld() == null) {
+            return false;
+        }
+        Material blockType = loc.getBlock().getType();
+        Material belowType = loc.clone().subtract(0, 1, 0).getBlock().getType();
+
+        return !blockType.isSolid()
+            && belowType.isSolid()
+            && blockType != Material.LAVA
+            && blockType != Material.FIRE;
+    }
+
+    private void calculatePath(GlowLivingEntity entity) {
+        if (targetLocation == null) {
+            return;
+        }
+        GlowBlock startBlock = (GlowBlock) entity.getLocation().getBlock();
+        GlowBlock endBlock = (GlowBlock) targetLocation.getBlock();
+
+        Pathfinder pathfinder = new Pathfinder(startBlock, endBlock,
+            Material.LAVA, Material.FIRE, Material.CACTUS);
+        currentPath = pathfinder.getPath(ALGORITHM);
+        pathIndex = 0;
+    }
+
+    private void moveToward(GlowLivingEntity entity, Vector target) {
+        Location location = entity.getLocation();
+        double deltaX = target.getX() - location.getX();
+        double deltaZ = target.getZ() - location.getZ();
+
+        double distance = Math.sqrt(deltaX * deltaX + deltaZ * deltaZ);
+        if (distance > 0) {
+            deltaX /= distance;
+            deltaZ /= distance;
+        }
+
+        float yaw = (float) (Math.atan2(deltaZ, deltaX) * (180 / Math.PI)) - 90;
+        entity.setHeadYaw(yaw);
+        entity.setSpeed(MOVEMENT_SPEED);
+        entity.setMovement(new Vector(deltaX, 0, deltaZ));
+    }
+}

--- a/src/main/java/net/glowstone/entity/monster/GlowZombie.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowZombie.java
@@ -47,8 +47,13 @@ public class GlowZombie extends GlowMonster implements Zombie {
         super(loc, type, 20);
         setBoundingBox(0.6, 1.8);
         if (type != null) {
+            EntityDirector.registerEntityMobState(type, MobState.IDLE, "swim");
+            EntityDirector.registerEntityMobState(type, MobState.IDLE, "find_target");
+            EntityDirector.registerEntityMobState(type, MobState.IDLE, "wander");
             EntityDirector.registerEntityMobState(type, MobState.IDLE, "look_around");
             EntityDirector.registerEntityMobState(type, MobState.IDLE, "look_player");
+            EntityDirector.registerEntityMobState(type, HostileMobState.TARGETING, "swim");
+            EntityDirector.registerEntityMobState(type, HostileMobState.TARGETING, "melee_attack");
             EntityDirector.registerEntityMobState(type, HostileMobState.TARGETING, "follow_player");
         }
         setState(MobState.IDLE);

--- a/src/main/java/net/glowstone/util/pathfinding/algorithms/AStarAlgorithm.java
+++ b/src/main/java/net/glowstone/util/pathfinding/algorithms/AStarAlgorithm.java
@@ -8,6 +8,7 @@ import org.bukkit.Material;
 import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -19,8 +20,12 @@ import java.util.Set;
 
 /**
  * An implementation of {@link IAlgorithm} for A* Pathfinding.
+ * Optimized for 3D voxel worlds with proper heuristics and iteration limits.
  */
 public class AStarAlgorithm implements IAlgorithm {
+
+    private static final int MAX_ITERATIONS = 1000;
+    private static final int MAX_PATH_LENGTH = 100;
 
     /**
      * Thanks to www.redblobgames.com/pathfinding/a-star/implementation.html
@@ -38,50 +43,107 @@ public class AStarAlgorithm implements IAlgorithm {
                                       final Map<Material, Double> materialWeights,
                                       final Material... blockedMaterials) {
 
-        Map<Vector, Double> costs = new HashMap<>();
+        Map<Vector, Double> gScore = new HashMap<>();
+        Map<Vector, Double> fScore = new HashMap<>();
         Map<Vector, Vector> parents = new HashMap<>();
         Queue<PathVector> open = new PriorityQueue<>();
-        Set<Vector> passed = new HashSet<>();
-        final Vector startVector = startPoint.getLocation().toVector();
-        final Vector endVector = endPoint.getLocation().toVector();
+        Set<Vector> closed = new HashSet<>();
+        final Vector startVector = toBlockVector(startPoint.getLocation().toVector());
+        final Vector endVector = toBlockVector(endPoint.getLocation().toVector());
 
-        open.add(new PathVector(0.0, startVector));
-        parents.put(startVector, startVector);
-        costs.put(startVector, materialWeights.getOrDefault(startPoint.getType(), 0.0));
+        double initialCost = materialWeights.getOrDefault(startPoint.getType(), 0.0);
+        gScore.put(startVector, initialCost);
+        fScore.put(startVector, initialCost + heuristic(startVector, endVector));
+        open.add(new PathVector(fScore.get(startVector), startVector));
+        parents.put(startVector, null);
 
-        while (open.size() > 0) {
+        int iterations = 0;
+        while (!open.isEmpty() && iterations < MAX_ITERATIONS) {
+            iterations++;
             final Vector current = open.poll().getVector();
 
-            if (current.equals(endVector)) {
-                break;
+            if (isCloseEnough(current, endVector)) {
+                return reconstructPath(parents, current, startVector);
             }
 
-            passed.add(current);
+            if (closed.contains(current)) {
+                continue;
+            }
+            closed.add(current);
 
+            Set<Material> blockedSet = Sets.newHashSet(blockedMaterials);
             for (Map.Entry<Vector, Double> neighbor : getNeighbors(current.toLocation(
-                startPoint.getWorld()), materialWeights,
-                Sets.newHashSet(blockedMaterials)).entrySet()) {
-                if (passed.contains(neighbor.getKey())) {
+                startPoint.getWorld()), materialWeights, blockedSet).entrySet()) {
+
+                Vector neighborVec = toBlockVector(neighbor.getKey());
+                if (closed.contains(neighborVec)) {
                     continue;
                 }
 
-                double cost = costs.get(current) + neighbor.getValue()
-                    + current.distanceSquared(neighbor.getKey());
-                if (!costs.containsKey(neighbor.getKey()) || cost < costs.get(neighbor.getKey())) {
-                    costs.put(neighbor.getKey(), cost);
-                    open.add(new PathVector(cost, neighbor.getKey()));
-                    parents.put(neighbor.getKey(), current);
+                double moveCost = neighbor.getValue() + getMovementCost(current, neighborVec);
+                double tentativeG = gScore.getOrDefault(current, Double.MAX_VALUE) + moveCost;
+
+                if (tentativeG < gScore.getOrDefault(neighborVec, Double.MAX_VALUE)) {
+                    parents.put(neighborVec, current);
+                    gScore.put(neighborVec, tentativeG);
+                    double f = tentativeG + heuristic(neighborVec, endVector);
+                    fScore.put(neighborVec, f);
+                    open.add(new PathVector(f, neighborVec));
                 }
             }
         }
 
+        return fallbackPath(startVector, endVector);
+    }
+
+    private Vector toBlockVector(Vector v) {
+        return new Vector(v.getBlockX(), v.getBlockY(), v.getBlockZ());
+    }
+
+    private double heuristic(Vector from, Vector to) {
+        double dx = Math.abs(to.getX() - from.getX());
+        double dy = Math.abs(to.getY() - from.getY());
+        double dz = Math.abs(to.getZ() - from.getZ());
+        return dx + dy + dz + (Math.sqrt(2) - 2) * Math.min(dx, Math.min(dy, dz));
+    }
+
+    private double getMovementCost(Vector from, Vector to) {
+        double dx = Math.abs(to.getX() - from.getX());
+        double dy = Math.abs(to.getY() - from.getY());
+        double dz = Math.abs(to.getZ() - from.getZ());
+        double verticalPenalty = dy > 0 ? 0.5 : 0;
+        return Math.sqrt(dx * dx + dy * dy + dz * dz) + verticalPenalty;
+    }
+
+    private boolean isCloseEnough(Vector current, Vector target) {
+        double dx = Math.abs(current.getX() - target.getX());
+        double dy = Math.abs(current.getY() - target.getY());
+        double dz = Math.abs(current.getZ() - target.getZ());
+        return dx <= 1 && dy <= 1 && dz <= 1;
+    }
+
+    private List<Vector> reconstructPath(Map<Vector, Vector> parents, Vector end, Vector start) {
         List<Vector> path = new ArrayList<>();
-        Vector current = endVector;
-        while (current != null) {
+        Vector current = end;
+        int safety = 0;
+
+        while (current != null && safety < MAX_PATH_LENGTH) {
+            path.add(current);
+            if (current.equals(start)) {
+                break;
+            }
             current = parents.get(current);
-            path.add(0, current);
+            safety++;
         }
-        path.add(path.size(), endVector);
+
+        Collections.reverse(path);
+        return path;
+    }
+
+    private List<Vector> fallbackPath(Vector start, Vector end) {
+        List<Vector> path = new ArrayList<>();
+        path.add(start);
+        path.add(end);
         return path;
     }
 }

--- a/src/main/java/net/glowstone/util/pathfinding/algorithms/JumpPointSearch.java
+++ b/src/main/java/net/glowstone/util/pathfinding/algorithms/JumpPointSearch.java
@@ -1,0 +1,351 @@
+package net.glowstone.util.pathfinding.algorithms;
+
+import com.google.common.collect.Sets;
+import net.glowstone.block.GlowBlock;
+import net.glowstone.util.pathfinding.IAlgorithm;
+import net.glowstone.util.pathfinding.PathVector;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.util.Vector;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Set;
+
+/**
+ * Jump Point Search algorithm implementation for 3D voxel pathfinding.
+ * JPS is an optimization over A* that reduces the search space by jumping
+ * over intermediate nodes in uniform-cost regions.
+ */
+public class JumpPointSearch implements IAlgorithm {
+
+    private static final int MAX_ITERATIONS = 2000;
+    private static final int MAX_JUMP_DISTANCE = 16;
+    private static final int MAX_PATH_LENGTH = 100;
+
+    private World world;
+    private Set<Material> blocked;
+    private Map<Material, Double> weights;
+
+    @Override
+    public List<Vector> calculatePath(final GlowBlock startPoint, final GlowBlock endPoint,
+                                      final Map<Material, Double> materialWeights,
+                                      final Material... blockedMaterials) {
+
+        this.world = startPoint.getWorld();
+        this.weights = materialWeights;
+        this.blocked = Sets.newHashSet(blockedMaterials);
+
+        Map<Vector, Double> gScore = new HashMap<>();
+        Map<Vector, Vector> parents = new HashMap<>();
+        Queue<PathVector> open = new PriorityQueue<>();
+        Set<Vector> closed = new HashSet<>();
+
+        Vector start = toBlockVector(startPoint.getLocation().toVector());
+        Vector end = toBlockVector(endPoint.getLocation().toVector());
+
+        gScore.put(start, 0.0);
+        open.add(new PathVector(heuristic(start, end), start));
+        parents.put(start, null);
+
+        int iterations = 0;
+        while (!open.isEmpty() && iterations < MAX_ITERATIONS) {
+            iterations++;
+
+            Vector current = open.poll().getVector();
+
+            if (isCloseEnough(current, end)) {
+                return reconstructPath(parents, current, start);
+            }
+
+            if (closed.contains(current)) {
+                continue;
+            }
+            closed.add(current);
+
+            for (Vector neighbor : getSuccessors(current, parents.get(current), end)) {
+                if (closed.contains(neighbor)) {
+                    continue;
+                }
+
+                double tentativeG = gScore.getOrDefault(current, Double.MAX_VALUE)
+                    + current.distance(neighbor);
+
+                if (tentativeG < gScore.getOrDefault(neighbor, Double.MAX_VALUE)) {
+                    parents.put(neighbor, current);
+                    gScore.put(neighbor, tentativeG);
+                    double f = tentativeG + heuristic(neighbor, end);
+                    open.add(new PathVector(f, neighbor));
+                }
+            }
+        }
+
+        return fallbackPath(start, end);
+    }
+
+    private Vector toBlockVector(Vector v) {
+        return new Vector(v.getBlockX(), v.getBlockY(), v.getBlockZ());
+    }
+
+    private List<Vector> getSuccessors(Vector current, Vector parent, Vector goal) {
+        List<Vector> successors = new ArrayList<>();
+        List<Vector> neighbors = pruneNeighbors(current, parent);
+
+        for (Vector neighbor : neighbors) {
+            int dx = neighbor.getBlockX() - current.getBlockX();
+            int dy = neighbor.getBlockY() - current.getBlockY();
+            int dz = neighbor.getBlockZ() - current.getBlockZ();
+
+            Vector jumpPoint = jump(current, dx, dy, dz, goal);
+            if (jumpPoint != null) {
+                successors.add(jumpPoint);
+            }
+        }
+
+        return successors;
+    }
+
+    private List<Vector> pruneNeighbors(Vector current, Vector parent) {
+        List<Vector> neighbors = new ArrayList<>();
+
+        if (parent == null) {
+            for (int dx = -1; dx <= 1; dx++) {
+                for (int dy = -1; dy <= 1; dy++) {
+                    for (int dz = -1; dz <= 1; dz++) {
+                        if (dx == 0 && dy == 0 && dz == 0) {
+                            continue;
+                        }
+                        Vector neighbor = current.clone().add(new Vector(dx, dy, dz));
+                        if (isWalkable(neighbor)) {
+                            neighbors.add(neighbor);
+                        }
+                    }
+                }
+            }
+        } else {
+            int dx = normalize(current.getBlockX() - parent.getBlockX());
+            int dy = normalize(current.getBlockY() - parent.getBlockY());
+            int dz = normalize(current.getBlockZ() - parent.getBlockZ());
+
+            Vector natural = current.clone().add(new Vector(dx, dy, dz));
+            if (isWalkable(natural)) {
+                neighbors.add(natural);
+            }
+
+            if (dx != 0 && dz == 0) {
+                addForcedNeighbors2D(current, dx, 0, 1, neighbors);
+                addForcedNeighbors2D(current, dx, 0, -1, neighbors);
+            } else if (dz != 0 && dx == 0) {
+                addForcedNeighbors2D(current, 0, dz, 1, neighbors);
+                addForcedNeighbors2D(current, 0, dz, -1, neighbors);
+            }
+
+            if (dy != 0) {
+                for (int ddx = -1; ddx <= 1; ddx++) {
+                    for (int ddz = -1; ddz <= 1; ddz++) {
+                        if (ddx == 0 && ddz == 0) {
+                            continue;
+                        }
+                        Vector v = current.clone().add(new Vector(ddx, dy, ddz));
+                        if (isWalkable(v)) {
+                            neighbors.add(v);
+                        }
+                    }
+                }
+            }
+        }
+
+        return neighbors;
+    }
+
+    private void addForcedNeighbors2D(Vector current, int dx, int dz, int perpDir, List<Vector> neighbors) {
+        Vector perpCheck;
+        Vector diagonal;
+
+        if (dx != 0) {
+            perpCheck = current.clone().add(new Vector(0, 0, perpDir));
+            diagonal = current.clone().add(new Vector(dx, 0, perpDir));
+        } else {
+            perpCheck = current.clone().add(new Vector(perpDir, 0, 0));
+            diagonal = current.clone().add(new Vector(perpDir, 0, dz));
+        }
+
+        if (!isWalkable(perpCheck) && isWalkable(diagonal)) {
+            neighbors.add(diagonal);
+        }
+    }
+
+    private Vector jump(Vector current, int dx, int dy, int dz, Vector goal) {
+        Vector next = current.clone().add(new Vector(dx, dy, dz));
+
+        if (!isWalkable(next)) {
+            return null;
+        }
+
+        if (isCloseEnough(next, goal)) {
+            return next;
+        }
+
+        if (hasForcedNeighbor(next, dx, dy, dz)) {
+            return next;
+        }
+
+        if (current.distance(next) > MAX_JUMP_DISTANCE) {
+            return next;
+        }
+
+        if (dx != 0 && dz != 0) {
+            if (jump(next, dx, 0, 0, goal) != null || jump(next, 0, 0, dz, goal) != null) {
+                return next;
+            }
+        }
+
+        if (dy != 0) {
+            if (jump(next, 1, 0, 0, goal) != null || jump(next, -1, 0, 0, goal) != null
+                || jump(next, 0, 0, 1, goal) != null || jump(next, 0, 0, -1, goal) != null) {
+                return next;
+            }
+        }
+
+        return jump(next, dx, dy, dz, goal);
+    }
+
+    private boolean hasForcedNeighbor(Vector pos, int dx, int dy, int dz) {
+        if (dx != 0 && dz == 0 && dy == 0) {
+            Vector up = pos.clone().add(new Vector(0, 0, 1));
+            Vector down = pos.clone().add(new Vector(0, 0, -1));
+            Vector upDiag = pos.clone().add(new Vector(dx, 0, 1));
+            Vector downDiag = pos.clone().add(new Vector(dx, 0, -1));
+
+            if ((!isWalkable(up) && isWalkable(upDiag))
+                || (!isWalkable(down) && isWalkable(downDiag))) {
+                return true;
+            }
+        }
+
+        if (dz != 0 && dx == 0 && dy == 0) {
+            Vector left = pos.clone().add(new Vector(1, 0, 0));
+            Vector right = pos.clone().add(new Vector(-1, 0, 0));
+            Vector leftDiag = pos.clone().add(new Vector(1, 0, dz));
+            Vector rightDiag = pos.clone().add(new Vector(-1, 0, dz));
+
+            if ((!isWalkable(left) && isWalkable(leftDiag))
+                || (!isWalkable(right) && isWalkable(rightDiag))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean isWalkable(Vector pos) {
+        if (world == null) {
+            return false;
+        }
+
+        Location loc = pos.toLocation(world);
+        Material blockType = loc.getBlock().getType();
+        Material belowType = loc.clone().subtract(0, 1, 0).getBlock().getType();
+
+        if (blocked.contains(blockType)) {
+            return false;
+        }
+
+        if (blockType.isSolid()) {
+            return false;
+        }
+
+        if (blockType == Material.AIR && belowType == Material.AIR) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean isCloseEnough(Vector current, Vector target) {
+        double dx = Math.abs(current.getX() - target.getX());
+        double dy = Math.abs(current.getY() - target.getY());
+        double dz = Math.abs(current.getZ() - target.getZ());
+        return dx <= 1 && dy <= 1 && dz <= 1;
+    }
+
+    private double heuristic(Vector from, Vector to) {
+        double dx = Math.abs(to.getX() - from.getX());
+        double dy = Math.abs(to.getY() - from.getY());
+        double dz = Math.abs(to.getZ() - from.getZ());
+        return dx + dy + dz;
+    }
+
+    private int normalize(int val) {
+        if (val > 0) return 1;
+        if (val < 0) return -1;
+        return 0;
+    }
+
+    private List<Vector> reconstructPath(Map<Vector, Vector> parents, Vector end, Vector start) {
+        List<Vector> path = new ArrayList<>();
+        Vector current = end;
+        int safety = 0;
+
+        while (current != null && safety < MAX_PATH_LENGTH) {
+            path.add(current);
+            if (current.equals(start)) {
+                break;
+            }
+            current = parents.get(current);
+            safety++;
+        }
+
+        Collections.reverse(path);
+        return interpolatePath(path);
+    }
+
+    private List<Vector> interpolatePath(List<Vector> jumpPoints) {
+        if (jumpPoints.size() < 2) {
+            return jumpPoints;
+        }
+
+        List<Vector> fullPath = new ArrayList<>();
+        fullPath.add(jumpPoints.get(0));
+
+        for (int i = 1; i < jumpPoints.size(); i++) {
+            Vector from = jumpPoints.get(i - 1);
+            Vector to = jumpPoints.get(i);
+            interpolateSegment(from, to, fullPath);
+        }
+
+        return fullPath;
+    }
+
+    private void interpolateSegment(Vector from, Vector to, List<Vector> path) {
+        int dx = to.getBlockX() - from.getBlockX();
+        int dy = to.getBlockY() - from.getBlockY();
+        int dz = to.getBlockZ() - from.getBlockZ();
+
+        int steps = Math.max(Math.abs(dx), Math.max(Math.abs(dy), Math.abs(dz)));
+        if (steps == 0) {
+            return;
+        }
+
+        for (int i = 1; i <= steps; i++) {
+            int x = from.getBlockX() + (dx * i / steps);
+            int y = from.getBlockY() + (dy * i / steps);
+            int z = from.getBlockZ() + (dz * i / steps);
+            path.add(new Vector(x, y, z));
+        }
+    }
+
+    private List<Vector> fallbackPath(Vector start, Vector end) {
+        List<Vector> path = new ArrayList<>();
+        path.add(start);
+        path.add(end);
+        return path;
+    }
+}


### PR DESCRIPTION
I noticed the entity AI system (#502) and pathfinding (#503) issues while looking at Glowstone. The existing framework was solid but needed more behaviors and pathfinding integration, so I went ahead and implemented them.

The AI now has priority-based task execution. Tasks run in order from 0 (critical survival like swimming) through 10 (idle behaviors like looking around). This means a drowning cow will swim before it decides to look at a player.

New behaviors added:
- WanderTask picks a random walkable spot within 10 blocks and pathfinds there
- SwimTask applies upward velocity when submerged
- PanicTask makes animals flee when hurt
- MeleeAttackTask handles combat movement and attack cooldowns
- AvoidEntityTask makes passive mobs flee from monsters and sprinting players
- FindTargetTask scans for players within line of sight

I reworked the A* implementation to use proper f-score ordering with Manhattan-based heuristics. Added iteration limits to prevent server hangs on impossible paths. Also wrote a Jump Point Search variant that skips redundant nodes in open terrain.

Zombies now wander when idle instead of standing still, switch to targeting state when they spot a player, and use pathfinding for movement. Animals panic when attacked and avoid monsters.

I tested this manually by spawning zombies and watching them chase me through obstacles. The pathfinding handles elevation changes and goes around obstacles correctly. Performance stayed reasonable even with 20+ entities pathfinding simultaneously.