### PR TITLE
Allow chests next to existing double chests

### DIFF
--- a/src/main/java/net/glowstone/block/blocktype/BlockChest.java
+++ b/src/main/java/net/glowstone/block/blocktype/BlockChest.java
@@ -2,6 +2,8 @@ package net.glowstone.block.blocktype;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 import net.glowstone.block.GlowBlock;
 import net.glowstone.block.GlowBlockState;
 import net.glowstone.block.entity.BlockEntity;
@@ -73,8 +75,8 @@ public class BlockChest extends BlockContainer {
 
             BlockFace normalFacing = getOppositeBlockFace(player.getLocation(), false);
 
-            Collection<BlockFace> attachedChests = searchChests(chestBlock);
-            switch (attachedChests.size()) {
+            List<BlockFace> attachableChests = findAttachableChests(chestBlock);
+            switch (attachableChests.size()) {
                 case 0:
                     chest.setFacingDirection(normalFacing);
                     state.setData(chest);
@@ -85,14 +87,9 @@ public class BlockChest extends BlockContainer {
                     ConsoleMessages.Warn.Block.Chest.TRIPLE_MIDDLE.log();
                     return;
             }
-            BlockFace otherPart = attachedChests.iterator().next();
+            BlockFace otherPart = attachableChests.iterator().next();
 
             GlowBlock otherPartBlock = chestBlock.getRelative(otherPart);
-
-            if (getAttachedChest(otherPartBlock) != null) {
-                ConsoleMessages.Warn.Block.Chest.TRIPLE_END.log();
-                return;
-            }
 
             BlockState otherPartState = otherPartBlock.getState();
             MaterialData otherPartData = otherPartState.getData();
@@ -134,23 +131,21 @@ public class BlockChest extends BlockContainer {
 
     @Override
     public boolean canPlaceAt(GlowPlayer player, GlowBlock block, BlockFace against) {
-        Collection<BlockFace> nearChests = searchChests(block);
-
-        if (nearChests.size() == 1) {
-            GlowBlock otherPartBlock = block.getRelative(nearChests.iterator().next());
-
-            if (getAttachedChest(otherPartBlock) != null) {
-                return false;
-            }
-        }
-        return nearChests.size() <= 1;
+        return findAttachableChests(block).size() <= 1;
 
     }
 
     private Collection<BlockFace> searchChests(GlowBlock block) {
+        return searchChests(block, null);
+    }
+
+    private Collection<BlockFace> searchChests(GlowBlock block, BlockFace excludedFace) {
         Collection<BlockFace> chests = new ArrayList<>();
 
         for (BlockFace face : SIDES) {
+            if (face == excludedFace) {
+                continue;
+            }
             GlowBlock possibleChest = block.getRelative(face);
             if (possibleChest.getType() == (isTrapped ? Material.TRAPPED_CHEST : Material.CHEST)) {
                 chests.add(face);
@@ -160,13 +155,23 @@ public class BlockChest extends BlockContainer {
         return chests;
     }
 
+    private List<BlockFace> findAttachableChests(GlowBlock block) {
+        return searchChests(block).stream()
+            .filter(face -> getAttachedChest(block.getRelative(face), face.getOppositeFace()) == null)
+            .collect(Collectors.toList());
+    }
+
     /**
      * Get the other half of a chest, or null if the given chest isn't part of a double chest.
      * @param me a chest block
      * @return the other half of the double chest if {@code me} is part of one; null otherwise
      */
     public BlockFace getAttachedChest(GlowBlock me) {
-        Collection<BlockFace> attachedChests = searchChests(me);
+        return getAttachedChest(me, null);
+    }
+
+    private BlockFace getAttachedChest(GlowBlock me, BlockFace excludedFace) {
+        Collection<BlockFace> attachedChests = searchChests(me, excludedFace);
         if (attachedChests.isEmpty()) {
             return null;
         }

--- a/src/test/java/net/glowstone/block/blocktype/BlockChestTest.java
+++ b/src/test/java/net/glowstone/block/blocktype/BlockChestTest.java
@@ -1,0 +1,68 @@
+package net.glowstone.block.blocktype;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import net.glowstone.block.GlowBlock;
+import org.bukkit.Material;
+import org.bukkit.block.BlockFace;
+import org.junit.Test;
+
+public class BlockChestTest {
+
+    private static final BlockFace[] SIDES = new BlockFace[] {
+        BlockFace.NORTH,
+        BlockFace.EAST,
+        BlockFace.SOUTH,
+        BlockFace.WEST
+    };
+
+    @Test
+    public void canPlaceSingleChestBesideDoubleChest() {
+        BlockChest blockChest = new BlockChest();
+        GlowBlock placement = blockWithAirNeighbors(Material.AIR);
+        GlowBlock doubleChestLeft = blockWithAirNeighbors(Material.CHEST);
+        GlowBlock doubleChestRight = blockWithAirNeighbors(Material.CHEST);
+
+        connect(placement, BlockFace.NORTH, doubleChestLeft);
+        connect(doubleChestLeft, BlockFace.SOUTH, placement);
+        connect(doubleChestLeft, BlockFace.EAST, doubleChestRight);
+        connect(doubleChestRight, BlockFace.WEST, doubleChestLeft);
+
+        assertTrue(blockChest.canPlaceAt(null, placement, BlockFace.UP));
+    }
+
+    @Test
+    public void cannotPlaceChestBetweenTwoAttachableSingleChests() {
+        BlockChest blockChest = new BlockChest();
+        GlowBlock placement = blockWithAirNeighbors(Material.AIR);
+        GlowBlock northChest = blockWithAirNeighbors(Material.CHEST);
+        GlowBlock eastChest = blockWithAirNeighbors(Material.CHEST);
+
+        connect(placement, BlockFace.NORTH, northChest);
+        connect(placement, BlockFace.EAST, eastChest);
+        connect(northChest, BlockFace.SOUTH, placement);
+        connect(eastChest, BlockFace.WEST, placement);
+
+        assertFalse(blockChest.canPlaceAt(null, placement, BlockFace.UP));
+    }
+
+    private static GlowBlock blockWithAirNeighbors(Material material) {
+        GlowBlock block = mock(GlowBlock.class);
+        when(block.getType()).thenReturn(material);
+
+        for (BlockFace face : SIDES) {
+            GlowBlock air = mock(GlowBlock.class);
+            when(air.getType()).thenReturn(Material.AIR);
+            when(block.getRelative(face)).thenReturn(air);
+        }
+
+        return block;
+    }
+
+    private static void connect(GlowBlock source, BlockFace face, GlowBlock target) {
+        when(source.getRelative(face)).thenReturn(target);
+    }
+}


### PR DESCRIPTION
Fixes GlowstoneMC/1.13-board#20.\n\n- allow single chests beside existing double chests\n- preserve triple-chest guard\n- add regression tests