### PR TITLE
feat: implement entity AI system with wander, melee attack, and flee tasks [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/src/main/java/net/glowstone/entity/GlowAnimal.java
+++ b/src/main/java/net/glowstone/entity/GlowAnimal.java
@@ -44,6 +44,8 @@ public class GlowAnimal extends GlowAgeable implements Animals {
         if (type != null) {
             EntityDirector.registerEntityMobState(type, MobState.IDLE, "look_around");
             EntityDirector.registerEntityMobState(type, MobState.IDLE, "look_player");
+            EntityDirector.registerEntityMobState(type, MobState.IDLE, "wander");
+            EntityDirector.registerEntityMobState(type, MobState.ATTACKED, "flee");
         }
         setState(MobState.IDLE);
 

--- a/src/main/java/net/glowstone/entity/GlowLivingEntity.java
+++ b/src/main/java/net/glowstone/entity/GlowLivingEntity.java
@@ -452,6 +452,11 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
         if (nextAmbientTime == 0) {
             nextAmbientTime = getAmbientDelay();
         }
+
+        // pulse AI tasks
+        if (hasAI()) {
+            taskManager.pulse();
+        }
     }
 
     @Override
@@ -1147,6 +1152,10 @@ public abstract class GlowLivingEntity extends GlowEntity implements LivingEntit
             Sound hurtSound = getHurtSound();
             if (hurtSound != null && !isSilent()) {
                 world.playSound(location, hurtSound, getSoundVolume(), getSoundPitch());
+            }
+            // triggered state for passive mobs to flee
+            if (hasAI() && (state == MobState.IDLE || state == MobState.WANDER)) {
+                setState(MobState.ATTACKED);
             }
         }
         setLastDamager(source);

--- a/src/main/java/net/glowstone/entity/ai/EntityDirector.java
+++ b/src/main/java/net/glowstone/entity/ai/EntityDirector.java
@@ -20,6 +20,9 @@ public class EntityDirector {
         registerEntityTask("look_around", LookAroundTask.class);
         registerEntityTask("look_player", LookAtPlayerTask.class);
         registerEntityTask("follow_player", FollowPlayerTask.class);
+        registerEntityTask("wander", WanderTask.class);
+        registerEntityTask("melee_attack", MeleeAttackTask.class);
+        registerEntityTask("flee", FleeTask.class);
     }
 
     /**

--- a/src/main/java/net/glowstone/entity/ai/FleeTask.java
+++ b/src/main/java/net/glowstone/entity/ai/FleeTask.java
@@ -1,0 +1,110 @@
+package net.glowstone.entity.ai;
+
+import net.glowstone.entity.GlowLivingEntity;
+import net.glowstone.entity.GlowPlayer;
+import net.glowstone.util.TickUtil;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+
+import java.util.List;
+
+/**
+ * A task that causes a passive entity to flee from nearby players when threatened.
+ */
+public class FleeTask extends EntityTask {
+
+    private static final double FLEE_RANGE = 8;
+    private static final double SAFE_DISTANCE = 12;
+    private static final double SPEED = 0.25;
+    private GlowPlayer threat;
+
+    public FleeTask() {
+        super("flee");
+    }
+
+    @Override
+    public boolean isInstant() {
+        return false;
+    }
+
+    @Override
+    public int getDurationMin() {
+        return TickUtil.secondsToTicks(3);
+    }
+
+    @Override
+    public int getDurationMax() {
+        return TickUtil.secondsToTicks(6);
+    }
+
+    @Override
+    public boolean shouldStart(GlowLivingEntity entity) {
+        return entity.getState() == MobState.ATTACKED;
+    }
+
+    @Override
+    public void start(GlowLivingEntity entity) {
+        threat = findNearestPlayer(entity);
+    }
+
+    @Override
+    public void end(GlowLivingEntity entity) {
+        entity.setVelocity(new Vector(0, entity.getVelocity().getY(), 0));
+        threat = null;
+    }
+
+    @Override
+    public void execute(GlowLivingEntity entity) {
+        if (threat == null || !threat.isOnline() || threat.isDead()) {
+            threat = findNearestPlayer(entity);
+            if (threat == null) {
+                entity.setState(MobState.IDLE);
+                return;
+            }
+        }
+        double distanceSq = entity.getLocation().distanceSquared(threat.getLocation());
+        if (distanceSq > SAFE_DISTANCE * SAFE_DISTANCE) {
+            entity.setState(MobState.IDLE);
+            return;
+        }
+        Location location = entity.getLocation();
+        Location threatLoc = threat.getLocation();
+        double deltaX = location.getX() - threatLoc.getX();
+        double deltaZ = location.getZ() - threatLoc.getZ();
+        double distance = Math.sqrt(deltaX * deltaX + deltaZ * deltaZ);
+        if (distance < 0.1) {
+            return;
+        }
+        entity.setVelocity(new Vector(
+            (deltaX / distance) * SPEED,
+            entity.getVelocity().getY(),
+            (deltaZ / distance) * SPEED
+        ));
+        float yaw = (float) (Math.atan2(deltaZ, deltaX) * (180 / Math.PI)) - 90;
+        entity.setHeadYaw(yaw);
+        entity.setYaw(yaw);
+    }
+
+    private GlowPlayer findNearestPlayer(GlowLivingEntity entity) {
+        List<Entity> nearbyEntities = entity.getNearbyEntities(FLEE_RANGE, FLEE_RANGE, FLEE_RANGE);
+        double nearestSquared = Double.MAX_VALUE;
+        GlowPlayer nearest = null;
+        for (Entity nearbyEntity : nearbyEntities) {
+            if (nearbyEntity.getType() != EntityType.PLAYER) {
+                continue;
+            }
+            GlowPlayer player = (GlowPlayer) nearbyEntity;
+            if (player.isDead() || !player.isOnline()) {
+                continue;
+            }
+            double dist = player.getLocation().distanceSquared(entity.getLocation());
+            if (dist < nearestSquared) {
+                nearest = player;
+                nearestSquared = dist;
+            }
+        }
+        return nearest;
+    }
+}

--- a/src/main/java/net/glowstone/entity/ai/LookAtPlayerTask.java
+++ b/src/main/java/net/glowstone/entity/ai/LookAtPlayerTask.java
@@ -6,6 +6,7 @@ import net.glowstone.util.TickUtil;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Monster;
 
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -88,7 +89,7 @@ public class LookAtPlayerTask extends EntityTask {
         // todo: pitch rotation (head up/down)
         delay = 1;
 
-        if (entity.getType() == EntityType.ZOMBIE) {
+        if (entity instanceof Monster) {
             entity.setState(HostileMobState.TARGETING);
         }
     }

--- a/src/main/java/net/glowstone/entity/ai/MeleeAttackTask.java
+++ b/src/main/java/net/glowstone/entity/ai/MeleeAttackTask.java
@@ -1,0 +1,118 @@
+package net.glowstone.entity.ai;
+
+import net.glowstone.entity.GlowLivingEntity;
+import net.glowstone.entity.GlowPlayer;
+import net.glowstone.util.TickUtil;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+
+import java.util.List;
+
+/**
+ * A task that causes a hostile entity to attack nearby players.
+ */
+public class MeleeAttackTask extends EntityTask {
+
+    private static final double RANGE = 16;
+    private static final double ATTACK_RANGE = 2.5;
+    private static final double SPEED = 0.35;
+    private GlowPlayer target;
+    private int attackCooldown;
+
+    public MeleeAttackTask() {
+        super("melee_attack");
+    }
+
+    @Override
+    public boolean isInstant() {
+        return false;
+    }
+
+    @Override
+    public int getDurationMin() {
+        return TickUtil.secondsToTicks(4);
+    }
+
+    @Override
+    public int getDurationMax() {
+        return TickUtil.secondsToTicks(10);
+    }
+
+    @Override
+    public boolean shouldStart(GlowLivingEntity entity) {
+        return entity.getState() == HostileMobState.TARGETING;
+    }
+
+    @Override
+    public void start(GlowLivingEntity entity) {
+        target = findNearestPlayer(entity);
+        attackCooldown = 0;
+    }
+
+    @Override
+    public void end(GlowLivingEntity entity) {
+        entity.setVelocity(new Vector(0, entity.getVelocity().getY(), 0));
+        target = null;
+    }
+
+    @Override
+    public void execute(GlowLivingEntity entity) {
+        if (target == null || !target.isOnline() || target.isDead()) {
+            target = findNearestPlayer(entity);
+            if (target == null) {
+                entity.setState(MobState.IDLE);
+                return;
+            }
+        }
+        double distanceSq = entity.getLocation().distanceSquared(target.getLocation());
+        if (distanceSq > RANGE * RANGE) {
+            entity.setState(MobState.IDLE);
+            return;
+        }
+        if (distanceSq > ATTACK_RANGE * ATTACK_RANGE) {
+            Location location = entity.getLocation();
+            Location targetLoc = target.getLocation();
+            double deltaX = targetLoc.getX() - location.getX();
+            double deltaZ = targetLoc.getZ() - location.getZ();
+            double distance = Math.sqrt(deltaX * deltaX + deltaZ * deltaZ);
+            entity.setVelocity(new Vector(
+                (deltaX / distance) * SPEED,
+                entity.getVelocity().getY(),
+                (deltaZ / distance) * SPEED
+            ));
+            float yaw = (float) (Math.atan2(deltaZ, deltaX) * (180 / Math.PI)) - 90;
+            entity.setHeadYaw(yaw);
+            entity.setYaw(yaw);
+        } else {
+            if (attackCooldown <= 0) {
+                target.damage(3.0, entity);
+                attackCooldown = 20;
+            } else {
+                attackCooldown--;
+            }
+        }
+    }
+
+    private GlowPlayer findNearestPlayer(GlowLivingEntity entity) {
+        List<Entity> nearbyEntities = entity.getNearbyEntities(RANGE, RANGE, RANGE);
+        double nearestSquared = Double.MAX_VALUE;
+        GlowPlayer nearest = null;
+        for (Entity nearbyEntity : nearbyEntities) {
+            if (nearbyEntity.getType() != EntityType.PLAYER) {
+                continue;
+            }
+            GlowPlayer player = (GlowPlayer) nearbyEntity;
+            if (player.isDead() || !player.isOnline()) {
+                continue;
+            }
+            double dist = player.getLocation().distanceSquared(entity.getLocation());
+            if (dist < nearestSquared) {
+                nearest = player;
+                nearestSquared = dist;
+            }
+        }
+        return nearest;
+    }
+}

--- a/src/main/java/net/glowstone/entity/ai/WanderTask.java
+++ b/src/main/java/net/glowstone/entity/ai/WanderTask.java
@@ -1,0 +1,92 @@
+package net.glowstone.entity.ai;
+
+import net.glowstone.entity.GlowLivingEntity;
+import net.glowstone.util.TickUtil;
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * A task that causes an entity to wander randomly around its current location.
+ */
+public class WanderTask extends EntityTask {
+
+    private static final double WANDER_RANGE = 8;
+    private static final double SPEED = 0.15;
+    private Location target;
+    private int stuckTicks;
+
+    public WanderTask() {
+        super("wander");
+    }
+
+    @Override
+    public boolean isInstant() {
+        return false;
+    }
+
+    @Override
+    public int getDurationMin() {
+        return TickUtil.secondsToTicks(2);
+    }
+
+    @Override
+    public int getDurationMax() {
+        return TickUtil.secondsToTicks(6);
+    }
+
+    @Override
+    public boolean shouldStart(GlowLivingEntity entity) {
+        return ThreadLocalRandom.current().nextFloat() <= 0.05;
+    }
+
+    @Override
+    public void start(GlowLivingEntity entity) {
+        target = getRandomWanderTarget(entity);
+        stuckTicks = 0;
+    }
+
+    @Override
+    public void end(GlowLivingEntity entity) {
+        entity.setVelocity(new Vector(0, entity.getVelocity().getY(), 0));
+        target = null;
+    }
+
+    @Override
+    public void execute(GlowLivingEntity entity) {
+        if (target == null) {
+            return;
+        }
+        if (entity.getLocation().distanceSquared(target) < 1.0) {
+            return;
+        }
+        Location location = entity.getLocation();
+        double deltaX = target.getX() - location.getX();
+        double deltaZ = target.getZ() - location.getZ();
+        double distance = Math.sqrt(deltaX * deltaX + deltaZ * deltaZ);
+        if (distance < 0.1) {
+            return;
+        }
+        entity.setVelocity(new Vector(
+            (deltaX / distance) * SPEED,
+            entity.getVelocity().getY(),
+            (deltaZ / distance) * SPEED
+        ));
+        float yaw = (float) (Math.atan2(deltaZ, deltaX) * (180 / Math.PI)) - 90;
+        entity.setHeadYaw(yaw);
+        entity.setYaw(yaw);
+        stuckTicks++;
+        if (stuckTicks > 100) {
+            target = getRandomWanderTarget(entity);
+            stuckTicks = 0;
+        }
+    }
+
+    private Location getRandomWanderTarget(GlowLivingEntity entity) {
+        Location loc = entity.getLocation();
+        double x = loc.getX() + (ThreadLocalRandom.current().nextDouble() - 0.5) * WANDER_RANGE * 2;
+        double z = loc.getZ() + (ThreadLocalRandom.current().nextDouble() - 0.5) * WANDER_RANGE * 2;
+        return new Location(loc.getWorld(), x, loc.getY(), z);
+    }
+}

--- a/src/main/java/net/glowstone/entity/monster/GlowMonster.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowMonster.java
@@ -1,6 +1,9 @@
 package net.glowstone.entity.monster;
 
 import net.glowstone.entity.GlowCreature;
+import net.glowstone.entity.ai.EntityDirector;
+import net.glowstone.entity.ai.HostileMobState;
+import net.glowstone.entity.ai.MobState;
 import org.bukkit.Location;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Monster;
@@ -21,6 +24,13 @@ public class GlowMonster extends GlowCreature implements Monster {
      */
     public GlowMonster(Location loc, EntityType type, double maxHealth) {
         super(loc, type, maxHealth);
+        if (type != null) {
+            EntityDirector.registerEntityMobState(type, MobState.IDLE, "look_around");
+            EntityDirector.registerEntityMobState(type, MobState.IDLE, "look_player");
+            EntityDirector.registerEntityMobState(type, MobState.IDLE, "wander");
+            EntityDirector.registerEntityMobState(type, HostileMobState.TARGETING, "melee_attack");
+        }
+        setState(MobState.IDLE);
     }
 
     /**

--- a/src/main/java/net/glowstone/entity/monster/GlowZombie.java
+++ b/src/main/java/net/glowstone/entity/monster/GlowZombie.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 import lombok.Setter;
 import net.glowstone.entity.ai.EntityDirector;
 import net.glowstone.entity.ai.HostileMobState;
-import net.glowstone.entity.ai.MobState;
 import net.glowstone.entity.meta.MetadataIndex;
 import net.glowstone.util.SoundUtil;
 import org.bukkit.Location;
@@ -47,11 +46,8 @@ public class GlowZombie extends GlowMonster implements Zombie {
         super(loc, type, 20);
         setBoundingBox(0.6, 1.8);
         if (type != null) {
-            EntityDirector.registerEntityMobState(type, MobState.IDLE, "look_around");
-            EntityDirector.registerEntityMobState(type, MobState.IDLE, "look_player");
             EntityDirector.registerEntityMobState(type, HostileMobState.TARGETING, "follow_player");
         }
-        setState(MobState.IDLE);
     }
 
     @Override


### PR DESCRIPTION
Implements #502

This PR adds a comprehensive Entity AI system to Glowstone with the following changes:

## New AI Tasks
- **WanderTask**: Entities randomly wander around their current location
- **MeleeAttackTask**: Hostile entities pursue and attack nearby players
- **FleeTask**: Passive entities flee from threats when attacked

## Critical Fixes
- **AI execution**: Added `taskManager.pulse()` call to `GlowLivingEntity.pulse()` — the AI framework was never actually executed
- **Damage trigger**: Added ATTACKED state transition when entities are damaged, enabling passive mobs to flee

## AI Registration
- All hostile monsters (via GlowMonster base class) now get IDLE tasks (look_around, look_player, wander) and TARGETING tasks (melee_attack)
- All passive animals (GlowAnimal) now get wander task in IDLE state and flee task in ATTACKED state
- Extended LookAtPlayerTask to trigger TARGETING for all Monster types (not just Zombies)

## Cleanup
- Removed duplicate AI registration from GlowZombie (now inherited from GlowMonster)